### PR TITLE
chore(baselines): snapshot pre-emit-summary gate results

### DIFF
--- a/pi-sandbox/.pi/components/emit-summary.ts
+++ b/pi-sandbox/.pi/components/emit-summary.ts
@@ -1,0 +1,53 @@
+// emit-summary.ts — a structured-output harvest stub for child pi processes.
+// The child calls emit_summary({title, body}) IN PLACE of producing a
+// free-form final assistant message; the parent harvests each call from
+// the NDJSON `tool_execution_start` event stream (--mode json) and decides
+// what to do with the {title, body} pair — display it, persist it to
+// .pi/scratch/<name>-summary.md, feed it into a subsequent phase, etc.
+//
+// Semantics differ from stage-write.ts: stage_* deferred side effects;
+// emit_* surfaces structured output, no side effect to commit. Parent
+// applies byte caps and validation; the stub itself has no filesystem
+// contact.
+//
+// Intended to be loaded into a child only, via `pi -e <abs path>`. The
+// parent should pair this with `--tools emit_summary,<read-only verbs>`
+// so the agent has no write/edit channel at all.
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+
+export default function (pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "emit_summary",
+    label: "Emit Summary",
+    description:
+      "Emit a named, structured summary for the parent to harvest. " +
+      "Use this IN PLACE of producing summaries in free-form assistant text — " +
+      "the parent harvests each call from the NDJSON event stream and decides " +
+      "what to do with it (display, persist, feed into a next phase). Call " +
+      "once per distinct summary; the parent may accept several in one run.",
+    parameters: Type.Object({
+      title: Type.String({
+        description:
+          "Short identifying label for this summary (e.g. `directory-survey`, `risk-review`).",
+      }),
+      body: Type.String({
+        description:
+          "The full summary text. The parent applies byte caps; don't exceed ~8 KB.",
+      }),
+    }),
+    async execute(_id, params) {
+      const bytes = Buffer.byteLength(params.body, "utf8");
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Emitted summary "${params.title}" (${bytes} bytes). Parent will handle.`,
+          },
+        ],
+        details: { title: params.title, bytes },
+      };
+    },
+  });
+}

--- a/pi-sandbox/skills/pi-agent-assembler/SKILL.md
+++ b/pi-sandbox/skills/pi-agent-assembler/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pi-agent-assembler
-description: Composes documented, pre-tested parts from a committed library into Pi agents. Use this skill whenever the user wants to create a pi-coding-agent extension, sub-agent, slash command, or lifecycle hook and the request can be covered by one of the known patterns (recon / drafter-with-approval / confined-drafter / orchestrator). Trigger on phrases like "pi extension", "pi agent", "pi sub-agent", "registerTool", "ExtensionAPI", ".pi/extensions/", ".pi/components/", "recon", "drafter", "stage write", "emit summary", "orchestrator", or any ask to extend pi with behavior that fits a known shape. This skill does NOT author from scratch — if no pattern matches, it STOPS and emits a GAP message so the user can fall back to `pi-agent-builder`.
+description: Composes documented, pre-tested parts from a committed library into Pi agents. Use this skill whenever the user wants to create a pi-coding-agent extension, sub-agent, slash command, or lifecycle hook and the request can be covered by one of the known patterns (recon / drafter-with-approval / confined-drafter / scout-then-draft / orchestrator). Trigger on phrases like "pi extension", "pi agent", "pi sub-agent", "registerTool", "ExtensionAPI", ".pi/extensions/", ".pi/components/", "recon", "drafter", "stage write", "emit summary", "scout", "orchestrator", or any ask to extend pi with behavior that fits a known shape. This skill does NOT author from scratch — if no pattern matches, it STOPS and emits a GAP message so the user can fall back to `pi-agent-builder`.
 ---
 
 # Pi Agent Assembler
@@ -69,6 +69,7 @@ TypeScript skeleton with TODO-marked insertion points.
 | `patterns/recon.md` | **Read-only survey.** Child walks a directory / codebase and emits one or more structured summaries via `emit_summary`. No side effects. |
 | `patterns/drafter-with-approval.md` | **Single drafter + user gate.** Child stages writes in parent memory via `stage_write`; parent previews via `ctx.ui.confirm` and promotes approved drafts. Canonical: `deferred-writer.ts`. |
 | `patterns/confined-drafter.md` | **Single drafter, no approval gate.** Child writes freely but only inside a scoped cwd via `cwd-guard.ts`. Use when a human-confirm loop would hurt more than it helps (batch / scripted runs, agent-maker). |
+| `patterns/scout-then-draft.md` | **Recon + drafter composed in one handler.** Child 1 surveys via `emit_summary`; parent assembles a handoff brief; child 2 drafts via `stage_write` with the brief in-prompt; parent previews via `ctx.ui.confirm`. No delegator LLM. |
 | `patterns/orchestrator.md` | **Delegator over drafters + LLM review.** One RPC delegator LLM dispatches drafters (via `run_deferred_writer` stub) and reviews drafts (via `review.ts`); parent harvests both stubs from NDJSON. Canonical: `delegated-writer.ts`. |
 
 ## How to use this skill
@@ -79,7 +80,9 @@ Follow `procedure.md` exactly:
 2. **Pick parts** — the pattern's parts list is authoritative.
 3. **Verify cwd-guard** is first in the parts list for every
    write-capable child (recon's child is read-only + `emit_summary`,
-   so it loads `emit-summary.ts` in cwd-guard's place).
+   so it loads `emit-summary.ts` in cwd-guard's place; in
+   scout-then-draft, the recon child skips cwd-guard and the
+   drafter child loads it).
 4. **Emit glue** from the pattern's skeleton, filling TODO slots.
 5. **If step 1 is not a confident match, STOP and emit the GAP
    message** exactly as given in `procedure.md`.

--- a/pi-sandbox/skills/pi-agent-assembler/SKILL.md
+++ b/pi-sandbox/skills/pi-agent-assembler/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pi-agent-assembler
-description: Composes documented, pre-tested parts from a committed library into Pi agents. Use this skill whenever the user wants to create a pi-coding-agent extension, sub-agent, slash command, or lifecycle hook and the request can be covered by one of the known patterns (recon / drafter-with-approval / confined-drafter / orchestrator). Trigger on phrases like "pi extension", "pi agent", "pi sub-agent", "registerTool", "ExtensionAPI", ".pi/extensions/", ".pi/components/", "recon", "drafter", "stage write", "orchestrator", or any ask to extend pi with behavior that fits a known shape. This skill does NOT author from scratch — if no pattern matches, it STOPS and emits a GAP message so the user can fall back to `pi-agent-builder`.
+description: Composes documented, pre-tested parts from a committed library into Pi agents. Use this skill whenever the user wants to create a pi-coding-agent extension, sub-agent, slash command, or lifecycle hook and the request can be covered by one of the known patterns (recon / drafter-with-approval / confined-drafter / orchestrator). Trigger on phrases like "pi extension", "pi agent", "pi sub-agent", "registerTool", "ExtensionAPI", ".pi/extensions/", ".pi/components/", "recon", "drafter", "stage write", "emit summary", "orchestrator", or any ask to extend pi with behavior that fits a known shape. This skill does NOT author from scratch — if no pattern matches, it STOPS and emits a GAP message so the user can fall back to `pi-agent-builder`.
 ---
 
 # Pi Agent Assembler
@@ -21,12 +21,15 @@ rather than a confabulated extension.
    extensions in `patterns/` are the vocabulary. You do not write new
    child-tools, new stub shapes, or new NDJSON harvesters inside this
    skill.
-2. **cwd-guard on every sub-pi spawn.** Every generated agent that
-   spawns a child pi process MUST load
+2. **cwd-guard on every write-capable sub-pi spawn.** Every
+   generated agent that spawns a child pi process with a write-capable
+   tool in its allowlist MUST load
    `pi-sandbox/.pi/components/cwd-guard.ts` via `-e <abs path>` and
-   pin `PI_SANDBOX_ROOT` in the child's env. No exceptions; this is
-   the safety rail that keeps a child from writing outside its run
-   cwd.
+   pin `PI_SANDBOX_ROOT` in the child's env. This is the safety
+   rail that keeps a child from writing outside its run cwd. The
+   sole exception is the recon pattern, whose child has a read-only
+   allowlist plus `emit_summary` (no filesystem contact) — no
+   write channel, nothing to sandbox.
 3. **If no pattern matches, STOP.** Emit the GAP template from
    `procedure.md`. Do not improvise a new pattern in place.
 4. **Write to `.pi/extensions/<n>.ts`**, not to the cwd root. Pi
@@ -43,12 +46,13 @@ into child pi processes via `pi -e <abs path>`.
 
 | Part | Role | When to use |
 | --- | --- | --- |
-| `cwd-guard.ts` | Sandbox for child writes | **REQUIRED on every sub-pi spawn.** Registers `sandbox_write` + `sandbox_edit`; both reject paths outside `$PI_SANDBOX_ROOT`. Replaces built-in `write` / `edit`. |
+| `cwd-guard.ts` | Sandbox for child writes | **REQUIRED on every write-capable sub-pi spawn.** Registers `sandbox_write` + `sandbox_edit`; both reject paths outside `$PI_SANDBOX_ROOT`. Replaces built-in `write` / `edit`. Recon children skip it — they have no write channel at all. |
 | `stage-write.ts` | Stub drafter channel | The child should draft files the *parent previews and approves* before anything hits disk. Child calls `stage_write({path, content})`; parent harvests from NDJSON `tool_execution_start` events and `fs.writeFileSync`s only on user approval. |
+| `emit-summary.ts` | Stub structured-output channel | The child should return one or more *named summaries* instead of free-form assistant text. Child calls `emit_summary({title, body})`; parent harvests from NDJSON `tool_execution_start` events, caps byte-length per body, and persists / forwards the result. The recon pattern's primary output channel. |
 | `review.ts` | Stub reviewer verdict | An orchestrator LLM renders `approve`/`revise` verdicts on staged drafts. Parent harvests the verdicts and loops (dispatch → review → revise) up to a bounded iteration count. |
 
 Per-part detail: `parts/cwd-guard.md`, `parts/stage-write.md`,
-`parts/review.md`.
+`parts/emit-summary.md`, `parts/review.md`.
 
 `pi-sandbox/.pi/components/run-deferred-writer.ts` also ships in the
 library, but it is the delegated-writer pattern's dispatch stub
@@ -62,7 +66,7 @@ TypeScript skeleton with TODO-marked insertion points.
 
 | Pattern | Problem shape |
 | --- | --- |
-| `patterns/recon.md` | **Read-only survey.** Child walks a directory / codebase and emits a bounded text summary. No side effects. |
+| `patterns/recon.md` | **Read-only survey.** Child walks a directory / codebase and emits one or more structured summaries via `emit_summary`. No side effects. |
 | `patterns/drafter-with-approval.md` | **Single drafter + user gate.** Child stages writes in parent memory via `stage_write`; parent previews via `ctx.ui.confirm` and promotes approved drafts. Canonical: `deferred-writer.ts`. |
 | `patterns/confined-drafter.md` | **Single drafter, no approval gate.** Child writes freely but only inside a scoped cwd via `cwd-guard.ts`. Use when a human-confirm loop would hurt more than it helps (batch / scripted runs, agent-maker). |
 | `patterns/orchestrator.md` | **Delegator over drafters + LLM review.** One RPC delegator LLM dispatches drafters (via `run_deferred_writer` stub) and reviews drafts (via `review.ts`); parent harvests both stubs from NDJSON. Canonical: `delegated-writer.ts`. |
@@ -73,8 +77,9 @@ Follow `procedure.md` exactly:
 
 1. **Classify** the user's prompt against the pattern rows above.
 2. **Pick parts** — the pattern's parts list is authoritative.
-3. **Verify cwd-guard** is first in the parts list (except for
-   recon, where the child has no write tool at all).
+3. **Verify cwd-guard** is first in the parts list for every
+   write-capable child (recon's child is read-only + `emit_summary`,
+   so it loads `emit-summary.ts` in cwd-guard's place).
 4. **Emit glue** from the pattern's skeleton, filling TODO slots.
 5. **If step 1 is not a confident match, STOP and emit the GAP
    message** exactly as given in `procedure.md`.
@@ -103,8 +108,11 @@ Load the `pi-agent-builder` skill instead when:
 - **Inventing a new part in a user session.** The library is
   closed; if a new child-tool shape is needed, that's a GAP, not
   an opportunity to improvise.
-- **Skipping cwd-guard "just this once".** Non-negotiable on every
-  spawn. An agent without it is unsafe no matter how narrow the
+- **Skipping cwd-guard on a write-capable child.** Non-negotiable
+  on every write-capable spawn; the one exception is the recon
+  child (read-only + `emit_summary`, no filesystem contact). An
+  agent that skips cwd-guard while handing the child `sandbox_write`
+  / `write` / `edit` / `bash` is unsafe no matter how narrow the
   task looks.
 - **Paraphrasing a pattern's skeleton.** Use the template as-is.
   Tweaking boilerplate re-introduces the failure modes the patterns

--- a/pi-sandbox/skills/pi-agent-assembler/SKILL.md
+++ b/pi-sandbox/skills/pi-agent-assembler/SKILL.md
@@ -103,6 +103,18 @@ Load the `pi-agent-builder` skill instead when:
 `packaging.md`, `production.md`, `skills-and-context.md`,
 `reading-short-prompts.md`) — use them for from-scratch authorship.
 
+## Naming conventions
+
+Part names encode intent. Pick the bucket first; name the tool
+second. If no bucket fits, raise it — the library's coherence is
+worth the pause.
+
+| Prefix / name | Semantics | Examples |
+| --- | --- | --- |
+| `stage_*` | Child proposes a side effect; parent holds the commit. The stub returns immediately; the parent decides later whether to persist. | `stage_write`. Future candidates: `stage_exec`, `stage_http_call`. |
+| `emit_*` | Structured-output harvest; no side effect deferred. The parent receives a named piece of structured text to display / persist / forward. | `emit_summary`. Future candidates: `emit_finding`, `emit_metric`. |
+| role name | Purpose-specific stub. Used when no prefix family fits, typically because the tool is single-use inside one pattern. | `review`, `run_deferred_writer`. Future candidate: `ask_user`. |
+
 ## Anti-patterns
 
 - **Inventing a new part in a user session.** The library is

--- a/pi-sandbox/skills/pi-agent-assembler/parts/cwd-guard.md
+++ b/pi-sandbox/skills/pi-agent-assembler/parts/cwd-guard.md
@@ -17,8 +17,10 @@ skill. The child's `--tools` allowlist should include
 `edit`, so the only write path out of the child is validated.
 
 Exception: `recon` pattern. Recon children have no write channel at
-all — the allowlist is read-only (`ls,read,grep,glob`), so cwd-guard
-adds nothing. Every OTHER pattern loads it.
+all — the allowlist is read-only plus `emit_summary` (the stub has
+no filesystem contact), so cwd-guard adds nothing. Recon loads
+`emit-summary.ts` instead; see `parts/emit-summary.md`. Every
+OTHER pattern loads cwd-guard.
 
 ## Load mechanism
 

--- a/pi-sandbox/skills/pi-agent-assembler/parts/emit-summary.md
+++ b/pi-sandbox/skills/pi-agent-assembler/parts/emit-summary.md
@@ -1,0 +1,108 @@
+# Part: `emit-summary.ts`
+
+**Location:** `pi-sandbox/.pi/components/emit-summary.ts`
+
+## What it does
+
+Pi extension that registers a **stub** tool
+`emit_summary({title, body})`. The tool's `execute` is a no-op — it
+returns a confirm message but does NOT touch disk. The parent
+harvests each `tool_execution_start` event for `emit_summary` from
+the child's NDJSON stdout (`--mode json`) to recover
+`{title, body}`.
+
+`emit_*` is the structured-output counterpart to `stage_*`: no side
+effect is deferred, the child is simply handing the parent a named
+piece of structured text to display / persist / feed into a next
+phase. See the "Naming conventions" section in `SKILL.md`.
+
+## When to use
+
+- **recon pattern:** the child walks a directory / codebase and
+  hands back one or more structured summaries. Replaces harvesting
+  free-form assistant text from `message_end` events.
+- **scout-then-draft pattern:** the recon phase emits summaries
+  that the parent assembles into a handoff brief for the drafter
+  phase.
+
+## When NOT to use
+
+- Any pattern where the child needs to return a *side effect* (a
+  file write, an exec, an HTTP call). Use `stage_*` for those.
+- Patterns where the parent genuinely wants the child's final
+  assistant prose (there are none in this library today).
+
+## Load mechanism
+
+```ts
+const EMIT_SUMMARY = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "components",
+  "emit-summary.ts",
+);
+```
+
+Pass `-e <EMIT_SUMMARY>` to the child. Resolve the path relative to
+the parent extension's own `import.meta.url`, NOT from `$HOME` or
+the user's cwd.
+
+## Required `--tools` allowlist
+
+Include `emit_summary` plus whatever read-only verbs the child role
+needs. For recon:
+
+```
+ls,read,grep,glob,emit_summary
+```
+
+Never add `write`, `edit`, `stage_write`, or `bash` in a pattern
+that uses `emit_summary` as its primary output channel — they
+undermine the "structured-output-only" contract.
+
+## Harvesting in the parent
+
+The child speaks NDJSON on stdout (`--mode json`). Each time the
+LLM calls `emit_summary`, the parent sees:
+
+```json
+{"type":"tool_execution_start","toolName":"emit_summary","args":{"title":"…","body":"…"}}
+```
+
+Accumulate `{title, body}` into an array. Apply a per-body byte cap
+(`Buffer.byteLength(body, "utf8") > SUMMARY_BYTE_CAP`) and
+optionally a total-across-all-summaries cap before persisting.
+
+## Spawn snippet
+
+```ts
+const child = spawn(
+  "pi",
+  [
+    "-e", EMIT_SUMMARY,
+    "--tools", "ls,read,grep,glob,emit_summary",
+    "--no-extensions",
+    "--mode", "json",
+    "--provider", "openrouter",
+    "--model", MODEL,
+    "--no-session",
+    "--thinking", "off",
+    "-p", agentPrompt,
+  ],
+  { stdio: ["ignore", "pipe", "pipe"], cwd: sandboxRoot },
+);
+```
+
+Note: `PI_SANDBOX_ROOT` is NOT required here — `emit_summary` has
+no filesystem contact and the child's allowlist is read-only.
+Patterns that combine `emit_summary` with write-capable parts
+(e.g. `scout-then-draft`'s drafter phase) set `PI_SANDBOX_ROOT`
+only on the spawn that loads `cwd-guard.ts`.
+
+## Canonical usage
+
+`patterns/recon.md`'s skeleton is the reference wiring for
+`emit_summary`. The drafter phase in `patterns/scout-then-draft.md`
+does NOT use it — `stage_write` is the right choice there because
+the drafter proposes files to persist, not structured summaries to
+display.

--- a/pi-sandbox/skills/pi-agent-assembler/patterns/orchestrator.md
+++ b/pi-sandbox/skills/pi-agent-assembler/patterns/orchestrator.md
@@ -8,7 +8,11 @@ for dispatch, `review` for verdicts); the parent harvests both from
 NDJSON and drives the real pipeline.
 
 This is the most complex pattern here. Prefer a simpler pattern
-unless the prompt explicitly asks for orchestration.
+unless the prompt explicitly asks for orchestration. In particular,
+if the user's real shape is "one survey + one draft" (look at what's
+there, then write the missing piece), reach for `scout-then-draft`
+first — orchestrator's delegator LLM and revise loop are overkill
+for that case.
 
 ## Short-prompt signals that match
 

--- a/pi-sandbox/skills/pi-agent-assembler/patterns/recon.md
+++ b/pi-sandbox/skills/pi-agent-assembler/patterns/recon.md
@@ -1,8 +1,8 @@
 # Pattern: `recon`
 
 **When to use:** user wants a read-only survey of a directory,
-codebase, or fixture. The child walks the inputs and emits a
-bounded text summary; nothing is written.
+codebase, or fixture. The child walks the inputs and emits bounded,
+structured summaries via `emit_summary`; nothing is written.
 
 ## Short-prompt signals that match
 
@@ -17,22 +17,35 @@ The child remains read-only.
 
 ## Parts
 
-None from the write library. Recon deliberately does NOT load
-cwd-guard — the child has no write tool at all.
+In load order on the child:
+
+1. `emit-summary.ts` — the stub the child calls with `{title, body}`
+   to hand a structured summary back to the parent. The child MUST
+   NOT produce summaries as free-form assistant text — the parent
+   harvests `emit_summary` calls from the NDJSON event stream and
+   has no robust way to use text-in-message.
+
+`cwd-guard.ts` is deliberately **not** loaded. Recon children have
+no write channel at all; the `--tools` allowlist is read-only plus
+`emit_summary` (the stub has no filesystem contact). Adding
+cwd-guard would only pollute the tool surface.
 
 The parent's role:
 
-- Spawn a child with a read-only `--tools` allowlist.
-- Harvest the child's final assistant text from `message_end`
-  events.
-- Enforce a byte-length cap on the summary (`.slice(0, N)` or
-  `Buffer.byteLength`).
-- Write the summary to `.pi/scratch/<name>.md` (parent-side, using
-  the built-in `write` — the parent isn't sandboxed by cwd-guard).
+- Spawn a child with a read-only `--tools` allowlist plus
+  `emit_summary`.
+- Harvest `{title, body}` from every `tool_execution_start` event
+  where `toolName === "emit_summary"`.
+- Enforce a byte-length cap on each body (and optionally a total
+  cap across all summaries).
+- Concatenate (or pick one) and write the result to
+  `.pi/scratch/<name>-summary.md` with the parent's built-in
+  `fs.writeFileSync` — the parent isn't sandboxed by cwd-guard.
 
 ## `--tools` allowlist
 
-Exactly read-only verbs: `ls,read,grep,glob`.
+Exactly read-only verbs plus the emit stub:
+`ls,read,grep,glob,emit_summary`.
 
 Forbidden: `write`, `edit`, `stage_write`, `bash`. The allowlist
 is what makes this pattern "recon" — anything that can mutate
@@ -54,10 +67,17 @@ auto-discovered by pi and won't register.
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 const PHASE_TIMEOUT_MS = 120_000;
 const SUMMARY_BYTE_CAP = 8_000;
+const TOTAL_BYTE_CAP = 32_000;
+
+const EMIT_SUMMARY = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..", "components", "emit-summary.ts",
+);
 
 export default function (pi: ExtensionAPI) {
   pi.registerCommand("TODO:CMD_NAME", {
@@ -73,6 +93,10 @@ export default function (pi: ExtensionAPI) {
         ctx.ui.notify("TASK_MODEL env var not set. Source models.env.", "error");
         return;
       }
+      if (!fs.existsSync(EMIT_SUMMARY)) {
+        ctx.ui.notify(`emit-summary missing at ${EMIT_SUMMARY}`, "error");
+        return;
+      }
       const sandboxRoot = path.resolve(process.cwd());
       const targetAbs = path.resolve(sandboxRoot, target);
       if (targetAbs !== sandboxRoot && !targetAbs.startsWith(sandboxRoot + path.sep)) {
@@ -81,18 +105,22 @@ export default function (pi: ExtensionAPI) {
       }
 
       const agentPrompt =
-        `You are a RECON AGENT. Survey ${targetAbs} and produce a bounded ` +
-        `summary. Use only 'ls', 'read', 'grep', 'glob' (no write, no edit, ` +
-        `no bash). Return a concise report (<= ${SUMMARY_BYTE_CAP} bytes) ` +
-        `naming the files/directories you actually saw. ` +
-        `TODO:AGENT_PROMPT`;
+        `You are a RECON AGENT. Survey ${targetAbs} and produce bounded ` +
+        `summaries. Use only 'ls', 'read', 'grep', 'glob' (no write, no edit, ` +
+        `no bash). Instead of producing a final assistant message, call ` +
+        `emit_summary({title, body}) with a short title and a body <= ${SUMMARY_BYTE_CAP} ` +
+        `bytes naming the files/directories you actually saw. Call it once for ` +
+        `the overall directory survey; call it a second time only if you have ` +
+        `a distinct, differently-scoped view to report. ` +
+        `TODO:AGENT_PROMPT Reply DONE and stop.`;
 
-      let summary = "";
+      const summaries: Array<{ title: string; body: string }> = [];
       const child = spawn(
         "pi",
         [
+          "-e", EMIT_SUMMARY,
           "--mode", "json",
-          "--tools", "ls,read,grep,glob",
+          "--tools", "ls,read,grep,glob,emit_summary",
           "--no-extensions",
           "--provider", "openrouter",
           "--model", MODEL,
@@ -120,18 +148,18 @@ export default function (pi: ExtensionAPI) {
           if (!line.trim()) continue;
           let e: Record<string, unknown>;
           try { e = JSON.parse(line); } catch { continue; }
-          if (e.type === "tool_execution_start") {
+          if (e.type === "tool_execution_start" && e.toolName === "emit_summary") {
+            toolCalls++;
+            const a = e.args as Record<string, unknown> | undefined;
+            const title = typeof a?.title === "string" ? a.title : "";
+            const body = typeof a?.body === "string" ? a.body : "";
+            if (title && body) {
+              summaries.push({ title, body });
+              ctx.ui.notify(`Recon → emit_summary "${title}" (${Buffer.byteLength(body, "utf8")} bytes)`, "info");
+            }
+          } else if (e.type === "tool_execution_start") {
             toolCalls++;
             ctx.ui.notify(`Recon → ${e.toolName}`, "info");
-          } else if (e.type === "message_end") {
-            const msg = e.message as { role?: string; content?: unknown } | undefined;
-            if (msg?.role === "assistant" && Array.isArray(msg.content)) {
-              for (const part of msg.content as Array<{ type?: string; text?: string }>) {
-                if (part?.type === "text" && typeof part.text === "string") {
-                  summary = part.text;
-                }
-              }
-            }
           }
         }
       });
@@ -146,22 +174,29 @@ export default function (pi: ExtensionAPI) {
         ctx.ui.notify(`Recon timed out after ${PHASE_TIMEOUT_MS / 1000}s.`, "error");
         return;
       }
-      if (!summary) {
-        ctx.ui.notify(`Recon produced no summary. Stderr: ${stderr.slice(-1000)}`, "error");
+      if (summaries.length === 0) {
+        ctx.ui.notify(`Recon produced no emit_summary calls. Stderr: ${stderr.slice(-1000)}`, "error");
         return;
       }
 
-      // Bounded summary. TODO:VALIDATION — add task-specific checks here.
-      if (Buffer.byteLength(summary, "utf8") > SUMMARY_BYTE_CAP) {
-        summary = summary.slice(0, SUMMARY_BYTE_CAP) + "\n…(truncated)";
+      // Per-summary byte cap, then total-length cap on the concatenation.
+      // TODO:VALIDATION — add task-specific checks here.
+      const capped = summaries.map((s) => {
+        const bytes = Buffer.byteLength(s.body, "utf8");
+        const body = bytes > SUMMARY_BYTE_CAP ? s.body.slice(0, SUMMARY_BYTE_CAP) + "\n…(truncated)" : s.body;
+        return `## ${s.title}\n\n${body}`;
+      });
+      let combined = capped.join("\n\n---\n\n");
+      if (Buffer.byteLength(combined, "utf8") > TOTAL_BYTE_CAP) {
+        combined = combined.slice(0, TOTAL_BYTE_CAP) + "\n…(truncated)";
       }
 
       const outDir = path.resolve(sandboxRoot, ".pi/scratch");
       fs.mkdirSync(outDir, { recursive: true });
       const outPath = path.join(outDir, "TODO:CMD_NAME-summary.md");
