### PR TITLE
fix(assembler): add scout-then-draft to Patterns I know line

### DIFF
--- a/pi-sandbox/sample-agents/drafter-with-approval__haiku__safe-drafter.ts
+++ b/pi-sandbox/sample-agents/drafter-with-approval__haiku__safe-drafter.ts
@@ -1,0 +1,159 @@
+// .pi/extensions/safe-drafter.ts — code/documentation drafter with mandatory review gate.
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const PHASE_TIMEOUT_MS = 120_000;
+const MAX_FILES_PROMOTABLE = 50;
+const MAX_CONTENT_BYTES_PER_FILE = 2_000_000;
+const PREVIEW_LINES_PER_FILE = 20;
+
+const CWD_GUARD = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..", "components", "cwd-guard.ts",
+);
+const STAGE_WRITE_TOOL = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..", "components", "stage-write.ts",
+);
+
+const sha256 = (s: string) => createHash("sha256").update(s, "utf8").digest("hex");
+
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand("safe-draft", {
+    description: "Generate code or documentation with mandatory preview & approval before any files are written",
+    handler: async (args, ctx) => {
+      if (!args.trim()) {
+        ctx.ui.notify("Usage: /safe-draft <task description>", "warning");
+        return;
+      }
+      const MODEL = process.env.TASK_MODEL;
+      if (!MODEL) {
+        ctx.ui.notify("TASK_MODEL env var not set. Source models.env.", "error");
+        return;
+      }
+      if (!fs.existsSync(STAGE_WRITE_TOOL) || !fs.existsSync(CWD_GUARD)) {
+        ctx.ui.notify("components missing; check pi-sandbox/.pi/components/", "error");
+        return;
+      }
+      const sandboxRoot = path.resolve(process.cwd());
+
+      const agentPrompt =
+        `You are a DRAFTER. Task: ${args}.\n\n` +
+        `Nothing you do will touch disk until the user approves. Call ` +
+        `stage_write({path, content}) with a RELATIVE path inside ${sandboxRoot} ` +
+        `and the full content. Do NOT call any write/edit tool. ` +
+        `Generate the code or documentation exactly as it should appear in the final file. ` +
+        `Include all necessary imports, headers, boilerplate, and complete content. ` +
+        `Use stage_write for every file you produce. Reply DONE and stop.`;
+
+      const stagedWrites: Array<{ path: unknown; content: unknown }> = [];
+      const child = spawn(
+        "pi",
+        [
+          "-e", CWD_GUARD,
+          "-e", STAGE_WRITE_TOOL,
+          "--mode", "json",
+          "--tools", "stage_write,ls",
+          "--no-extensions",
+          "--provider", "openrouter",
+          "--model", MODEL,
+          "--no-session",
+          "--thinking", "off",
+          "-p", agentPrompt,
+        ],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+          cwd: sandboxRoot,
+          env: { ...process.env, PI_SANDBOX_ROOT: sandboxRoot },
+        },
+      );
+
+      let buffer = "";
+      let stderr = "";
+      let timedOut = false;
+      const timer = setTimeout(() => { timedOut = true; child.kill("SIGKILL"); }, PHASE_TIMEOUT_MS);
+
+      child.stdout.on("data", (d) => {
+        buffer += d.toString();
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          let e: Record<string, unknown>;
+          try { e = JSON.parse(line); } catch { continue; }
+          if (e.type === "tool_execution_start" && e.toolName === "stage_write") {
+            const a = e.args as Record<string, unknown> | undefined;
+            if (a) {
+              stagedWrites.push({ path: a.path, content: a.content });
+              const p = typeof a.path === "string" ? a.path : "<?>";
+              const len = typeof a.content === "string" ? a.content.length : 0;
+              ctx.ui.notify(`Drafter → stage_write ${p} (${len} chars)`, "info");
+            }
+          } else if (e.type === "tool_execution_start") {
+            ctx.ui.notify(`Drafter → ${e.toolName}`, "info");
+          }
+        }
+      });
+      child.stderr.on("data", (d) => { stderr += d.toString(); });
+
+      const code = await new Promise<number>((resolve) => {
+        child.on("close", (c) => { clearTimeout(timer); resolve(c ?? 0); });
+        child.on("error", () => { clearTimeout(timer); resolve(-1); });
+      });
+
+      if (timedOut) { ctx.ui.notify(`Drafter timed out; drafts discarded.`, "error"); return; }
+      if (code !== 0) { ctx.ui.notify(`Drafter exit ${code}. Stderr: ${stderr.slice(-2000)}`, "error"); return; }
+      if (stagedWrites.length === 0) { ctx.ui.notify("Drafter made no stage_write calls.", "warning"); return; }
+      if (stagedWrites.length > MAX_FILES_PROMOTABLE) {
+        ctx.ui.notify(`Drafter staged ${stagedWrites.length} files (> ${MAX_FILES_PROMOTABLE}); aborting.`, "error");
+        return;
+      }
+
+      const plans: Array<{ relPath: string; destAbs: string; content: string; sha: string; byteLength: number }> = [];
+      const skips: string[] = [];
+      for (const s of stagedWrites) {
+        if (typeof s.path !== "string" || !s.path) { skips.push(`<invalid path>`); continue; }
+        if (typeof s.content !== "string") { skips.push(`${s.path}: non-string content`); continue; }
+        if (path.isAbsolute(s.path) || s.path.split("/").includes("..")) { skips.push(`${s.path}: absolute or '..'`); continue; }
+        const destAbs = path.resolve(sandboxRoot, s.path);
+        if (destAbs !== sandboxRoot && !destAbs.startsWith(sandboxRoot + path.sep)) { skips.push(`${s.path}: escapes sandbox`); continue; }
+        if (fs.existsSync(destAbs)) { skips.push(`${s.path}: exists`); continue; }
+        const bytes = Buffer.byteLength(s.content, "utf8");
+        if (bytes > MAX_CONTENT_BYTES_PER_FILE) { skips.push(`${s.path}: ${bytes} bytes > cap`); continue; }
+        plans.push({ relPath: s.path, destAbs, content: s.content, sha: sha256(s.content), byteLength: bytes });
+      }
+      for (const skip of skips) ctx.ui.notify(`Skipping ${skip}`, "warning");
+      if (plans.length === 0) { ctx.ui.notify("No promotable drafts.", "warning"); return; }
+
+      const previewBody = plans.map((p) => {
+        const head = `${p.destAbs} (${p.byteLength} bytes, sha ${p.sha.slice(0, 10)}…)`;
+        const lines = p.content.split("\n");
+        const shown = lines.slice(0, PREVIEW_LINES_PER_FILE).join("\n");
+        const tail = lines.length > PREVIEW_LINES_PER_FILE ? `\n… (+${lines.length - PREVIEW_LINES_PER_FILE} more)` : "";
+        return `${head}\n${shown}${tail}`;
+      }).join("\n\n---\n\n");
+
+      const ok = await ctx.ui.confirm(`Promote ${plans.length} file(s)?`, previewBody);
+      if (!ok) { ctx.ui.notify("Cancelled; nothing written.", "info"); return; }
+
+      const promoted: string[] = [];
+      const failures: string[] = [];
+      for (const p of plans) {
+        if (fs.existsSync(p.destAbs)) { failures.push(`${p.relPath}: exists now`); continue; }
+        try {
+          fs.mkdirSync(path.dirname(p.destAbs), { recursive: true });
+          fs.writeFileSync(p.destAbs, p.content, "utf8");
+          const actual = sha256(fs.readFileSync(p.destAbs, "utf8"));
+          if (actual !== p.sha) { failures.push(`${p.relPath}: hash mismatch`); continue; }
+          promoted.push(p.destAbs);
+        } catch (e) { failures.push(`${p.relPath}: ${(e as Error).message}`); }
+      }
+      if (failures.length > 0) ctx.ui.notify(`Promotion failures:\n${failures.join("\n")}`, "error");
+      if (promoted.length > 0) ctx.ui.notify(`Wrote ${promoted.length} file(s):\n${promoted.join("\n")}`, "info");
+    },
+  });
+}

