### PR TITLE
Document pi-agent-builder model targets and testing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,16 @@ wiring a new agent, match the tier to the job:
 | `LEAD_MODEL` | Team Lead / Task Overseer | Reviews worker output, assigns follow-ups, keeps the plan on track. Runs often; solid reasoning but not frontier. |
 | `TASK_MODEL` | Code Rabbit / Worker | Bulk task execution. Runs constantly; optimize for cost-per-token at acceptable quality. |
 
+In addition to the three tiers, `models.env` exposes
+`AGENT_BUILDER_CANDIDATES` — a comma-separated list of models we
+consider acceptable for driving the `pi-agent-builder` skill (the LLM
+that turns a short natural-language prompt into a pi extension).
+Current candidates: **Haiku 4.5**
+(`anthropic/claude-haiku-4.5`), **Gemini 3 Flash Preview**
+(`google/gemini-3-flash-preview`), and **GLM 5.1** (`z-ai/glm-5.1`).
+Pick one and pass it via `--model` when invoking pi; see "Creating pi
+agents" below for the full command.
+
 Source the file before launching pi so the tier vars are in scope:
 
 ```sh
@@ -56,6 +66,7 @@ extensions that follow its recipes.
 
 ```sh
 set -a; source models.env; set +a
+# Pick any model from $AGENT_BUILDER_CANDIDATES, or fall back to $LEAD_MODEL.
 npm run pi -- --provider openrouter --model "$LEAD_MODEL" \
   --skill skills/pi-agent-builder \
   -p "Use the pi-agent-builder skill to <describe the agent>."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,14 +37,14 @@ wiring a new agent, match the tier to the job:
 | `TASK_MODEL` | Code Rabbit / Worker | Bulk task execution. Runs constantly; optimize for cost-per-token at acceptable quality. |
 
 In addition to the three tiers, `models.env` exposes
-`AGENT_BUILDER_CANDIDATES` — a comma-separated list of models we
-consider acceptable for driving the `pi-agent-builder` skill (the LLM
-that turns a short natural-language prompt into a pi extension).
-Current candidates: **Haiku 4.5**
-(`anthropic/claude-haiku-4.5`), **Gemini 3 Flash Preview**
+`AGENT_BUILDER_TARGETS` — a comma-separated list of models the
+`pi-agent-builder` skill is expected to work well on (the skill should
+produce a correct, safe pi extension from a short natural-language
+prompt on every one of them, not just one). Current targets: **Haiku
+4.5** (`anthropic/claude-haiku-4.5`), **Gemini 3 Flash Preview**
 (`google/gemini-3-flash-preview`), and **GLM 5.1** (`z-ai/glm-5.1`).
-Pick one and pass it via `--model` when invoking pi; see "Creating pi
-agents" below for the full command.
+When refining the skill, test against all three; when invoking pi,
+pick any one and pass it via `--model`.
 
 Source the file before launching pi so the tier vars are in scope:
 
@@ -66,7 +66,7 @@ extensions that follow its recipes.
 
 ```sh
 set -a; source models.env; set +a
-# Pick any model from $AGENT_BUILDER_CANDIDATES, or fall back to $LEAD_MODEL.
+# Pick any model from $AGENT_BUILDER_TARGETS, or fall back to $LEAD_MODEL.
 npm run pi -- --provider openrouter --model "$LEAD_MODEL" \
   --skill skills/pi-agent-builder \
   -p "Use the pi-agent-builder skill to <describe the agent>."

--- a/models.env
+++ b/models.env
@@ -19,3 +19,10 @@ LEAD_MODEL=google/gemini-3-flash-preview
 # Executes assigned tasks constantly; cost-per-token dominates.
 # "Good enough" coding quality at bulk pricing.
 TASK_MODEL=deepseek/deepseek-v3.2
+
+# Agent Builder Candidates
+# Models we consider acceptable for driving the `pi-agent-builder` skill
+# (i.e. the LLM that reads a short natural-language prompt and writes a
+# pi extension). Comma-separated so scripts can iterate; pick one and
+# pass it via --model when invoking pi.
+AGENT_BUILDER_CANDIDATES=anthropic/claude-haiku-4.5,google/gemini-3-flash-preview,z-ai/glm-5.1

--- a/models.env
+++ b/models.env
@@ -20,9 +20,10 @@ LEAD_MODEL=google/gemini-3-flash-preview
 # "Good enough" coding quality at bulk pricing.
 TASK_MODEL=deepseek/deepseek-v3.2
 
-# Agent Builder Candidates
-# Models we consider acceptable for driving the `pi-agent-builder` skill
-# (i.e. the LLM that reads a short natural-language prompt and writes a
-# pi extension). Comma-separated so scripts can iterate; pick one and
-# pass it via --model when invoking pi.
-AGENT_BUILDER_CANDIDATES=anthropic/claude-haiku-4.5,google/gemini-3-flash-preview,z-ai/glm-5.1
+# Agent Builder Targets
+# Models the `pi-agent-builder` skill is expected to work well on: the
+# skill should produce a correct, safe pi extension from a short
+# natural-language prompt on every one of these, not just one. Test
+# skill refinements against all three. Comma-separated so scripts can
+# iterate; at invocation time pick any one and pass it via --model.
+AGENT_BUILDER_TARGETS=anthropic/claude-haiku-4.5,google/gemini-3-flash-preview,z-ai/glm-5.1


### PR DESCRIPTION
## Summary
This PR adds documentation and configuration for the `pi-agent-builder` skill's target models, establishing a clear set of models that the skill should reliably work with and providing guidance for testing and invocation.

## Key Changes
- **models.env**: Added `AGENT_BUILDER_TARGETS` variable listing three models (Claude Haiku 4.5, Gemini 3 Flash Preview, GLM 5.1) that the pi-agent-builder skill is expected to work well on
- **AGENTS.md**: 
  - Added new section explaining the purpose and usage of `AGENT_BUILDER_TARGETS`
  - Clarified that the skill should produce correct, safe extensions on all target models, not just one
  - Added guidance to test skill refinements against all three models
  - Added inline comment in the example command recommending selection from `$AGENT_BUILDER_TARGETS` or fallback to `$LEAD_MODEL`

## Implementation Details
The `AGENT_BUILDER_TARGETS` is exposed as a comma-separated list to enable scripts to iterate over the models programmatically. The documentation emphasizes that when refining the skill, all three target models should be tested for correctness and safety, while at invocation time any one of them can be selected via the `--model` flag.

https://claude.ai/code/session_01SqNczdQGeDvjWpfjUwKoaS