-      fs.writeFileSync(outPath, summary, "utf8");
+      fs.writeFileSync(outPath, combined, "utf8");
       ctx.ui.notify(
-        `Recon complete (${toolCalls} tool call(s), ${Buffer.byteLength(summary, "utf8")} bytes). Summary: ${outPath}`,
+        `Recon complete (${toolCalls} tool call(s), ${summaries.length} summary/summaries, ${Buffer.byteLength(combined, "utf8")} bytes). Summary: ${outPath}`,
         "info",
       );
     },
@@ -176,15 +211,22 @@ contains each of these anchors:
 
 - `registerCommand("TODO:CMD_NAME"` — replaced with the chosen
   slash command name.
-- `"--tools", "ls,read,grep,glob"` — read-only allowlist, no
-  writers.
+- `-e <abs path ending in components/emit-summary.ts>` on the spawn
+  args. Resolve the path relative to the parent extension's own
+  `import.meta.url`, NOT from `$HOME` or cwd.
+- `"--tools", "ls,read,grep,glob,emit_summary"` — read-only verbs
+  plus the emit stub. No `write`, `edit`, `stage_write`, or `bash`.
 - `"--no-extensions"` on the spawn args.
+- NDJSON parser matches on
+  `e.type === "tool_execution_start" && e.toolName === "emit_summary"`
+  and reads `title` / `body` from `e.args`. The parent must NOT
+  rely on `message_end` assistant text for the summary content.
 - `setTimeout(…, PHASE_TIMEOUT_MS)` + `child.kill("SIGKILL")` — hard
   timeout.
