### PR TITLE
Refine composer plan: delegate() signature, Phase 1.6 orchestrator, bring-up order

### DIFF
--- a/parts-first-plan/10-composer-skill.md
+++ b/parts-first-plan/10-composer-skill.md
@@ -56,6 +56,13 @@ Body sections:
 7. **When to fall back to `pi-agent-builder`** — same as assembler's
    fallback section; point at builder's references.
 
+Not shipped: `prompts-seen.md`. That file is assembler-specific (logs
+pattern-name asks seen in the wild). The composer's signal surface is
+inherited from
+`pi-sandbox/skills/pi-agent-builder/references/reading-short-prompts.md`,
+which is already load-bearing for the prompt validator (§30). No
+composer-local mirror.
+
 ## procedure.md
 
 Five-step flow:
@@ -116,7 +123,9 @@ Bullets (expected count ~12):
 9. Sandbox root — `PI_SANDBOX_ROOT` in child env whenever `cwd-guard.ts`
    is loaded.
 10. Confirmation gate — `ctx.ui.confirm` before any parent-side
-    `fs.writeFileSync` (drafter-with-approval shape only).
+    `fs.writeFileSync`. Required iff `stage-write ∈ components &&
+    review ∉ components`; when `review ∈ components` the LLM verdict
+    is the gate, no human confirm fires.
 11. Dashboard (orchestrator-only) — `ctx.ui.setWidget` + `setStatus` on
     every state mutation; guard against absence.
 12. `ctx.ui.notify` — one message per phase boundary (child spawn,
@@ -139,9 +148,28 @@ Three topologies. Each entry is ~20 lines:
 
 - **When:** recon phase + drafter phase, parent assembles brief between.
 - **Covers:** scout-then-draft.
-- **Canonical reference:** TODO — if no canonical exists, inline a
-  short worked example citing `deferred-writer.ts` for the drafter
-  half and the recon spawn shape for the scout half.
+- **Canonical reference:** no single existing extension — inline this
+  worked example until `composer-scout-then-draft` lands and takes
+  over as the reference.
+
+  ```
+  // Phase 1: scout child (emit-summary only, no write channel)
+  const scoutResult = await runChild(/* args with -e emit-summary */);
+  const brief = scoutResult.summaries
+    .map(s => `## ${s.title}\n${s.body}`)
+    .join("\n\n");
+  if (Buffer.byteLength(brief, "utf8") > BRIEF_MAX_BYTES) {
+    throw new Error("brief exceeds budget");
+  }
+
+  // Phase 2: drafter child (shape borrowed from
+  // pi-sandbox/.pi/extensions/deferred-writer.ts:52-128 — child spawn
+  // + NDJSON loop, plus lines 278-306 — promotion)
+  const drafterPrompt = `${args}\n\n<brief>\n${brief}\n</brief>`;
+  const drafterResult = await runChild(/* args with -e stage-write, cwd-guard */);
+  // ...stage-write.finalize handles confirm + promote as in single-spawn.
+  ```
+
 - **Rails that apply:** all of single-spawn + bounded brief size
   (`Buffer.byteLength` check before second spawn).
 

--- a/parts-first-plan/20-composer-grader.md
+++ b/parts-first-plan/20-composer-grader.md
@@ -25,7 +25,7 @@ export const COMPONENTS: Record<string, ComponentSpec>;
 Per-component `wiringChecks`:
 
 - **cwd-guard**: `PI_SANDBOX_ROOT` in at least one spawn's env + `-e <...cwd-guard.ts>` on every write-capable spawn.
-- **stage-write**: extBlob contains `tool_execution_start` + `"stage_write"` + `ctx.ui.confirm` + `fs.writeFileSync` + `sha256` (ignore case for the last).
+- **stage-write**: extBlob contains `tool_execution_start` + `"stage_write"` + `fs.writeFileSync` + `sha256` (ignore case for the last). Confirm-gate predicate (cross-component, receives full `components` set): if `review ∉ components`, assert `ctx.ui.confirm` present; if `review ∈ components`, assert `ctx.ui.confirm` **absent** — the LLM verdict is the gate.
 - **emit-summary**: extBlob contains `tool_execution_start` + `"emit_summary"` + (`Buffer.byteLength` OR `.slice(0,`) + optional `.pi/scratch/` write. If `stage-write` not in component list, confirm `ctx.ui.confirm` is absent.
 - **review**: any spawn has `--mode rpc` and `--tools` includes `review`.
 - **run-deferred-writer**: any spawn has `--tools` includes `run_deferred_writer`; extBlob contains `Promise.all` (concurrent dispatch).
@@ -59,9 +59,23 @@ runDir, artifacts, rubric)`. Dispatch by `spec.expectation.kind`:
      a brief assembly (`Buffer.byteLength` between spawns);
      `rpc-delegator-over-concurrent-drafters` = one `--mode rpc`
      spawn + `Promise.all` + inner drafter spawn(s). If
-     `composition` omitted, infer from component list (see
-     `60-open-questions.md` §2) and emit a P1 warning that it's
-     implicit.
+     `composition` omitted, infer from component list per the
+     cascade below (canonical rule in `60-open-questions.md` §2;
+     mirrored here because the grader consumes it at every run) and
+     emit a P1 warning that it's implicit.
+
+     ```
+     composition-inference (when expectation.composition is omitted):
+       if run-deferred-writer ∈ components        → rpc-delegator-over-concurrent-drafters
+       else if review ∈ components                → rpc-delegator-over-concurrent-drafters
+       else if emit-summary ∈ components && stage-write ∈ components
+                                                  → sequential-phases-with-brief
+       else                                       → single-spawn
+     ```
+
+     The `review ∈ components` branch prevents `composer-review-only`
+     (`[cwd-guard, stage-write, review]`) from being mis-inferred as
+     `sequential-phases-with-brief`.
   5. **Probes** (load + behavioral) — unchanged; mode pick becomes
      "recon if `emit-summary ∈ components && stage-write ∉ components
      && cwd-guard ∉ components`".

--- a/parts-first-plan/30-composer-tasks.md
+++ b/parts-first-plan/30-composer-tasks.md
@@ -3,6 +3,18 @@
 Net-new tasks under `scripts/task-runner/tasks/composer-*/`. Existing
 assembler tasks untouched.
 
+## Bring-up order
+
+Land the skill scaffold (§10) and grader (§20) against
+**`composer-drafter-approval` only** before authoring the other four
+mirror tasks. `deferred-writer.ts` is the cleanest canonical reference
+(316 lines, fully working), so the first A/B round debugs the grader
+shape against known-good code. Extend to the remaining mirror tasks
+(`composer-recon`, `composer-confined-drafter`, `composer-scout-then-draft`,
+`composer-out-of-library`) only once the single-task loop is green on
+≥2 of 3 `$AGENT_BUILDER_TARGETS`. Five simultaneous A/Bs is a
+coarse-grained debug loop.
+
 ## test.yaml shape
 
 ```
@@ -48,7 +60,8 @@ path and we want a baseline on the simpler four before adding it.
 | Task dir | Components | Composition | Why it's new |
 | --- | --- | --- | --- |
 | `composer-review-only/` | `[cwd-guard, stage-write, review]` | `single-spawn` with review | Single drafter whose output goes through an LLM review before promotion, but no RPC delegator. Assembler's orchestrator pattern insists on RPC; composer should allow this thinner shape. |
-| `composer-full-orchestrator/` | `[cwd-guard, stage-write, review, run-deferred-writer]` | `rpc-delegator-over-concurrent-drafters` | Full orchestrator as a composition sanity-check. Prompt mirrors `delegated-writer.ts`'s intent. |
+
+`composer-full-orchestrator` moved to Phase 1.6 — see bottom of file.
 
 ## Prompt authoring rules
 
@@ -81,11 +94,13 @@ Logic (~40 lines):
    `cwd-guard`, `run_deferred_writer`, `sandbox_write`).
 7. Print a per-task report; exit 1 if any task fails.
 
-Output a scratch `signal-map.ts` table built from
-`reading-short-prompts.md:32-48`; keep the source of truth in the
-reference markdown and mirror it in code. A small follow-up is to
-auto-generate `signal-map.ts` from the markdown at build time — defer
-unless the dual-source drift shows up.
+Source-of-truth decision: write the markdown parser first — the drift
+test described in `60-open-questions.md §4` needs it regardless. If
+the parser fits in under 40 lines, use it to auto-generate
+`signal-map.ts` at build time directly (no hand-mirror). If the parser
+needs more than 40 lines, keep a hand-mirrored `signal-map.ts` and use
+the parser only for the drift test. This avoids committing to (a) vs
+(b) before seeing what the parser actually costs.
 
 ## Invocation examples
 
@@ -109,3 +124,20 @@ npm run validate-prompts
   — these are the assembler baseline.
 - `scripts/task-runner/agent-maker.sh` — already generic over `-s`.
 - `scripts/task-runner/run-task.sh` — same.
+
+## Phase 1.6 — `composer-full-orchestrator`
+
+| Task dir | Components | Composition |
+| --- | --- | --- |
+| `composer-full-orchestrator/` | `[cwd-guard, stage-write, review, run-deferred-writer]` | `rpc-delegator-over-concurrent-drafters` |
+
+Full orchestrator as a composition sanity-check. Prompt mirrors
+`delegated-writer.ts`'s intent.
+
+Add **after** mirror tasks (1a/1b/1c) sustain green on ≥2/3 models
+across ≥1 full round. Rationale: pre-`delegate()`, composer emits the
+full RPC orchestrator inline (`delegated-writer.ts` is 701 lines),
+which is the worst-fit shape for small-model authorship and risks
+masking wins on simpler compositions. Pass criteria for Phase 1.6 are
+spelled out in `50-verification-and-ab.md`; Phase 2 does **not** gate
+on Phase 1.6.

--- a/parts-first-plan/40-components-heavy-phase2.md
+++ b/parts-first-plan/40-components-heavy-phase2.md
@@ -35,7 +35,7 @@ export const parentSide: ParentSide = {
 Per-component contributions:
 
 - **cwd-guard**: `{tools: ["read","sandbox_write","sandbox_edit","ls","grep"], spawnArgs: ["-e", GUARD], env: {PI_SANDBOX_ROOT: cwd}, harvest: noop, finalize: noop}`.
-- **stage-write**: `{tools: ["stage_write"], harvest: collectStaged, finalize: confirmThenPromote}`. Extracts `{path, content}` on `tool_execution_start` events where `toolName === "stage_write"`; finalize prompts `ctx.ui.confirm` then `fs.writeFileSync` with sha256 verify.
+- **stage-write**: `{tools: ["stage_write"], harvest: collectStaged, finalize: confirmThenPromote}`. Extracts `{path, content}` on `tool_execution_start` events where `toolName === "stage_write"`; finalize reads the sibling `review` component state if present (defers to the LLM verdict map) and otherwise prompts `ctx.ui.confirm`, then `fs.writeFileSync` with sha256 verify. This is the code-level manifestation of the `rails.md` §10 predicate (confirm iff `stage-write ∈ components && review ∉ components`).
 - **emit-summary**: `{tools: ["emit_summary"], harvest: collectSummaries, finalize: persistToScratchOrReturnBrief}`. Configurable finalize: either write each summary to `.pi/scratch/<title>.md` (recon shape) or return concatenated brief with byte cap (scout shape).
 - **review**: `{tools: ["review"], harvest: collectVerdicts, finalize: returnVerdictMap}`. Used by the orchestrator runtime; not normally active in a single-spawn composer agent.
 - **run-deferred-writer**: `{tools: ["run_deferred_writer"], harvest: collectDispatchRequests, finalize: returnDispatchList}`. Used by the orchestrator runtime to trigger `Promise.all` fan-out.
@@ -47,26 +47,49 @@ and the generic `state` types.
 
 ## 2.2 Ship `delegate()` runtime
 
-`pi-sandbox/.pi/components/delegate.ts` — a generic parent-side runtime.
-Signature roughly:
+`pi-sandbox/.pi/lib/delegate.ts` — a generic parent-side runtime (lives
+under `lib/` per `60-open-questions.md §5`, not `components/`, to
+signal "library, not auto-loaded artifact"). Signature:
 
 ```ts
 export async function delegate(ctx: HandlerContext, opts: {
-  components: ParentSide[];
-  prompt: string;
-  model: string;
-  mode: "json" | "rpc";
-  timeoutMs: number;
-  extraTools?: string[];          // rarely needed
-  cwd: string;
+  components: ParentSide[];      // required — the whole point
+  prompt: string;                // required — the ask
+  model?: string;                // optional; default inferred from components (see below)
+  extraTools?: string[];         // optional; rarely used
 }): Promise<DelegateResult>;
 ```
+
+Two required keys, two optional. Everything else is a rail with a
+sensible default baked into `delegate()`:
+
+- `timeoutMs`: `PHASE_TIMEOUT_MS = 120_000` — module-level const.
+  Every caller in the canonical extensions passes the same value
+  today; it is not a per-call parameter, it is a rail.
+- `mode`: always `"json"`. `"rpc"` is orchestrator-only and the
+  orchestrator stays bespoke (see end of this section), so
+  `delegate()` never needs it. No `mode` parameter.
+- `cwd`: `process.cwd()`. The only time a caller wants a different
+  cwd is the per-run isolation in `agent-maker.sh`, which already
+  sets `process.chdir()` before loading extensions.
+- `model`: default = role inference from component set, per the
+  `AGENTS.md` tier rule. If `review ∈ components ||
+  run-deferred-writer ∈ components`, use `$LEAD_MODEL`; else
+  `$TASK_MODEL`. Caller can override by passing `model` explicitly.
+  This turns "match the tier to the child's role" from a per-agent
+  obligation into a library default.
+
+Escape hatch: pass `model` to override tier inference. There is no
+escape hatch for `timeoutMs`/`mode`/`cwd` by design — if you need
+one, you are writing something `delegate()` doesn't cover and should
+drop to bespoke spawn code (like the RPC orchestrator below).
 
 Internals:
 
 - Unions `opts.components[].tools` + `opts.extraTools` for `--tools`.
 - Concatenates `opts.components[].spawnArgs` for `-e` flags.
-- Merges `opts.components[].env` into child env.
+- Merges `opts.components[].env` into child env (`PI_SANDBOX_ROOT`
+  from `cwd-guard.env` lands here).
 - Applies every rail from `rails.md` (§1–9, 12): SIGKILL timer, NDJSON
   loop, `--no-extensions`, cost extraction, path validation on any
   promoted writes.
@@ -82,21 +105,44 @@ bespoke — the orchestrator authors its own dispatch→review loop but
 imports per-component harvesters from `parentSide` instead of
 re-implementing them.
 
+Resulting thin-agent call (Phase 2.4) collapses to two keys:
+
+```ts
+await delegate(ctx, {
+  components: [CWD_GUARD, STAGE_WRITE],
+  prompt: args,
+});
+```
+
 ## 2.3 Refactor canonical extensions onto `delegate()`
 
 **Validates the abstraction against real code before the composer
-starts emitting it.**
+starts emitting it.** Land `deferred-writer.ts` first; only then
+re-estimate the orchestrator target.
 
 - `pi-sandbox/.pi/extensions/deferred-writer.ts`:
-  - Before: ~300 lines of spawn + NDJSON + confirm + promote.
-  - After: ~30 lines — single `delegate()` call with `[CWD_GUARD,
-    STAGE_WRITE]`, prompt from slash-command args, `ctx.ui.confirm`
-    gate wired in the `stage-write.finalize`.
+  - Before: 316 lines of spawn + NDJSON + confirm + promote.
+  - After: ~15 lines — single `delegate()` call with `[CWD_GUARD,
+    STAGE_WRITE]`, prompt from slash-command args, confirm gate
+    wired in `stage-write.finalize` per §2.1.
+  - **Gate:** if the LOC reduction is less than 5× (i.e. the refactor
+    ends up >60 lines), stop and reconsider `delegate()`'s shape
+    before touching the orchestrator. The schema is wrong if a
+    known-good extension doesn't collapse cleanly.
 - `pi-sandbox/.pi/extensions/delegated-writer.ts`:
-  - Before: ~400 lines (dispatch → review → revise RPC loop).
-  - After: ~150 lines. RPC loop stays custom but drafter spawns inside
-    `Promise.all` delegate to `delegate()`; review-verdict parsing
-    uses `REVIEW.parentSide.harvest`.
+  - Before: **701 lines** (dispatch → review → revise RPC loop,
+    per-drafter dashboard, cost aggregation, feedback map).
+  - After: measure after `deferred-writer.ts` lands — apply the same
+    reduction *ratio* to the non-RPC-loop portion (drafter spawns,
+    per-event harvest, promotion) and keep the RPC
+    dispatch→review→revise loop custom. Earlier drafts quoted a
+    specific target line count, but the real figure depends on what
+    `delegate()` reclaims from the drafter-spawn path, which won't
+    be known until 2.3 step 1.
+  - Required behaviors preserved: drafter spawns inside `Promise.all`
+    delegate to `delegate()`; review-verdict parsing uses
+    `REVIEW.parentSide.harvest`; dispatch-list harvest uses
+    `RUN_DEFERRED_WRITER.parentSide.harvest`.
 
 Both refactors must pass their existing probe tasks
 (`deferred-writer` and any orchestrator task we add in Phase 1.6)
@@ -106,9 +152,11 @@ byte-equivalently — no user-visible behavior change.
 
 Once `delegate()` exists and canonical extensions validate it:
 
-- `procedure.md` step 4 ("wire it") emits ~15-line TS files calling
-  `delegate({components: [...], ...})` instead of inline spawn/NDJSON
-  code.
+- `procedure.md` step 4 ("wire it") emits ~10-line TS files calling
+  `delegate({components: [...], prompt})` instead of inline
+  spawn/NDJSON code. The two-key signature from §2.2 is what lets
+  the body be this short — earlier "~15 lines" estimates assumed the
+  7-key signature that R20 trimmed.
 - Per-part `parts/*.md` "Parent-side wiring template" sections
   collapse to a single line per part: "adds `parentSide` to
   `delegate()` call — see `_parent-side.ts`." This dramatically

--- a/parts-first-plan/50-verification-and-ab.md
+++ b/parts-first-plan/50-verification-and-ab.md
@@ -69,10 +69,15 @@ Before declaring Phase 1 done and entering Phase 2:
      `out-of-library-agent` on ≥2/3 models.
 2. **Cost & turns regression bound.** For each (mirror-task, model)
    cell, `grade.json.cost_total_usd` and turn count must be within
-   +25% of the baseline cell. Median across `$AGENT_BUILDER_TARGETS`
-   must be inside the $0.013–$0.048 band for GLM 5.1.
-3. **Net-new tasks passing.** `composer-review-only` and
-   `composer-full-orchestrator` achieve P0 full-pass on ≥2/3 models.
+   `max(+25%, +$0.02)` of the baseline cell, AND the regression must
+   appear in ≥2 of 3 `$AGENT_BUILDER_TARGETS` to flag. Single-cell
+   regressions are logged but not blocking — on a $0.013 baseline
+   cell, +25% is $0.003, inside run-to-run noise. Median across
+   `$AGENT_BUILDER_TARGETS` must be inside the $0.013–$0.048 band
+   for GLM 5.1.
+3. **Net-new tasks passing.** `composer-review-only` achieves P0
+   full-pass on ≥2/3 models. `composer-full-orchestrator` is Phase
+   1.6 per `30-composer-tasks.md` and does not gate Phase 2.
 4. **Prompt lint green.** `npm run validate-prompts` passes on all
    `composer-*` tasks.
 5. **Unit tests green.** `npx tsx --test scripts/grader/__tests__/*.test.ts`.
@@ -103,8 +108,12 @@ Per round, produce a single `summary.md` with a table:
 ```
 
 Diff against baseline via `scripts/grader/report-diff.sh` (TODO —
-small new script, ~30 lines of awk + sort). Regressions surface as
-red rows.
+small new script, ~30 lines of awk + sort). Spec: reads two
+`grade.json` files (baseline, current), diffs on (P0 pass count,
+`cost_total_usd`, turn count, exit status), prints a markdown table
+with red rows when any metric exceeds the `max(+25%, +$0.02)` bound
+from pass criterion #2. No new dependencies; `jq` for extraction,
+`awk` for the comparison, `sort` for stable row order.
 
 ## Rollback
 

--- a/parts-first-plan/60-open-questions.md
+++ b/parts-first-plan/60-open-questions.md
@@ -19,13 +19,25 @@ gives the skill a named-shape vocabulary small models latch onto.
 
 ## 2. Auto-infer `composition` from component list?
 
-Rule sketch:
+This is the **source of truth** for the inference cascade; the grader
+(`20-composer-grader.md §Composition-topology check`) mirrors it.
 
-- `review ∈ components` or `run-deferred-writer ∈ components` →
-  `rpc-delegator-over-concurrent-drafters`.
-- `emit-summary ∈ components && stage-write ∈ components` →
-  `sequential-phases-with-brief`.
-- Else → `single-spawn`.
+```
+composition-inference (when expectation.composition is omitted):
+  if run-deferred-writer ∈ components        → rpc-delegator-over-concurrent-drafters
+  else if review ∈ components                → rpc-delegator-over-concurrent-drafters
+  else if emit-summary ∈ components && stage-write ∈ components
+                                             → sequential-phases-with-brief
+  else                                       → single-spawn
+```
+
+Ordering matters: the `review ∈ components` branch fires **before**
+the `emit-summary + stage-write` branch. Without that precedence,
+`composer-review-only` (`[cwd-guard, stage-write, review]`) would
+never have triggered `sequential-phases-with-brief` — but tasks like
+`composer-scout-then-draft` (`[cwd-guard, emit-summary, stage-write]`
+plus *nothing else*) need the emit-summary+stage-write branch to fire
+on their own. The ordered cascade separates the two cleanly.
 
 **Recommendation:** make `composition:` optional in `test.yaml`;
 auto-infer with a P1 warning when it's load-bearing but omitted. This
@@ -59,11 +71,16 @@ The prompt validator (§30) needs a machine-readable version of
 - (b) auto-generate from the markdown at build time — zero drift,
   needs a small parser.
 
-**Recommendation:** start with (a); add a `prompts-signal-drift.test.ts`
-that re-parses the markdown and fails the build if the code table
-diverges. Upgrade to (b) if the test starts firing weekly.
+**Recommendation:** write the markdown parser first — the
+`prompts-signal-drift.test.ts` drift test needs it either way. If
+the parser fits in under 40 lines, use it to auto-generate
+`signal-map.ts` at build time directly (option b) and skip the
+hand-mirror. If the parser needs more than 40 lines, keep a
+hand-mirrored `signal-map.ts` and use the parser only for the drift
+test (option a). The choice is driven by parser cost, not an upfront
+preference.
 
-**Status:** provisionally (a) + drift test.
+**Status:** parser-size-driven. Revisit once the parser is written.
 
 ## 5. Does `delegate()` belong in `pi-sandbox/.pi/components/` or
    somewhere else?
@@ -90,18 +107,21 @@ too.
 
 ## 6. Orchestrator task in Phase 1?
 
-Phase 1 plans `composer-full-orchestrator` as a net-new task. But
-orchestrator is the highest-complexity shape and the most likely to
-regress on small models. Adding it to Phase 1 might delay Phase 2
-gate-open unnecessarily.
+Phase 1 originally planned `composer-full-orchestrator` as a net-new
+task. But orchestrator is the highest-complexity shape and the most
+likely to regress on small models — and pre-`delegate()`, composer
+emits the full RPC orchestrator inline (~700 lines mirroring
+`delegated-writer.ts`), which risks masking wins on simpler
+compositions.
 
-**Recommendation:** include it in Phase 1 but don't gate Phase 2 on
-it. Pass criteria §3 requires only 2/3 models to pass — if GLM fails
-orchestrator specifically, that's a known small-model ceiling (like
-recon behavioral=partial on deepseek-v3.2 in `AGENTS.md`), not a
-skill defect.
+**Recommendation:** move to Phase 1.6 (see `30-composer-tasks.md`
+bottom). Gate: mirror tasks (1a/1b/1c) sustain green on ≥2/3 models
+across ≥1 full round before orchestrator is authored. Phase 2 does
+not gate on Phase 1.6; if GLM fails orchestrator specifically, that
+remains a known small-model ceiling (like recon behavioral=partial on
+deepseek-v3.2 in `AGENTS.md`).
 
-**Status:** provisionally yes.
+**Status:** decided — Phase 1.6, not Phase 1.
 
 ## 7. Should `pi-agent-composer` link into
    `pi-agent-builder/references/defaults.md`?

--- a/parts-first-plan/README.md
+++ b/parts-first-plan/README.md
@@ -35,17 +35,24 @@ re-enter later as a reference.
    4.5, Gemini 3 Flash Preview, GLM 5.1) is the design constraint; if
    the composer regresses GLM below the assembler's $0.013–$0.048/task,
    3–6-turn band, we investigate before widening scope.
+5. **Narrow bring-up.** Scaffold + grader ship against one mirror task
+   (`composer-drafter-approval`) before the other four; five
+   simultaneous A/Bs is a coarse-grained debug loop. See
+   `30-composer-tasks.md §Bring-up order`.
 
 ## Work branch
 
-`claude/disable-assembler-pattern-format-eKNZh` — despite the name, the
-approach is "add composer alongside" not "disable assembler." Branch
-name is retained to keep the PR thread coherent.
+`claude/review-project-plan-O6lS8` — this plan and the composer skill
+land on the same branch.
 
 ## Phase gates
 
 - **Enter Phase 1.4** (initial composer round) only after 1.1–1.3 land.
+- **Enter Phase 1.6** (orchestrator task) only after mirror tasks
+  sustain green on ≥2/3 `$AGENT_BUILDER_TARGETS` across ≥1 full round.
 - **Enter Phase 2** only after Phase 1 sustains green on all three
-  `$AGENT_BUILDER_TARGETS` across at least five composer tasks.
+  `$AGENT_BUILDER_TARGETS` across at least five composer tasks. Phase
+  2 does **not** gate on Phase 1.6 — orchestrator is the
+  highest-complexity shape and a known small-model ceiling risk.
 - **Deletion of `pi-agent-assembler`** is not on this plan. That is a
   separate decision informed by Phase-2 evidence.


### PR DESCRIPTION
## Summary

This PR refines the composer project plan based on deeper analysis of the `delegate()` runtime abstraction and task sequencing. Key changes include simplifying the `delegate()` function signature to two required parameters, moving the orchestrator task to Phase 1.6, and establishing a narrow bring-up order to reduce debug complexity.

## Key Changes

- **Simplified `delegate()` signature** (`40-components-heavy-phase2.md`):
  - Reduced from 7 parameters to 2 required (`components`, `prompt`) + 2 optional (`model`, `extraTools`)
  - Baked in sensible defaults: `timeoutMs` (120s), `mode` ("json"), `cwd` (process.cwd())
  - Added automatic model tier inference from component set (LEAD_MODEL if review/run-deferred-writer present, else TASK_MODEL)
  - Moved `delegate()` to `lib/` instead of `components/` to signal "library, not auto-loaded artifact"
  - This enables ~10-line extension calls instead of 15+ lines

- **Updated `stage-write` component behavior** (`40-components-heavy-phase2.md`):
  - Now reads sibling `review` component state to determine confirmation gate
  - Confirms only when `stage-write ∈ components && review ∉ components`
  - When review is present, LLM verdict becomes the gate (no human confirm)
  - Codifies the `rails.md` §10 predicate at the component level

- **Reorganized task sequencing** (`30-composer-tasks.md`):
  - Added "Bring-up order" section: land scaffold + grader against `composer-drafter-approval` only before other mirror tasks
  - Rationale: five simultaneous A/Bs is too coarse-grained for debugging
  - Moved `composer-full-orchestrator` to Phase 1.6 (post-mirror-task validation)

- **Moved orchestrator to Phase 1.6** (`30-composer-tasks.md`, `50-verification-and-ab.md`, `60-open-questions.md`):
  - Orchestrator is highest-complexity shape and highest small-model regression risk
  - Pre-`delegate()`, composer would emit ~700 lines of RPC orchestrator inline, masking wins on simpler compositions
  - Gate: mirror tasks must sustain green on ≥2/3 models across ≥1 full round before orchestrator is authored
  - Phase 2 does **not** gate on Phase 1.6; orchestrator is a known small-model ceiling

- **Clarified composition inference** (`60-open-questions.md`, `20-composer-grader.md`):
  - Established ordered cascade: `run-deferred-writer` → `review` → `emit-summary + stage-write` → `single-spawn`
  - Ordering prevents `composer-review-only` from being mis-inferred as `sequential-phases-with-brief`
  - Made this the canonical rule in `60-open-questions.md` §2, mirrored in grader

- **Refined refactoring validation gates** (`40-components-heavy-phase2.md`):
  - `deferred-writer.ts`: target 5× LOC reduction (316 → ~15 lines); stop and reconsider if <5×
  - `delegated-writer.ts`: measure reduction ratio after deferred-writer lands; preserve RPC loop as custom code
  - Both must pass existing probe tasks byte-equivalently

- **Updated cost regression bounds** (`50-verification-and-ab.md`):
  - Changed from flat +25% to `max(+25%, +$0.02)` per cell
  - Regression only blocks if it appears in ≥2 of 3 models; single-cell regressions logged but not blocking
  - Rationale: on $0.013 baseline, +25% is $0.003, inside run-to-run noise

- **Clarified prompt validator approach** (`60-open-questions.md`, `30-composer-tasks.md`

https://claude.ai/code/session_01X41xPZcNttpcZYrsNDYuyA