--- a/pi-sandbox/sample-agents/orchestrator__gemini__task-orchestrator.ts
+++ b/pi-sandbox/sample-agents/orchestrator__gemini__task-orchestrator.ts
@@ -1,0 +1,645 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+// Constants for safety and bounds
+const DELEGATOR_PHASE_TIMEOUT_MS = 120_000;
+const DRAFTER_TIMEOUT_MS = 180_000;
+const MAX_SUBTASKS = 10;
+const MAX_FILES_PROMOTABLE = 50;
+const MAX_CONTENT_BYTES_PER_FILE = 2_000_000;
+const MAX_REVISE_ITERATIONS = 3;
+const NOTIFY_TEXT_MAX = 400;
+const DASHBOARD_KEY = "task-orchestrator";
+const TASK_PREVIEW_CHARS = 60;
+const CONTENT_PREVIEW_LINES = 2;
+const CONTENT_PREVIEW_CHARS = 80;
+const WRITTEN_PREVIEW_LINES = 8;
+const WRITTEN_PREVIEW_CHARS = 120;
+
+// Resolve components from the library
+const STAGE_WRITE_TOOL = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..", "components", "stage-write.ts",
+);
+const RUN_DEFERRED_WRITER_TOOL = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..", "components", "run-deferred-writer.ts",
+);
+const REVIEW_TOOL = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..", "components", "review.ts",
+);
+const CWD_GUARD = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..", "components", "cwd-guard.ts",
+);
+
+type StagedWrite = {
+  relPath: string;
+  destAbs: string;
+  content: string;
+  sha: string;
+  byteLength: number;
+  taskIndex: number;
+};
+
+type ReviewCall = {
+  file_path: string;
+  verdict: "approve" | "revise";
+  feedback?: string;
+};
+
+type DrafterResult = {
+  stagedWrites: Array<{ path: unknown; content: unknown }>;
+  code: number;
+  timedOut: boolean;
+  stderr: string;
+  costUsd: number;
+};
+
+type PhaseResult = {
+  tasks: string[];
+  reviews: ReviewCall[];
+  timedOut: boolean;
+  costUsd: number;
+};
+
+type UiCtx = {
+  ui: {
+    notify: (m: string, level: "info" | "warning" | "error") => void;
+    setWidget?: (key: string, content: string[] | undefined) => void;
+    setStatus?: (key: string, text: string | undefined) => void;
+  };
+};
+
+type DrafterPhase = "pending" | "running" | "done" | "timed_out" | "error";
+type PipelinePhase =
+  | "dispatching" | "drafting" | "reviewing" | "revising" | "promoting" | "done" | "failed";
+
+type DrafterState = {
+  task: string;
+  phase: DrafterPhase;
+  stagedWrites: Array<{ path: string; content: string; bytes: number }>;
+};
+
+type PipelineState = {
+  userGoal: string;
+  phase: PipelinePhase;
+  iteration: number;
+  drafters: Map<number, DrafterState>;
+  verdicts: Map<string, ReviewCall>;
+  costs: { delegatorUsd: number; draftersUsd: number };
+};
+
+function extractCostUsd(ev: Record<string, unknown>): number {
+  if (ev.type !== "message_end") return 0;
+  const msg = ev.message as { usage?: { cost?: { total?: number } } } | undefined;
+  const total = msg?.usage?.cost?.total;
+  return typeof total === "number" && isFinite(total) ? total : 0;
+}
+
+const fmtUsd = (n: number) => `$${n.toFixed(4)}`;
+const sha256 = (data: string) => createHash("sha256").update(data, "utf8").digest("hex");
+const trunc = (s: string, n = NOTIFY_TEXT_MAX) =>
+  s.length > n ? s.slice(0, n) + `… (+${s.length - n} chars)` : s;
+
+const PHASE_EMOJI: Record<DrafterPhase, string> = {
+  pending: "⏸",
+  running: "🔄",
+  done: "✅",
+  timed_out: "⏱",
+  error: "⚠",
+};
+
+function renderDashboard(state: PipelineState): string[] {
+  const lines: string[] = [];
+  const goalShort = trunc(state.userGoal, 70);
+  lines.push(`/task-orchestrator · iter ${state.iteration}/${MAX_REVISE_ITERATIONS} · ${state.phase}`);
+  lines.push(`goal: ${goalShort}`);
+  lines.push("─".repeat(48));
+
+  if (state.drafters.size === 0) {
+    lines.push("(no drafters dispatched yet)");
+    return lines;
+  }
+
+  const indices = Array.from(state.drafters.keys()).sort((a, b) => a - b);
+  for (const i of indices) {
+    const d = state.drafters.get(i)!;
+    const emoji = PHASE_EMOJI[d.phase];
+    const taskShort = trunc(d.task, TASK_PREVIEW_CHARS);
+    lines.push(`[${i + 1}] ${emoji} ${d.phase}  "${taskShort}"`);
+    if (d.stagedWrites.length === 0) {
+      if (d.phase === "running" || d.phase === "pending") {
+        lines.push("    └─ (no drafts yet)");
+      } else {
+        lines.push("    └─ (no files staged)");
+      }
+      continue;
+    }
+    for (let j = 0; j < d.stagedWrites.length; j++) {
+      const w = d.stagedWrites[j];
+      const isLast = j === d.stagedWrites.length - 1;
+      const prefix = isLast ? "└─" : "├─";
+      const verdict = state.verdicts.get(w.path);
+      const verdictTag = verdict
+        ? verdict.verdict === "approve"
+          ? "  · ✅ approve"
+          : `  · ✳ revise: ${trunc(verdict.feedback ?? "(no feedback)", 50)}`
+        : "";
+      lines.push(`    ${prefix} ${w.path} (${w.bytes} b)${verdictTag}`);
+      const contentLines = w.content.split("\n").slice(0, CONTENT_PREVIEW_LINES);
+      for (const cl of contentLines) {
+        const clTrim = trunc(cl, CONTENT_PREVIEW_CHARS);
+        lines.push(`       ${clTrim}`);
+      }
+      if (w.content.split("\n").length > CONTENT_PREVIEW_LINES) {
+        lines.push(`       …`);
+      }
+    }
+  }
+  return lines;
+}
+
+function updateDashboard(ctx: UiCtx, state: PipelineState) {
+  if (!ctx.ui.setWidget) return;
+  try { ctx.ui.setWidget(DASHBOARD_KEY, renderDashboard(state)); } catch {}
+}
+
+function clearDashboard(ctx: UiCtx) {
+  if (!ctx.ui.setWidget) return;
+  try { ctx.ui.setWidget(DASHBOARD_KEY, undefined); } catch {}
+}
+
+function renderStatus(state: PipelineState): string {
+  const total = state.drafters.size;
+  const done = Array.from(state.drafters.values()).filter(d => d.phase === "done").length;
+  const totalCost = state.costs.delegatorUsd + state.costs.draftersUsd;
+  return `task-orchestrator · ${state.phase} · iter ${state.iteration}/${MAX_REVISE_ITERATIONS} · drafters ${done}/${total} · ${fmtUsd(totalCost)}`;
+}
+
+function updateStatus(ctx: UiCtx, state: PipelineState) {
+  if (!ctx.ui.setStatus) return;
+  try { ctx.ui.setStatus(DASHBOARD_KEY, renderStatus(state)); } catch {}
+}
+
+async function runDrafter(
+  taskIndex: number,
+  task: string,
+  feedback: string[] | undefined,
+  taskModel: string,
+  sandboxRoot: string,
+  ctx: UiCtx,
+  onStage?: (w: { path: string; content: string; bytes: number }) => void,
+): Promise<DrafterResult> {
+  const base = `You are a DRAFTER. Task: ${task}.
+To create a file, call 'stage_write' with a relative 'path' (inside the project at ${sandboxRoot}) and full 'content'. Nothing touches disk until approved.
+
+Rules:
+- Only 'stage_write'. No real write tools.
+- Paths relative, inside ${sandboxRoot}, no '..'.
+- Use 'read' / 'ls' on absolute paths under ${sandboxRoot} to explore.
+- Stop after staging everything. Reply DONE.`;
+  const prompt = feedback && feedback.length > 0
+    ? `${base}\n\nThis is a REVISION pass. Previous attempt had issues. Apply this feedback verbatim:\n${feedback.map(f => `- ${f}`).join("\n")}`
+    : base;
+
+  return new Promise((resolve) => {
+    const child = spawn("pi", [
+      "--mode", "json",
+      "-e", CWD_GUARD,
+      "-e", STAGE_WRITE_TOOL,
+      "-p", prompt,
+      "--no-extensions", "--no-session", "--thinking", "off",
+      "--tools", "stage_write,ls,read",
+      "--provider", "openrouter", "--model", taskModel,
+    ], {
+      stdio: ["ignore", "pipe", "pipe"],
+      cwd: sandboxRoot,
+      env: { ...process.env, PI_SANDBOX_ROOT: sandboxRoot }
+    });
+
+    let buffer = "";
+    let stderr = "";
+    const stagedWrites: Array<{ path: unknown; content: unknown }> = [];
+    let costUsd = 0;
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, DRAFTER_TIMEOUT_MS);
+
+    child.stdout.on("data", (d) => {
+      buffer += d.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let e: Record<string, unknown>;
+        try { e = JSON.parse(line); } catch { continue; }
+        if (e.type === "tool_execution_start") {
+          const name = e.toolName as string | undefined;
+          const inputObj = e.args as Record<string, unknown> | undefined;
+          if (name === "stage_write" && inputObj) {
+            stagedWrites.push({ path: inputObj.path, content: inputObj.content });
+            const p = typeof inputObj.path === "string" ? inputObj.path : "<?>";
+            const content = typeof inputObj.content === "string" ? inputObj.content : "";
+            if (onStage && typeof inputObj.path === "string") {
+              onStage({ path: p, content, bytes: Buffer.byteLength(content, "utf8") });
+            }
+          }
+        } else if (e.type === "message_end") {
+          costUsd += extractCostUsd(e);
+        }
+      }
+    });
+    child.stderr.on("data", (d) => { stderr += d.toString(); });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ stagedWrites, code: code ?? 0, timedOut, stderr, costUsd });
+    });
+    child.on("error", () => {
+      clearTimeout(timer);
+      resolve({ stagedWrites, code: -1, timedOut, stderr, costUsd });
+    });
+  });
+}
+
+class DelegatorSession {
+  private child: ChildProcess;
+  private buffer = "";
+  private stderr = "";
+  private listeners = new Set<(ev: Record<string, unknown>) => void>();
+  private closed = false;
+
+  constructor(leadModel: string, sandboxRoot: string) {
+    this.child = spawn("pi", [
+      "--mode", "rpc",
+      "--no-extensions", "--no-session", "--no-context-files",
+      "--thinking", "off",
+      "-e", CWD_GUARD,
+      "-e", RUN_DEFERRED_WRITER_TOOL,
+      "-e", REVIEW_TOOL,
+      "--tools", "run_deferred_writer,review",
+      "--provider", "openrouter", "--model", leadModel,
+    ], {
+      stdio: ["pipe", "pipe", "pipe"],
+      cwd: sandboxRoot,
+      env: { ...process.env, PI_SANDBOX_ROOT: sandboxRoot }
+    });
+
+    this.child.stdout!.on("data", (d) => this.onStdout(d));
+    this.child.stderr!.on("data", (d) => { this.stderr += d.toString(); });
+    this.child.on("close", () => { this.closed = true; });
+    this.child.on("error", () => { this.closed = true; });
+  }
+
+  private onStdout(d: Buffer) {
+    this.buffer += d.toString();
+    while (true) {
+      const idx = this.buffer.indexOf("\n");
+      if (idx === -1) break;
+      let line = this.buffer.slice(0, idx);
+      this.buffer = this.buffer.slice(idx + 1);
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+      if (!line.trim()) continue;
+      let ev: Record<string, unknown>;
+      try { ev = JSON.parse(line); } catch { continue; }
+      for (const l of this.listeners) l(ev);
+    }
+  }
+
+  async runPrompt(
+    message: string,
+    phaseLabel: string,
+    timeoutMs: number,
+    ctx: UiCtx,
+    onTask?: (task: string) => void,
+    onReview?: (r: ReviewCall) => void,
+  ): Promise<PhaseResult> {
+    if (this.closed) return { tasks: [], reviews: [], timedOut: true, costUsd: 0 };
+    return new Promise<PhaseResult>((resolve) => {
+      const tasks: string[] = [];
+      const reviews: ReviewCall[] = [];
+      let costUsd = 0;
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        this.listeners.delete(listener);
+        resolve({ tasks, reviews, timedOut: true, costUsd });
+      }, timeoutMs);
+
+      const listener = (ev: Record<string, unknown>) => {
+        const type = ev.type as string | undefined;
+        if (type === "message_end") {
+          costUsd += extractCostUsd(ev);
+        }
+        if (type === "tool_execution_start") {
+          const name = ev.toolName as string | undefined;
+          const inputObj = ev.args as Record<string, unknown> | undefined;
+          if (name === "run_deferred_writer" && inputObj && typeof inputObj.task === "string") {
+            tasks.push(inputObj.task);
+            if (onTask) onTask(inputObj.task);
+          } else if (name === "review" && inputObj && typeof inputObj.file_path === "string") {
+            const verdict = inputObj.verdict === "approve" ? "approve" : "revise";
+            const feedback = typeof inputObj.feedback === "string" ? inputObj.feedback : undefined;
+            const rc: ReviewCall = { file_path: inputObj.file_path, verdict, feedback };
+            reviews.push(rc);
+            if (onReview) onReview(rc);
+          }
+        } else if (type === "agent_end") {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          this.listeners.delete(listener);
+          resolve({ tasks, reviews, timedOut: false, costUsd });
+        } else if (type === "response" && ev.success === false) {
+          ctx.ui.notify(`${phaseLabel} RPC error: ${ev.error}`, "error");
+        }
+      };
+      this.listeners.add(listener);
+      try {
+        this.child.stdin!.write(JSON.stringify({ type: "prompt", message }) + "\n");
+      } catch (e) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.listeners.delete(listener);
+        ctx.ui.notify(`${phaseLabel} failed to write prompt: ${(e as Error).message}`, "error");
+        resolve({ tasks, reviews, timedOut: true, costUsd });
+      }
+    });
+  }
+
+  close() {
+    try { this.child.stdin!.end(); } catch {}
+    try { this.child.kill("SIGKILL"); } catch {}
+  }
+  getStderrTail(bytes = 2000): string {
+    return this.stderr.slice(-bytes);
+  }
+}
+
+function validateStagedWrite(
+  s: { path: unknown; content: unknown },
+  taskIndex: number,
+  sandboxRoot: string,
+): StagedWrite | { error: string } {
+  if (typeof s.path !== "string" || !s.path) return { error: "invalid path" };
+  if (typeof s.content !== "string") return { error: `${s.path}: content not string` };
+  const relPath = s.path;
+  if (path.isAbsolute(relPath) || relPath.split("/").includes("..") || relPath.split(path.sep).includes("..")) {
+    return { error: `${relPath}: absolute or contains '..'` };
+  }
+  const destAbs = path.resolve(sandboxRoot, relPath);
+  if (destAbs !== sandboxRoot && !destAbs.startsWith(sandboxRoot + path.sep)) {
+    return { error: `${relPath}: escapes sandbox` };
+  }
+  if (fs.existsSync(destAbs)) return { error: `${relPath}: destination exists` };
+  const byteLength = Buffer.byteLength(s.content, "utf8");
+  if (byteLength > MAX_CONTENT_BYTES_PER_FILE) {
+    return { error: `${relPath}: too large (${byteLength} bytes)` };
+  }
+  return {
+    relPath,
+    destAbs,
+    content: s.content,
+    sha: sha256(s.content),
+    byteLength,
+    taskIndex,
+  };
+}
+
+function promoteFiles(plans: StagedWrite[], ctx: UiCtx): StagedWrite[] {
+  const promoted: StagedWrite[] = [];
+  const failures: string[] = [];
+  for (const p of plans) {
+    try {
+      if (fs.existsSync(p.destAbs)) { failures.push(`${p.relPath}: exists`); continue; }
+      fs.mkdirSync(path.dirname(p.destAbs), { recursive: true });
+      fs.writeFileSync(p.destAbs, p.content, "utf8");
+      const actualSha = sha256(fs.readFileSync(p.destAbs, "utf8"));
+      if (actualSha !== p.sha) { failures.push(`${p.relPath}: sha mismatch after write`); continue; }
+      promoted.push(p);
+    } catch (e) {
+      failures.push(`${p.relPath}: ${(e as Error).message}`);
+    }
+  }
+  if (failures.length > 0) ctx.ui.notify(`Failures:\n${failures.join("\n")}`, "error");
+  return promoted;
+}
+
+function renderWrittenSummary(promoted: StagedWrite[]): string {
+  const sections = promoted.map((p) => {
+    const lines = p.content.split("\n");
+    const shown = lines.slice(0, WRITTEN_PREVIEW_LINES).map((l) => trunc(l, WRITTEN_PREVIEW_CHARS));
+    const more = lines.length > WRITTEN_PREVIEW_LINES ? `\n  … (+${lines.length - WRITTEN_PREVIEW_LINES} more lines)` : "";
+    return `── ${p.relPath} (${p.byteLength} b) ──\n${shown.map((l) => "  " + l).join("\n")}${more}`;
+  });
+  return `Wrote ${promoted.length} file(s):\n\n${sections.join("\n\n")}`;
+}
+
+function buildReviewPrompt(
+  tasks: string[],
+  staged: StagedWrite[],
+  isInitial: boolean,
+): string {
+  const header = isInitial
+    ? `All drafters have finished. Review every staged file by calling review(file_path, verdict, feedback).`
+    : `Drafters re-ran with your feedback. Review the updated staged files again.`;
+  const taskList = tasks.map((t, i) => `  [${i + 1}] ${t}`).join("\n");
+  const files = staged.map((s) =>
+    `--- ${s.relPath} (from subtask [${s.taskIndex + 1}]) ---\n${s.content}`
+  ).join("\n\n");
+  return `${header}
+
+Rules:
+- Emit exactly one review call per file listed below.
+- verdict="approve" if the file meets the task and is correct.
+- verdict="revise" if it needs another pass; feedback MUST be a sentence or two the drafter can act on.
+- Do not invent paths — only review files listed.
+
+Subtasks:
+${taskList}
+
+Staged files:
+${files}`;
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand("task-orchestrator", {
+    description: "Break down a complex goal into subtasks, execute them with drafters, and let an LLM reviewer verify results.",
+    handler: async (args, ctx) => {
+      if (!args.trim()) {
+        ctx.ui.notify("Usage: /task-orchestrator <complex goal>", "error");
+        return;
+      }
+
+      const LEAD_MODEL = process.env.LEAD_MODEL;
+      const TASK_MODEL = process.env.TASK_MODEL;
+      if (!LEAD_MODEL || !TASK_MODEL) {
+        ctx.ui.notify("LEAD_MODEL or TASK_MODEL env var not set.", "error");
+        return;
+      }
+
+      const sandboxRoot = path.resolve(process.cwd());
+      const state: PipelineState = {
+        userGoal: args,
+        phase: "dispatching",
+        iteration: 0,
+        drafters: new Map(),
+        verdicts: new Map(),
+        costs: { delegatorUsd: 0, draftersUsd: 0 },
+      };
+      const refreshUi = () => { updateDashboard(ctx, state); updateStatus(ctx, state); };
+      refreshUi();
+
+      const session = new DelegatorSession(LEAD_MODEL, sandboxRoot);
+      try {
+        // Phase 1: dispatch
+        const dispatchPrompt = `You are a DELEGATOR. User goal: ${args}.
+Break this goal into sub-tasks (logical steps). For each sub-task, call run_deferred_writer(task).
+Each "task" must be a complete, self-contained instruction a drafter can execute independently.
+Reply DONE when all tasks are dispatched.`;
+
+        const dispatchRes = await session.runPrompt(
+          dispatchPrompt, "Dispatch", DELEGATOR_PHASE_TIMEOUT_MS, ctx,
+          (task) => {
+            const nextIdx = state.drafters.size;
+            state.drafters.set(nextIdx, { task, phase: "pending", stagedWrites: [] });
+            refreshUi();
+          },
+        );
+        state.costs.delegatorUsd += dispatchRes.costUsd;
+        refreshUi();
+        if (dispatchRes.timedOut) {
+          state.phase = "failed"; refreshUi();
+          ctx.ui.notify(`Dispatch phase timed out.`, "error");
+          return;
+        }
+        const tasks = dispatchRes.tasks;
+        if (tasks.length === 0) {
+          state.phase = "failed"; refreshUi();
+          ctx.ui.notify("No tasks dispatched.", "error");
+          return;
+        }
+
+        // Phase 2: parallel drafters
+        const taskStaged = new Map<number, Array<{ path: unknown; content: unknown }>>();
+        const runAllDrafters = async (indices: number[], feedbackByTask?: Map<number, string[]>) => {
+          state.phase = feedbackByTask ? "revising" : "drafting";
+          for (const i of indices) {
+            const d = state.drafters.get(i);
+            if (d) { d.phase = "running"; d.stagedWrites = []; }
+          }
+          refreshUi();
+          await Promise.all(indices.map(async (i) => {
+            const fb = feedbackByTask?.get(i);
+            const res = await runDrafter(
+              i, tasks[i], fb, TASK_MODEL, sandboxRoot, ctx,
+              (w) => {
+                const d = state.drafters.get(i);
+                if (d) { d.stagedWrites.push(w); refreshUi(); }
+              },
+            );
+            state.costs.draftersUsd += res.costUsd;
+            const d = state.drafters.get(i);
+            if (d) { d.phase = res.timedOut ? "timed_out" : (res.code === 0 ? "done" : "error"); }
+            refreshUi();
+            taskStaged.set(i, res.stagedWrites);
+          }));
+        };
+        await runAllDrafters(tasks.map((_, i) => i));
+
+        // Phases 3+: review / revise loop
+        let iteration = 0;
+        let isInitial = true;
+        while (true) {
+          iteration++;
+          if (iteration > MAX_REVISE_ITERATIONS) {
+            ctx.ui.notify(`Max revision iterations reached.`, "error");
+            return;
+          }
+
+          const staged: StagedWrite[] = [];
+          const seenPaths = new Set<string>();
+          for (const [taskIndex, writes] of taskStaged.entries()) {
+            for (const w of writes) {
+              const result = validateStagedWrite(w, taskIndex, sandboxRoot);
+              if ("relPath" in result && !seenPaths.has(result.relPath)) {
+                seenPaths.add(result.relPath);
+                staged.push(result);
+              }
+            }
+          }
+
+          if (staged.length === 0) {
+            state.phase = "failed"; refreshUi();
+            ctx.ui.notify("No valid staged files to review.", "error");
+            return;
+          }
+
+          state.phase = "reviewing";
+          state.iteration = iteration;
+          state.verdicts.clear();
+          refreshUi();
+
+          const reviewPrompt = buildReviewPrompt(tasks, staged, isInitial);
+          isInitial = false;
+          const reviewRes = await session.runPrompt(
+            reviewPrompt, `Review-${iteration}`, DELEGATOR_PHASE_TIMEOUT_MS, ctx,
+            undefined, (r) => { state.verdicts.set(r.file_path, r); refreshUi(); },
+          );
+          state.costs.delegatorUsd += reviewRes.costUsd;
+          refreshUi();
+
+          if (reviewRes.timedOut) {
+            state.phase = "failed"; refreshUi();
+            ctx.ui.notify(`Review timed out.`, "error");
+            return;
+          }
+
+          const verdictByPath = new Map<string, ReviewCall>();
+          for (const r of reviewRes.reviews) verdictByPath.set(r.file_path, r);
+
+          const approved: StagedWrite[] = [];
+          const feedbackByTask = new Map<number, string[]>();
+          let anyRevise = false;
+
+          for (const s of staged) {
+            const v = verdictByPath.get(s.relPath);
+            if (!v || v.verdict === "revise") {
+              anyRevise = true;
+              const fb = v?.feedback ?? "Reviewer requested revision.";
+              const arr = feedbackByTask.get(s.taskIndex) ?? [];
+              arr.push(`${s.relPath}: ${fb}`);
+              feedbackByTask.set(s.taskIndex, arr);
+            } else {
+              approved.push(s);
+            }
+          }
+
+          if (!anyRevise) {
+            state.phase = "promoting"; refreshUi();
+            const written = promoteFiles(approved, ctx);
+            state.phase = "done"; refreshUi();
+            if (written.length > 0) {
+              ctx.ui.notify(renderWrittenSummary(written), "info");
+            }
+            return;
+          }
+
+          await runAllDrafters(Array.from(feedbackByTask.keys()), feedbackByTask);
+        }
+      } finally {
+        session.close();
+        clearDashboard(ctx);
+      }
+    },
+  });
+}

