### PR TITLE
Document anti-pattern for large file generation with Claude Code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,6 +287,23 @@ generation), a separate class of issues surfaces:
   `timeout_ms` close to the expected runtime rather than the max
   (keeps stale-event latency low), and don't start a new monitor
   on top of a stale one for an unrelated test.
+- **Don't hand Claude Code a plan that says "copy a big file verbatim,
+  then edit sections" and expect it to emit the result in a single
+  `Write` call.** We hit this with `scripts/grade-deferred-writer.sh`
+  (571 lines / 23 KB of escape-heavy bash — nested quote regexes,
+  heredocs, `awk -F:` + `printf`-built JSON). Every attempt crashed
+  at the same point: the small rubric committed fine, then the
+  grader copy died mid-`Write`. The failure is some mix of
+  per-response output-token ceiling, JSON-escape corruption of the
+  tool-call argument under length, and plain attention divergence
+  on "copy exactly 400 lines, change nothing." The fix is to keep
+  the body off the model's output stream entirely: `cp <src> <dst>`
+  via Bash, then one `Edit` per swap-map row with
+  `old_string`/`new_string` scoped to <30 lines. `sed -i` is **not**
+  a substitute — regex-heavy bash fights `sed`'s own quote escaping
+  in a different but equally bad way. Treat "re-emit a >~300-line
+  transformed copy via a single `Write`" as the anti-pattern and
+  always decompose it into `cp` + targeted `Edit`s.
 
 ## Repo layout
 


### PR DESCRIPTION
## Summary
Added guidance to AGENTS.md documenting a critical anti-pattern discovered when using Claude Code to generate large files: attempting to emit a complete transformed copy (>~300 lines) in a single `Write` call.

## Key Changes
- **New anti-pattern documentation**: Added detailed guidance explaining why "copy a big file verbatim, then edit sections" plans fail when handed to Claude Code
- **Root cause analysis**: Documented the failure modes including per-response output-token ceilings, JSON-escape corruption in tool arguments, and attention divergence on exact copying tasks
- **Recommended solution**: Provided the correct approach using `cp` for the initial file copy followed by targeted `Edit` calls with `old_string`/`new_string` pairs scoped to <30 lines
- **Tool-specific guidance**: Noted that `sed -i` is not a viable substitute due to quote escaping conflicts with bash syntax

## Implementation Details
The guidance is based on real-world failure with `scripts/grade-deferred-writer.sh` (571 lines / 23 KB of escape-heavy bash with nested quotes, heredocs, and complex awk/printf patterns). The documented solution decomposes the operation into:
1. File copy via Bash (`cp <src> <dst>`)
2. Multiple targeted `Edit` operations with small, focused string replacements

This prevents the model from attempting to re-emit large amounts of code in a single output, which consistently caused mid-operation failures.

https://claude.ai/code/session_019EdQ5CHSqteJruSmvs6Zyt