-- `Buffer.byteLength(summary, "utf8") > SUMMARY_BYTE_CAP` — a
-  byte-length cap on the harvested summary.
-- `fs.writeFileSync(outPath, summary, "utf8")` — parent writes the
-  summary (not the child).
-- NO `-e <…stage-write…>`, NO `-e <…cwd-guard…>`. Recon loads
-  neither.
+- Per-summary cap: `Buffer.byteLength(body, "utf8") > SUMMARY_BYTE_CAP`
+  (or `.slice(0, SUMMARY_BYTE_CAP)` on each body).
+- `fs.writeFileSync(outPath, combined, "utf8")` — parent writes the
+  summary (not the child). Path scoped to `.pi/scratch/`.
+- NO `-e <…stage-write…>`, NO `-e <…cwd-guard…>`. Recon loads only
+  `emit-summary.ts`.
 - NO `ctx.ui.confirm` call. Recon has no side effect to gate.

--- a/pi-sandbox/skills/pi-agent-assembler/patterns/scout-then-draft.md
+++ b/pi-sandbox/skills/pi-agent-assembler/patterns/scout-then-draft.md
@@ -1,0 +1,413 @@
+# Pattern: `scout-then-draft`
+
+**When to use:** user wants the agent to *first* survey an existing
+thing (a directory, a codebase, a fixture) and *then* produce one
+or more new files informed by what the survey found. Two sub-pi
+spawns per handler invocation — a recon child followed by a drafter
+child — with the parent assembling a handoff brief between them.
+
+This is two existing patterns (`recon` + `drafter-with-approval`)
+composed in a single extension. No delegator LLM, no revise loop —
+the parent owns the handoff.
+
+## Short-prompt signals that match
+
+- "look at `<X>`, then write `<Y>`"
+- "survey the project and add a `<Z>`"
+- "given what's there, produce the missing `<W>`"
+- "read the directory and generate a `README.md` summarizing it"
+- "audit the tests, then scaffold the missing one"
+
+## When NOT to use
+
+- **Pure recon** (survey only, no draft): use `patterns/recon.md`.
+- **Pure draft** (no survey phase): use
+  `patterns/drafter-with-approval.md` or `patterns/confined-drafter.md`.
+- **Multiple sub-tasks with LLM review:** use
+  `patterns/orchestrator.md`.
+
+If the prompt says "look at X, then write Y and Z in parallel"
+that's still scout-then-draft — the drafter child can stage
+multiple files in one run. If it says "and have an LLM review
+each," that's orchestrator.
+
+## Parts
+
+Two phases; each phase uses the parts from its underlying pattern.
+
+**Recon phase (child 1):**
+
+1. `emit-summary.ts` — the child emits one or more structured
+   summaries; the parent harvests `{title, body}` from NDJSON.
+
+**Drafter phase (child 2):**
+
+1. `cwd-guard.ts` — safety backstop; drafter writes via
+   `stage_write` but cwd-guard is loaded in case a future pattern
+   tweak adds a real write primitive.
+2. `stage-write.ts` — the stub write channel. Parent previews via
+   `ctx.ui.confirm` and promotes on approval.
+
+## `--tools` allowlist
+
+- **Recon child:** `ls,read,grep,glob,emit_summary` — exactly the
+  recon allowlist.
+- **Drafter child:** `stage_write,ls` (or `stage_write,ls,read`
+  if the drafter needs to inspect additional files beyond what the
+  recon brief conveys).
+
+Nothing else in either. No `write`, `edit`, `bash`, or real
+`sandbox_write` on either child.
+
+## Model tiers
+
+- **Recon child:** `$TASK_MODEL`.
+- **Drafter child:** `$TASK_MODEL` by default. Upgrade to
+  `$LEAD_MODEL` only if the drafter prompt explicitly needs
+  "review" or "decide" judgment (e.g. "pick the right shape
+  given the survey"). For most scout-then-draft prompts, both
+  phases are bulk worker output.
+
+## Handoff shape
+
+The parent assembles the brief by concatenating each harvested
+summary:
+
+```
+## <title-1>
+
+<body-1>
+
+---
+
+## <title-2>
+
+<body-2>
+```
+
+and prepending it to the drafter prompt:
+
+```
+<user task>
+
+Context — survey findings:
+<brief>
+```
+
+Apply the same per-body byte cap used in recon
+(`SUMMARY_BYTE_CAP`) plus a total-brief cap so an over-chatty
+recon can't blow up the drafter's prompt budget.
+
+## Skeleton
+
+Save this file as `.pi/extensions/<TODO:CMD_NAME>.ts` under the
+project's sandbox directory. Files at the cwd root are NOT
+auto-discovered by pi and won't register.
+
+```ts
+// .pi/extensions/TODO:CMD_NAME.ts — scout-then-draft: recon child feeds brief into drafter child.
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const RECON_TIMEOUT_MS = 120_000;
+const DRAFTER_TIMEOUT_MS = 180_000;
+const SUMMARY_BYTE_CAP = 8_000;
+const BRIEF_TOTAL_BYTE_CAP = 32_000;
+const MAX_FILES_PROMOTABLE = 50;
+const MAX_CONTENT_BYTES_PER_FILE = 2_000_000;
+const PREVIEW_LINES_PER_FILE = 20;
+
+const CWD_GUARD = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..", "components", "cwd-guard.ts",
+);
+const STAGE_WRITE_TOOL = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..", "components", "stage-write.ts",
+);
+const EMIT_SUMMARY = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..", "components", "emit-summary.ts",
+);
+
+const sha256 = (s: string) => createHash("sha256").update(s, "utf8").digest("hex");
+
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand("TODO:CMD_NAME", {
+    description: "TODO:CMD_DESCRIPTION",
+    handler: async (args, ctx) => {
+      if (!args.trim()) {
+        ctx.ui.notify("Usage: /TODO:CMD_NAME <task description>", "warning");
+        return;
+      }
+      const MODEL = process.env.TASK_MODEL;
+      if (!MODEL) {
+        ctx.ui.notify("TASK_MODEL env var not set. Source models.env.", "error");
+        return;
+      }
+      if (!fs.existsSync(EMIT_SUMMARY) || !fs.existsSync(STAGE_WRITE_TOOL) || !fs.existsSync(CWD_GUARD)) {
+        ctx.ui.notify("components missing; check pi-sandbox/.pi/components/", "error");
+        return;
+      }
+      const sandboxRoot = path.resolve(process.cwd());
+
+      // ---- Phase 1: recon child ---------------------------------------
+      const reconPrompt =
+        `You are a RECON AGENT. Survey ${sandboxRoot} (and subdirectories the ` +
+        `user task references) and produce bounded summaries via emit_summary. ` +
+        `Use only 'ls', 'read', 'grep', 'glob' (no write, no edit, no bash). ` +
+        `Call emit_summary({title, body}) with body <= ${SUMMARY_BYTE_CAP} bytes ` +
+        `per call. ` +
+        `TODO:AGENT_PROMPT_RECON ` +
+        `User goal (context only — do NOT write any files in this phase): ${args}. ` +
+        `Reply DONE and stop.`;
+
+      const summaries: Array<{ title: string; body: string }> = [];
+      const reconChild = spawn(
+        "pi",
+        [
+          "-e", EMIT_SUMMARY,
+          "--mode", "json",
+          "--tools", "ls,read,grep,glob,emit_summary",
+          "--no-extensions",
+          "--provider", "openrouter",
+          "--model", MODEL,
+          "--no-session",
+          "--thinking", "off",
+          "-p", reconPrompt,
+        ],
+        { stdio: ["ignore", "pipe", "pipe"], cwd: sandboxRoot },
+      );
+
+      let reconBuffer = "";
+      let reconStderr = "";
+      let reconTimedOut = false;
+      const reconTimer = setTimeout(() => { reconTimedOut = true; reconChild.kill("SIGKILL"); }, RECON_TIMEOUT_MS);
+
+      reconChild.stdout.on("data", (d) => {
+        reconBuffer += d.toString();
+        const lines = reconBuffer.split("\n");
+        reconBuffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          let e: Record<string, unknown>;
+          try { e = JSON.parse(line); } catch { continue; }
+          if (e.type === "tool_execution_start" && e.toolName === "emit_summary") {
+            const a = e.args as Record<string, unknown> | undefined;
+            const title = typeof a?.title === "string" ? a.title : "";
+            const body = typeof a?.body === "string" ? a.body : "";
+            if (title && body) {
+              summaries.push({ title, body });
+              ctx.ui.notify(`Scout → emit_summary "${title}" (${Buffer.byteLength(body, "utf8")} bytes)`, "info");
+            }
+          } else if (e.type === "tool_execution_start") {
+            ctx.ui.notify(`Scout → ${e.toolName}`, "info");
+          }
+        }
+      });
+      reconChild.stderr.on("data", (d) => { reconStderr += d.toString(); });
+
+      await new Promise<void>((resolve) => {
+        reconChild.on("close", () => { clearTimeout(reconTimer); resolve(); });
+        reconChild.on("error", () => { clearTimeout(reconTimer); resolve(); });
+      });
+
+      if (reconTimedOut) {
+        ctx.ui.notify(`Scout timed out; no draft produced.`, "error");
+        return;
+      }
+      if (summaries.length === 0) {
+        ctx.ui.notify(`Scout produced no emit_summary calls. Stderr: ${reconStderr.slice(-1000)}`, "error");
+        return;
+      }
+
+      // Assemble handoff brief. Per-summary cap + total-brief cap.
+      const capped = summaries.map((s) => {
+        const bytes = Buffer.byteLength(s.body, "utf8");
+        const body = bytes > SUMMARY_BYTE_CAP ? s.body.slice(0, SUMMARY_BYTE_CAP) + "\n…(truncated)" : s.body;
+        return `## ${s.title}\n\n${body}`;
+      });
+      let brief = capped.join("\n\n---\n\n");
+      if (Buffer.byteLength(brief, "utf8") > BRIEF_TOTAL_BYTE_CAP) {
+        brief = brief.slice(0, BRIEF_TOTAL_BYTE_CAP) + "\n…(truncated)";
+      }
+
+      // ---- Phase 2: drafter child -------------------------------------
+      const drafterPrompt =
+        `You are a DRAFTER. Task: ${args}.\n\n` +
+        `Context — survey findings from the recon phase:\n${brief}\n\n` +
+        `Nothing you do will touch disk until the user approves. Call ` +
+        `stage_write({path, content}) with a RELATIVE path inside ${sandboxRoot} ` +
+        `and the full content. Do NOT call any write/edit tool. ` +
+        `TODO:AGENT_PROMPT_DRAFTER Reply DONE and stop.`;
+
+      const stagedWrites: Array<{ path: unknown; content: unknown }> = [];
+      const drafterChild = spawn(
+        "pi",
+        [
+          "-e", CWD_GUARD,
+          "-e", STAGE_WRITE_TOOL,
+          "--mode", "json",
+          "--tools", "stage_write,ls",
+          "--no-extensions",
+          "--provider", "openrouter",
+          "--model", MODEL,
+          "--no-session",
+          "--thinking", "off",
+          "-p", drafterPrompt,
+        ],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+          cwd: sandboxRoot,
+          env: { ...process.env, PI_SANDBOX_ROOT: sandboxRoot },
+        },
+      );
+
+      let drafterBuffer = "";
+      let drafterStderr = "";
+      let drafterTimedOut = false;
+      const drafterTimer = setTimeout(() => { drafterTimedOut = true; drafterChild.kill("SIGKILL"); }, DRAFTER_TIMEOUT_MS);
+
+      drafterChild.stdout.on("data", (d) => {
+        drafterBuffer += d.toString();
+        const lines = drafterBuffer.split("\n");
+        drafterBuffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          let e: Record<string, unknown>;
+          try { e = JSON.parse(line); } catch { continue; }
+          if (e.type === "tool_execution_start" && e.toolName === "stage_write") {
+            const a = e.args as Record<string, unknown> | undefined;
+            if (a) {
+              stagedWrites.push({ path: a.path, content: a.content });
+              const p = typeof a.path === "string" ? a.path : "<?>";
+              const len = typeof a.content === "string" ? a.content.length : 0;
+              ctx.ui.notify(`Drafter → stage_write ${p} (${len} chars)`, "info");
+            }
+          } else if (e.type === "tool_execution_start") {
+            ctx.ui.notify(`Drafter → ${e.toolName}`, "info");
+          }
+        }
+      });
+      drafterChild.stderr.on("data", (d) => { drafterStderr += d.toString(); });
+
+      const drafterExit = await new Promise<number>((resolve) => {
+        drafterChild.on("close", (c) => { clearTimeout(drafterTimer); resolve(c ?? 0); });
+        drafterChild.on("error", () => { clearTimeout(drafterTimer); resolve(-1); });
+      });
+
+      if (drafterTimedOut) { ctx.ui.notify(`Drafter timed out; drafts discarded.`, "error"); return; }
+      if (drafterExit !== 0) { ctx.ui.notify(`Drafter exit ${drafterExit}. Stderr: ${drafterStderr.slice(-2000)}`, "error"); return; }
+      if (stagedWrites.length === 0) { ctx.ui.notify("Drafter made no stage_write calls.", "warning"); return; }
+      if (stagedWrites.length > MAX_FILES_PROMOTABLE) {
+        ctx.ui.notify(`Drafter staged ${stagedWrites.length} files (> ${MAX_FILES_PROMOTABLE}); aborting.`, "error");
+        return;
+      }
+
+      // Validation + preview + promotion: identical shape to
+      // drafter-with-approval. See that pattern's skeleton for the full
+      // per-draft validation (absolute-path reject, '..' reject,
+      // exists-skip, byte-length cap) and sha256-verified promotion.
+      const plans: Array<{ relPath: string; destAbs: string; content: string; sha: string; byteLength: number }> = [];
+      const skips: string[] = [];
+      for (const s of stagedWrites) {
+        if (typeof s.path !== "string" || !s.path) { skips.push(`<invalid path>`); continue; }
+        if (typeof s.content !== "string") { skips.push(`${s.path}: non-string content`); continue; }
+        if (path.isAbsolute(s.path) || s.path.split("/").includes("..")) { skips.push(`${s.path}: absolute or '..'`); continue; }
+        const destAbs = path.resolve(sandboxRoot, s.path);
+        if (destAbs !== sandboxRoot && !destAbs.startsWith(sandboxRoot + path.sep)) { skips.push(`${s.path}: escapes sandbox`); continue; }
+        if (fs.existsSync(destAbs)) { skips.push(`${s.path}: exists`); continue; }
+        const bytes = Buffer.byteLength(s.content, "utf8");
+        if (bytes > MAX_CONTENT_BYTES_PER_FILE) { skips.push(`${s.path}: ${bytes} bytes > cap`); continue; }
+        plans.push({ relPath: s.path, destAbs, content: s.content, sha: sha256(s.content), byteLength: bytes });
+      }
+      for (const skip of skips) ctx.ui.notify(`Skipping ${skip}`, "warning");
+      if (plans.length === 0) { ctx.ui.notify("No promotable drafts.", "warning"); return; }
+
+      // TODO:VALIDATION — optional task-specific post-drafter checks.
+
+      const previewBody = plans.map((p) => {
+        const head = `${p.destAbs} (${p.byteLength} bytes, sha ${p.sha.slice(0, 10)}…)`;
+        const lines = p.content.split("\n");
+        const shown = lines.slice(0, PREVIEW_LINES_PER_FILE).join("\n");
+        const tail = lines.length > PREVIEW_LINES_PER_FILE ? `\n… (+${lines.length - PREVIEW_LINES_PER_FILE} more)` : "";
+        return `${head}\n${shown}${tail}`;
+      }).join("\n\n---\n\n");
+
+      const ok = await ctx.ui.confirm(`Promote ${plans.length} file(s)?`, previewBody);
+      if (!ok) { ctx.ui.notify("Cancelled; nothing written.", "info"); return; }
+
+      const promoted: string[] = [];
+      const failures: string[] = [];
+      for (const p of plans) {
+        if (fs.existsSync(p.destAbs)) { failures.push(`${p.relPath}: exists now`); continue; }
+        try {
+          fs.mkdirSync(path.dirname(p.destAbs), { recursive: true });
+          fs.writeFileSync(p.destAbs, p.content, "utf8");
+          const actual = sha256(fs.readFileSync(p.destAbs, "utf8"));
+          if (actual !== p.sha) { failures.push(`${p.relPath}: hash mismatch`); continue; }
+          promoted.push(p.destAbs);
+        } catch (e) { failures.push(`${p.relPath}: ${(e as Error).message}`); }
+      }
+      if (failures.length > 0) ctx.ui.notify(`Promotion failures:\n${failures.join("\n")}`, "error");
+      if (promoted.length > 0) ctx.ui.notify(`Wrote ${promoted.length} file(s):\n${promoted.join("\n")}`, "info");
+    },
+  });
+}
+```
+
+## Validation checklist
+
+Two phases means two sets of anchors plus a structural phase-count
+anchor.
+
+**Phase count:**
+
+- Exactly **two** `spawn("pi"` calls in the handler body — the
+  recon child first, the drafter child second. A single-spawn
+  emit is the wrong pattern (pick `recon` or
+  `drafter-with-approval`); a three-plus-spawn emit is the wrong
+  pattern (pick `orchestrator`).
+
+**Recon child (first spawn):**
+
+- `-e <abs path ending in components/emit-summary.ts>`.
+- `"--tools", "ls,read,grep,glob,emit_summary"`.
+- `"--no-extensions"` and `"--no-session"`.
+- NDJSON parser matches on
+  `e.type === "tool_execution_start" && e.toolName === "emit_summary"`
+  and reads `title`/`body` from `e.args`.
+- `RECON_TIMEOUT_MS` + `child.kill("SIGKILL")`.
+- Per-summary byte cap (`Buffer.byteLength` or `.slice(0, N)`).
+- No `PI_SANDBOX_ROOT` on this spawn (no write channel to sandbox).
+
+**Drafter child (second spawn):**
+
+- `-e <abs path ending in components/cwd-guard.ts>` AND
+  `-e <abs path ending in components/stage-write.ts>`.
+- `PI_SANDBOX_ROOT: sandboxRoot` in the child env.
+- `"--tools", "stage_write,ls"` (or `,ls,read` if justified).
+- `"--no-extensions"` and `"--no-session"`.
+- NDJSON parser matches on
+  `e.toolName === "stage_write"` and reads `path`/`content` from
+  `e.args`.
+- `DRAFTER_TIMEOUT_MS` + SIGKILL.
+- `stagedWrites.length > MAX_FILES_PROMOTABLE` cap.
+- Per-file byte-length cap.
+- Path validation rejects absolute paths and `..` segments.
+- `ctx.ui.confirm(...)` before any `fs.writeFileSync`.
+- sha256 verification after write.
+- Cancel path (`ok === false`) exits cleanly with a notify.
+
+**Handoff:**
+
+- The drafter prompt includes the recon brief (e.g. via a
+  `Context — survey findings:` or similar marker) built from the
+  harvested summaries. The brief is NOT passed via env vars or
+  argv beyond the prompt itself.
+- A total-brief byte cap (`BRIEF_TOTAL_BYTE_CAP` or equivalent)
+  protects the drafter prompt from an over-chatty recon.

--- a/pi-sandbox/skills/pi-agent-assembler/procedure.md
+++ b/pi-sandbox/skills/pi-agent-assembler/procedure.md
@@ -11,9 +11,10 @@ examples):
 
 | User says… | Pattern |
 | --- | --- |
-| "summarize", "read", "survey", "what's in", "audit", "explore", "map out", "index" | `recon` |
+| "summarize", "read", "survey", "what's in", "audit", "explore", "map out", "index" (and no draft / write step follows) | `recon` |
 | "write X for me — I want to review before it saves", "draft a file and show me", "stage, then approve", "preview before writing" | `drafter-with-approval` |
 | "write X into `<dir>`", "generate a file", "create a project at", "no approval needed", batch / scripted run | `confined-drafter` |
+| "look at X, then write Y", "survey the project and add a Z", "given what's there, produce the missing W", "read the directory and generate a README summarizing it" | `scout-then-draft` |
 | "break this into sub-tasks and have an LLM check each", "dispatch several drafters then review", "orchestrator that reviews" | `orchestrator` |
 
 A confident match = the user's prompt contains at least one signal
@@ -21,9 +22,11 @@ from the pattern's "when to use" sentence (see each pattern's
 top-of-file paragraph).
 
 If multiple patterns match, prefer the **simpler** one (`recon` <
-`confined-drafter` < `drafter-with-approval` < `orchestrator`). Only
-promote to orchestrator when the user explicitly mentions multiple
-sub-tasks or review.
+`confined-drafter` < `drafter-with-approval` < `scout-then-draft` <
+`orchestrator`). Only promote to `scout-then-draft` when both a
+survey AND a draft step appear in the ask; only promote to
+`orchestrator` when the user explicitly mentions multiple sub-tasks
+or LLM review.
 
 If NO pattern matches, go straight to step 5.
 

--- a/scripts/approach-b-framework/baselines/pre-emit-summary/1-gemini.json
+++ b/scripts/approach-b-framework/baselines/pre-emit-summary/1-gemini.json
@@ -1,0 +1,1 @@
+{"model": "google/gemini-3-flash-preview","profile": "recon","p0_passed": "16/16","p1_passed": "2/2","load": "pass","behavioral": "pass","headline": "full pass","notes": []}

--- a/scripts/approach-b-framework/baselines/pre-emit-summary/1-haiku.json
+++ b/scripts/approach-b-framework/baselines/pre-emit-summary/1-haiku.json
@@ -1,0 +1,1 @@
+{"model": "anthropic/claude-haiku-4.5","profile": "recon","p0_passed": "16/16","p1_passed": "2/2","load": "pass","behavioral": "pass","headline": "full pass","notes": []}

--- a/scripts/approach-b-framework/baselines/pre-emit-summary/2-haiku.json
+++ b/scripts/approach-b-framework/baselines/pre-emit-summary/2-haiku.json
@@ -1,0 +1,1 @@
+{"label":"baseline-2-haiku","ext_files":1,"child_files":0,"gap_hits":5,"tool_execution_start_count":5,"has_cwd_guard_load":1,"has_sandbox_root_env":1,"has_sandbox_tools_in_allowlist":1}

--- a/scripts/approach-b-framework/baselines/pre-emit-summary/3-gemini.json
+++ b/scripts/approach-b-framework/baselines/pre-emit-summary/3-gemini.json
@@ -1,0 +1,1 @@
+{"label":"baseline-3-gemini","ext_files":0,"child_files":0,"gap_hits":17,"tool_execution_start_count":3,"has_cwd_guard_load":0,"has_sandbox_root_env":0,"has_sandbox_tools_in_allowlist":0}

--- a/scripts/approach-b-framework/baselines/pre-emit-summary/3-haiku.json
+++ b/scripts/approach-b-framework/baselines/pre-emit-summary/3-haiku.json
@@ -1,0 +1,1 @@
+{"label":"baseline-3-haiku","ext_files":0,"child_files":0,"gap_hits":5,"tool_execution_start_count":2,"has_cwd_guard_load":0,"has_sandbox_root_env":0,"has_sandbox_tools_in_allowlist":0}

--- a/scripts/approach-b-framework/profiles/recon.sh
+++ b/scripts/approach-b-framework/profiles/recon.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
-# profiles/recon.sh — read-only recon pattern (directory survey → bounded
-# summary, no side effects). The read-only counterpart of writer.sh.
+# profiles/recon.sh — read-only recon pattern (directory survey →
+# structured summaries via emit_summary, no side effects). The read-only
+# counterpart of writer.sh.
 #
 # Key shape differences from writer:
 #   - One file (extension only); no child-tool, nothing to stage.
-#   - --tools allowlist is read-only (ls + grep + glob + read); stage_write
-#     / write / edit / bash are all FORBIDDEN.
-#   - Summary is harvested from the child's message_end events (not
-#     tool_execution_start), because read-only children produce text, not
-#     staged tool calls.
+#   - --tools allowlist is read-only (ls + grep + glob + read) PLUS
+#     `emit_summary`; stage_write / write / edit / bash are all
+#     FORBIDDEN.
+#   - Summary is harvested from tool_execution_start events whose
+#     toolName === "emit_summary" (args.title / args.body). The
+#     child does NOT produce its summary as free-form assistant
+#     text — the parent ignores message_end for content purposes.
+#     This is a P0 contract: a correct recon loads emit-summary.ts
+#     via -e and harvests the structured calls.
 #   - Absence anchors: no ctx.ui.confirm (no gate to open — there is no
 #     side effect), no fs.writeFileSync outside .pi/scratch/ (recon does
 #     not promote).
@@ -62,51 +67,67 @@ profile_grade_tools_allowlist() {
   local allow
   allow=$(extract_tools_allowlist)
   if [[ -z "$allow" ]]; then
-    mark_p0 "--tools allowlist is read-only (ls/grep/glob/read), no writers" fail "no --tools flag found"
+    mark_p0 "--tools allowlist is read-only (ls/grep/glob/read) + emit_summary, no writers" fail "no --tools flag found"
     return
   fi
-  # At least one read-only verb MUST be present. `ls` alone is valid for
-  # the narrowest case, but a useful recon will have read too. We accept
-  # any of the four — the reading-short-prompts.md table lists all four
-  # as canonical for "read-only / survey / recon / explore".
-  local has_read_verb=0 forbidden=""
+  # At least one read-only verb MUST be present plus `emit_summary` (the
+  # structured-output channel). We accept any of the four read verbs —
+  # reading-short-prompts.md lists all four as canonical for "read-only
+  # / survey / recon / explore".
+  local has_read_verb=0 has_emit_summary=0 forbidden=""
   local v
   for v in ls read grep glob; do
     if [[ ",$allow," == *",$v,"* ]]; then has_read_verb=1; fi
   done
+  if [[ ",$allow," == *",emit_summary,"* ]]; then has_emit_summary=1; fi
   for v in stage_write write edit bash; do
     if [[ ",$allow," == *",$v,"* ]]; then forbidden="$forbidden $v"; fi
   done
   if [[ $has_read_verb -eq 0 ]]; then
-    mark_p0 "--tools allowlist is read-only (ls/grep/glob/read), no writers" fail "no read-only verb present: $allow"
+    mark_p0 "--tools allowlist is read-only (ls/grep/glob/read) + emit_summary, no writers" fail "no read-only verb present: $allow"
+  elif [[ $has_emit_summary -eq 0 ]]; then
+    mark_p0 "--tools allowlist is read-only (ls/grep/glob/read) + emit_summary, no writers" fail "emit_summary missing from $allow"
   elif [[ -n "$forbidden" ]]; then
-    mark_p0 "--tools allowlist is read-only (ls/grep/glob/read), no writers" fail "forbidden verb(s):$forbidden in $allow"
+    mark_p0 "--tools allowlist is read-only (ls/grep/glob/read) + emit_summary, no writers" fail "forbidden verb(s):$forbidden in $allow"
   else
-    mark_p0 "--tools allowlist is read-only (ls/grep/glob/read), no writers" pass
+    mark_p0 "--tools allowlist is read-only (ls/grep/glob/read) + emit_summary, no writers" pass
   fi
 }
 
 profile_grade_harvest() {
   say "## Harvest + validate"
-  # Recon reads the CHILD's final answer, which arrives as message_end
-  # (assistant role) — not as a tool call. message_update is acceptable
-  # too for streaming-collection implementations.
-  if [[ ${#EXT_FILES[@]} -gt 0 ]] && grep_any_ere 'message_end|message_update' "${EXT_FILES[@]}"; then
-    mark_p0 "harvest source = message_end / message_update event" pass
+  # Recon loads emit-summary.ts via `-e` on the spawn args so the child
+  # can call the emit_summary stub. The path should end in
+  # components/emit-summary.ts (resolved relative to the parent
+  # extension's own file), passed as the value of a `-e` argv entry.
+  if [[ ${#EXT_FILES[@]} -gt 0 ]] && grep_any_ere '(components/emit-summary\.ts|emit-summary\.ts)' "${EXT_FILES[@]}"; then
+    mark_p0 "emit-summary.ts loaded via -e" pass
   else
-    mark_p0 "harvest source = message_end / message_update event" fail
+    mark_p0 "emit-summary.ts loaded via -e" fail "emit-summary.ts path not referenced in extension"
   fi
 
-  # Negative: recon MUST NOT handle tool_execution_start AND read args
-  # off it — that's the writer harvest pattern. Accept any of the
+  # Recon harvests structured summaries from tool_execution_start events
+  # whose toolName === "emit_summary", reading {title, body} from
+  # e.args. Accept quoted-string and property-access forms for the tool
+  # name match.
+  if [[ ${#EXT_FILES[@]} -gt 0 ]] \
+     && grep_any "tool_execution_start" "${EXT_FILES[@]}" \
+     && grep_any_ere '["'\''`]emit_summary["'\''`]' "${EXT_FILES[@]}"; then
+    mark_p0 "harvest source = emit_summary tool_execution_start" pass
+  else
+    mark_p0 "harvest source = emit_summary tool_execution_start" fail "parent does not match on toolName === \"emit_summary\""
+  fi
+
+  # Negative: recon MUST NOT harvest stage_write-shape args (path +
+  # content) — that's the drafter harvest pattern. Accept any of the
   # common shapes the writer uses: direct e.args.path/content,
   # destructured `= e.args` / `= event.args`, or the `inputObj = e.args`
-  # idiom that the reference implementation uses.
-  if [[ ${#EXT_FILES[@]} -gt 0 ]] && grep_any "tool_execution_start" "${EXT_FILES[@]}" \
-     && grep_any_ere '(e|event)\.args\.(path|content)|args\.(path|content)|= *(e|event)\.args|= *inputObj|inputObj\.(path|content)' "${EXT_FILES[@]}"; then
-    mark_p0 "no writer-shape harvest (tool_execution_start + args)" fail "found writer-shape harvest in a recon agent"
+  # idiom. emit_summary args are title/body; this regex intentionally
+  # does not match those.
+  if [[ ${#EXT_FILES[@]} -gt 0 ]] && grep_any_ere '(e|event)\.args\.(path|content)|args\.(path|content)|inputObj\.(path|content)' "${EXT_FILES[@]}"; then
+    mark_p0 "no stage_write-shape harvest (path/content args)" fail "found drafter-shape harvest in a recon agent"
   else
-    mark_p0 "no writer-shape harvest (tool_execution_start + args)" pass
+    mark_p0 "no stage_write-shape harvest (path/content args)" pass
   fi
 }
 

--- a/scripts/approach-b-framework/tasks/scout-then-draft-agent/prompt.txt
+++ b/scripts/approach-b-framework/tasks/scout-then-draft-agent/prompt.txt
@@ -1,0 +1,1 @@
+Build me an agent that surveys a directory, then drafts a new README.md summarizing what's there. Show me the draft before saving.

--- a/scripts/approach-b-framework/tasks/scout-then-draft-agent/task.env
+++ b/scripts/approach-b-framework/tasks/scout-then-draft-agent/task.env
@@ -1,0 +1,28 @@
+# tasks/scout-then-draft-agent/task.env
+#
+# Gate for the scout-then-draft pattern. Forces the assembler to
+# emit an extension that spawns TWO children — a recon child
+# (emit-summary.ts, read-only allowlist + emit_summary) followed by
+# a drafter child (cwd-guard.ts + stage-write.ts, stage_write
+# allowlist) — with a handoff brief assembled from the recon
+# summaries and injected into the drafter prompt.
+#
+# No graded profile yet. Run without --grade and grep the emitted
+# extension by hand for the scout-then-draft Validation-checklist
+# anchors:
+#   - exactly TWO `spawn("pi"` calls in the handler.
+#   - first spawn: `-e <…/components/emit-summary.ts>`,
+#     `--tools "ls,read,grep,glob,emit_summary"`, no PI_SANDBOX_ROOT.
+#   - second spawn: `-e <…/components/cwd-guard.ts>` AND
+#     `-e <…/components/stage-write.ts>`, `--tools "stage_write,ls"`,
+#     `PI_SANDBOX_ROOT` set in env.
+#   - the drafter prompt includes the recon brief (look for a
+#     "Context" / "survey findings" marker plus a variable named
+#     `brief` or similar).
+#   - `ctx.ui.confirm(` somewhere in the handler body.
+#
+# Once the common misses are understood, add a graded profile
+# `scout-then-draft.sh` that codifies these anchors.
+PROFILE=writer
+PROBE_ARGS=""
+PROBE_EVIDENCE_ANCHOR=


### PR DESCRIPTION
Capture current assembler-skill behavior against Gate 1/2/3 so any
follow-up regression becomes a committed diff instead of a prior-
session transcript. Gate 1 (recon, haiku + gemini): 16/16 P0, 2/2 P1.
Gate 2 (confined-drafter composition, haiku): extension produced
with cwd-guard + PI_SANDBOX_ROOT + sandbox_write/sandbox_edit
allowlist. Gate 3 (out-of-library GAP probe, haiku + gemini): no
.ts, GAP strings in events.ndjson.

https://claude.ai/code/session_01RjbQgiY6CpmtGm198V8SrE