--- a/pi-sandbox/sample-agents/recon__gemini__recon-summarize.ts
+++ b/pi-sandbox/sample-agents/recon__gemini__recon-summarize.ts
@@ -1,0 +1,134 @@
+// .pi/extensions/recon-summarize.ts — recon agent.
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const PHASE_TIMEOUT_MS = 120_000;
+const SUMMARY_BYTE_CAP = 8_000;
+const TOTAL_BYTE_CAP = 32_000;
+
+const EMIT_SUMMARY = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..", "components", "emit-summary.ts",
+);
+
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand("recon-summarize", {
+    description: "Provide a high-level overview of a directory's contents.",
+    handler: async (args, ctx) => {
+      const target = args.trim() || ".";
+      const MODEL = process.env.TASK_MODEL;
+      if (!MODEL) {
+        ctx.ui.notify("TASK_MODEL env var not set. Source models.env.", "error");
+        return;
+      }
+      if (!fs.existsSync(EMIT_SUMMARY)) {
+        ctx.ui.notify(`emit-summary missing at ${EMIT_SUMMARY}`, "error");
+        return;
+      }
+      const sandboxRoot = path.resolve(process.cwd());
+      const targetAbs = path.resolve(sandboxRoot, target);
+      if (targetAbs !== sandboxRoot && !targetAbs.startsWith(sandboxRoot + path.sep)) {
+        ctx.ui.notify(`${target}: escapes sandbox ${sandboxRoot}`, "error");
+        return;
+      }
+
+      const agentPrompt =
+        `You are a RECON AGENT. Survey ${targetAbs} and produce bounded ` +
+        `summaries. Use only 'ls', 'read', 'grep', 'glob' (no write, no edit, ` +
+        `no bash). Instead of producing a final assistant message, call ` +
+        `emit_summary({title, body}) with a short title and a body <= ${SUMMARY_BYTE_CAP} ` +
+        `bytes naming the files/directories you actually saw. Call it once for ` +
+        `the overall directory survey; call it a second time only if you have ` +
+        `a distinct, differently-scoped view to report. ` +
+        `Focus on the folder structure, key files, and overall organization. Reply DONE and stop.`;
+
+      const summaries: Array<{ title: string; body: string }> = [];
+      const child = spawn(
+        "pi",
+        [
+          "-e", EMIT_SUMMARY,
+          "--mode", "json",
+          "--tools", "ls,read,grep,glob,emit_summary",
+          "--no-extensions",
+          "--provider", "openrouter",
+          "--model", MODEL,
+          "--no-session",
+          "--thinking", "off",
+          "-p", agentPrompt,
+        ],
+        { stdio: ["ignore", "pipe", "pipe"], cwd: sandboxRoot },
+      );
+
+      let buffer = "";
+      let stderr = "";
+      let toolCalls = 0;
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGKILL");
+      }, PHASE_TIMEOUT_MS);
+
+      child.stdout.on("data", (d) => {
+        buffer += d.toString();
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          let e: Record<string, unknown>;
+          try { e = JSON.parse(line); } catch { continue; }
+          if (e.type === "tool_execution_start" && e.toolName === "emit_summary") {
+            toolCalls++;
+            const a = e.args as Record<string, unknown> | undefined;
+            const title = typeof a?.title === "string" ? a.title : "";
+            const body = typeof a?.body === "string" ? a.body : "";
+            if (title && body) {
+              summaries.push({ title, body });
+              ctx.ui.notify(`Recon → emit_summary "${title}" (${Buffer.byteLength(body, "utf8")} bytes)`, "info");
+            }
+          } else if (e.type === "tool_execution_start") {
+            toolCalls++;
+            ctx.ui.notify(`Recon → ${e.toolName}`, "info");
+          }
+        }
+      });
+      child.stderr.on("data", (d) => { stderr += d.toString(); });
+
+      await new Promise<void>((resolve) => {
+        child.on("close", () => { clearTimeout(timer); resolve(); });
+        child.on("error", () => { clearTimeout(timer); resolve(); });
+      });
+
+      if (timedOut) {
+        ctx.ui.notify(`Recon timed out after ${PHASE_TIMEOUT_MS / 1000}s.`, "error");
+        return;
+      }
+      if (summaries.length === 0) {
+        ctx.ui.notify(`Recon produced no emit_summary calls. Stderr: ${stderr.slice(-1000)}`, "error");
+        return;
+      }
+
+      // Per-summary byte cap, then total-length cap on the concatenation.
+      const capped = summaries.map((s) => {
+        const bytes = Buffer.byteLength(s.body, "utf8");
+        const body = bytes > SUMMARY_BYTE_CAP ? s.body.slice(0, SUMMARY_BYTE_CAP) + "\n…(truncated)" : s.body;
+        return `## ${s.title}\n\n${body}`;
+      });
+      let combined = capped.join("\n\n---\n\n");
+      if (Buffer.byteLength(combined, "utf8") > TOTAL_BYTE_CAP) {
+        combined = combined.slice(0, TOTAL_BYTE_CAP) + "\n…(truncated)";
+      }
+
+      const outDir = path.resolve(sandboxRoot, ".pi/scratch");
+      fs.mkdirSync(outDir, { recursive: true });
+      const outPath = path.join(outDir, "recon-summarize-summary.md");
+      fs.writeFileSync(outPath, combined, "utf8");
+      ctx.ui.notify(
+        `Recon complete (${toolCalls} tool call(s), ${summaries.length} summary/summaries, ${Buffer.byteLength(combined, "utf8")} bytes). Summary: ${outPath}`,
+        "info",
+      );
+    },
+  });
+}

--- a/pi-sandbox/skills/pi-agent-assembler/procedure.md
+++ b/pi-sandbox/skills/pi-agent-assembler/procedure.md
@@ -106,7 +106,7 @@ the library doesn't have, emit EXACTLY this message and stop:
 
 ```
 GAP: I don't have a component for "<user's ask, quoted>".
-Patterns I know: recon, drafter-with-approval, confined-drafter, orchestrator.
+Patterns I know: recon, drafter-with-approval, confined-drafter, scout-then-draft, orchestrator.
 Closest match: <"none" OR the nearest pattern name + 1-sentence why it doesn't quite fit>.
 To cover this you'd need: <one sentence describing the missing part or pattern>.
 To continue anyway, load the pi-agent-builder skill for from-scratch authorship.

--- a/scripts/grader/__tests__/paths.test.ts
+++ b/scripts/grader/__tests__/paths.test.ts
@@ -1,0 +1,22 @@
+import { strict as assert } from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { FRAMEWORK_ROOT, REPO_ROOT } from "../lib/paths.ts";
+
+describe("paths", () => {
+  it("REPO_ROOT points at the AgentFactory checkout", () => {
+    assert.ok(
+      fs.existsSync(path.join(REPO_ROOT, "pi-sandbox")),
+      `REPO_ROOT (${REPO_ROOT}) is missing pi-sandbox/ — constant resolves above the repo`,
+    );
+    assert.ok(fs.existsSync(path.join(REPO_ROOT, "models.env")));
+  });
+
+  it("FRAMEWORK_ROOT points at scripts/", () => {
+    assert.ok(
+      fs.existsSync(path.join(FRAMEWORK_ROOT, "task-runner", "tasks")),
+      `FRAMEWORK_ROOT (${FRAMEWORK_ROOT}) is missing task-runner/tasks — constant does not resolve to scripts/`,
+    );
+  });
+});

--- a/scripts/grader/index.ts
+++ b/scripts/grader/index.ts
@@ -16,13 +16,9 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { gradeAssemblerTask } from "./graders/assembler.ts";
+import { FRAMEWORK_ROOT, REPO_ROOT } from "./lib/paths.ts";
 import { loadTestSpec } from "./lib/test-spec.ts";
-
-const HERE = path.dirname(fileURLToPath(import.meta.url));
-const FRAMEWORK_ROOT = path.resolve(HERE, "..");
-const REPO_ROOT = path.resolve(FRAMEWORK_ROOT, "..", "..");
 
 function usage(): never {
   console.error(

--- a/scripts/grader/lib/paths.ts
+++ b/scripts/grader/lib/paths.ts
@@ -1,0 +1,7 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+export const FRAMEWORK_ROOT = path.resolve(HERE, "..", "..");
+export const REPO_ROOT = path.resolve(FRAMEWORK_ROOT, "..");

--- a/scripts/reverse-pipeline/gap-matrix-results.md
+++ b/scripts/reverse-pipeline/gap-matrix-results.md
@@ -184,3 +184,70 @@ the scout-then-draft pattern in particular absorbs a lot of
 "multi-stage analysis" asks. Seeds have to hit capabilities that
 *can't be composed*, not just capabilities that aren't in a single
 part.
+
+## Combined rerun (2026-04-24)
+
+**Round:** `combined-rerun/20260424-0514`
+**Cells:** 11 tasks × 3 `$AGENT_BUILDER_TARGETS` = 33 (6 gap + 5
+assembly, `--max-seeds 1` per pattern).
+
+Triggered to validate the close-out stack (strict grader, network-I/O
+stop, revised seed 04, patterns-line fix) against the full matrix and
+catch any collateral damage to previously-passing assembly cells.
+
+Headline: **30/33 full pass** (18/18 gap, 12/15 assembly). Three
+assembly cells grade "mostly passing" — all model-quality issues, not
+routing or grader issues.
+
+### Gap — clean sweep
+
+All 6 gap seeds × 3 targets emit correct GAP. The 2026-04-24 0341
+round was 12/18; this round is 18/18. The four interventions in the
+stack are all holding:
+
+- `fetches-url-01` / glm-5.1 no longer runaway-loops (network-I/O
+  stop in `procedure.md` step 1).
+- `fetches-url-01` / haiku no longer assembles an http recon
+  (network-I/O stop in step 2 callout).
+- `shell-06` / haiku's stylized GAP no longer slips past the grader
+  regex (final-message helper in `events.ts`).
+- Seed 04 (non-pi-subprocess) holds 3/3 GAP on reverify.
+
+### Assembly — 3 "mostly passing" cells
+
+| Cell | P0 | Missed rubric row | Diagnosis |
+|---|---|---|---|
+| `confined-drafter` / haiku | 18/19 | "sandboxRoot captured + cwd pinned on spawn" | Haiku wrote a confined drafter without threading `sandboxRoot` through to the child's cwd. Classification correct, subprocess-rails lapse. |
+| `orchestrator` / haiku | 16/17 | "components loaded via -e match pattern ## Parts — missing: cwd-guard.ts" | Loaded `stage-write.ts`, `run-deferred-writer.ts`, `review.ts` but not `cwd-guard.ts`. Classification correct, incomplete component set. |
+| `orchestrator` / glm-5.1 | 0/1 | "at least one .ts artifact produced" | pi exited 124 (wall-clock timeout); delegator session hit the agent-maker hard timeout mid-analysis, so no extension file was written. Classification correct (the last NDJSON message unambiguously names orchestrator), execution did not complete. Mirrors the prior "orchestrator provider quirk" but on GLM instead of gemini. |
+
+None of the three are classifier misroutes; none reproduce the old
+bucket-3 "assembled when gap expected" failure mode. All three are
+single-rubric-row misses; the 0/1 cell is anomalous because the
+orchestrator rubric has only one P0 gate at the "extension file
+produced" check and the model never reached that step.
+
+### Bonus: grader `REPO_ROOT` bug caught
+
+First pass of the assembly matrix produced **0/15** `grade.json`
+files — every cell crashed with `Pattern file not found at
+/home/user/pi-sandbox/...`. Root cause:
+`scripts/grader/index.ts` computed `REPO_ROOT` as
+`path.resolve(FRAMEWORK_ROOT, "..", "..")` — one `..` too many,
+resolving above the repo checkout. `pattern-spec.test.ts` recomputed
+`REPO_ROOT` locally from its own filepath, so the unit suite stayed
+green through the regression.
+
+Fix extracted the path constants to `scripts/grader/lib/paths.ts` and
+added `paths.test.ts` (asserts `REPO_ROOT/pi-sandbox` and
+`FRAMEWORK_ROOT/task-runner/tasks` both exist). Grader tests: 20/20
+(was 18/18). The 15 assembly cells were regraded in place from the
+saved `artifacts/` directories; no LLM re-spend.
+
+### Residue
+
+Per-task `summary.md` files under
+`combined-rerun/20260424-0514/*/` still carry the pre-fix
+"grade.json missing" rows from `run-task.sh`'s initial pass. The
+per-cell `grade.json` + `grade.md` are authoritative and correct; the
+task-level summaries are cosmetic and not regenerated.


### PR DESCRIPTION
Every GAP emission echoed the stale list verbatim, omitting the
scout-then-draft pattern that already exists in the library.

https://claude.ai/code/session_01CHygNf3mq4Wd5xCPzHhoS4