### PR TITLE
Add pi-agent-composer skill with component-based composition

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "agent-maker": "bash -c 'set -a && source models.env && set +a && exec scripts/task-runner/agent-maker.sh \"$@\"' --",
     "agent-maker:i": "bash -c 'set -a && source models.env && set +a && exec scripts/task-runner/agent-maker.sh --interactive \"$@\"' --",
     "reverse-pipeline": "bash -c 'set -a && source models.env && set +a && exec tsx scripts/reverse-pipeline/index.ts \"$@\"' --",
-    "test:reverse-pipeline": "node --test --import tsx/esm scripts/reverse-pipeline/__tests__/*.test.ts"
+    "test:reverse-pipeline": "node --test --import tsx/esm scripts/reverse-pipeline/__tests__/*.test.ts",
+    "validate-prompts": "tsx scripts/grader/validate-prompt.ts"
   },
   "dependencies": {
     "@mariozechner/pi-coding-agent": "^0.69.0"

--- a/pi-sandbox/skills/pi-agent-composer/SKILL.md
+++ b/pi-sandbox/skills/pi-agent-composer/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: pi-agent-composer
+description: Composes pi agents from a committed library of components (cwd-guard, stage-write, emit-summary, review, run-deferred-writer) without being constrained to fixed patterns. Use this skill when the user wants to compose a pi-coding-agent extension parts-first — pick whichever components the ask requires and wire them with one of three composition topologies (single-spawn, sequential-phases-with-brief, rpc-delegator-over-concurrent-drafters). Trigger on phrases like "compose pi agent", "parts-first", "component-driven", "pi extension that uses cwd-guard / stage-write / emit-summary / review / run-deferred-writer", or any ask of the form "build a pi agent that uses X" / "pi extension with component Y". This skill does NOT author from scratch — if the ask doesn't decompose into the known components, it STOPS and emits a GAP message so the user can fall back to `pi-agent-builder`.
+---
+
+# Pi Agent Composer
+
+This skill composes agents by **picking components and wiring them
+with a composition topology**. It is the parts-first counterpart to
+`pi-agent-assembler`: where the assembler picks one of five fixed
+patterns, the composer picks any subset of the five components and
+infers the topology from the set.
+
+If the user's request cannot be expressed in terms of the known
+components, the skill **stops and emits a GAP message**. The gap
+message is the whole point: when the library can't cover a shape,
+you want that known rather than a confabulated extension.
+
+## Cardinal rules
+
+1. **Compose, don't author.** The components in
+   `pi-sandbox/.pi/components/` are the vocabulary. Do not invent
+   new child-tools, new stub shapes, or new NDJSON harvesters
+   inside this skill.
+2. **`cwd-guard.ts` on every write-capable sub-pi spawn.** Every
+   generated agent that spawns a child pi process with a
+   write-capable tool in its allowlist MUST load
+   `pi-sandbox/.pi/components/cwd-guard.ts` via `-e <abs path>` and
+   pin `PI_SANDBOX_ROOT` in the child's env. The sole exception is
+   a read-only child whose only output channel is `emit_summary`
+   (no filesystem contact, no write verbs in the allowlist).
+3. **Output under `.pi/extensions/<name>.ts`, never the cwd root.**
+   Pi auto-discovers extensions from `.pi/extensions/` under its
+   cwd. A file at `./<name>.ts` loads as nothing; the user then
+   sees "no artifacts" even though the model produced correct
+   TypeScript. When invoking the sandboxed write tool, the `path`
+   argument must start with `.pi/extensions/`.
+
+## Parts catalog
+
+All components live in `pi-sandbox/.pi/components/<name>.ts` and are
+loaded into child pi processes via `pi -e <abs path>`. Per-component
+detail in `parts/<name>.md` (each carries a "Parent-side wiring
+template" the parent extension copy-adapts).
+
+| Component | Role | When to use |
+| --- | --- | --- |
+| `cwd-guard.ts` | Sandbox for child writes | **REQUIRED on every write-capable sub-pi spawn.** Registers `sandbox_write` + `sandbox_edit`; both reject paths outside `$PI_SANDBOX_ROOT`. Replaces built-in `write` / `edit`. Skip only when the child is read-only + `emit_summary`. |
+| `stage-write.ts` | Stub drafter channel | The child should draft files the *parent previews and approves* before anything hits disk. Child calls `stage_write({path, content})`; parent harvests from NDJSON `tool_execution_start` events and `fs.writeFileSync`s only on user approval (or LLM verdict, when paired with `review`). |
+| `emit-summary.ts` | Stub structured-output channel | The child should return one or more *named summaries* instead of free-form assistant text. Child calls `emit_summary({title, body})`; parent harvests from NDJSON, caps byte-length per body, and persists to `.pi/scratch/<title>.md` or assembles into a brief for a follow-on phase. |
+| `review.ts` | Stub reviewer verdict | A reviewer LLM renders `approve`/`revise` on staged drafts. Parent harvests verdicts; `approve` ⇒ promote, `revise` ⇒ re-dispatch the drafter with the feedback string. When `review` is in the component set, the LLM is the gate — no `ctx.ui.confirm` fires. |
+| `run-deferred-writer.ts` | Stub dispatch verb | A delegator LLM dispatches one drafter per call. Parent harvests `{task}` strings and runs drafter children in parallel via `Promise.all`. Pair with `review.ts` inside an RPC delegator session. |
+
+## Compositions catalog
+
+Three topologies. Pick one based on the component set; full detail
+in `compositions.md`.
+
+| Topology | When | Canonical reference |
+| --- | --- | --- |
+| `single-spawn` | One child, one phase. Covers recon-style, confined-drafter, and drafter-with-approval shapes. | `pi-sandbox/.pi/extensions/deferred-writer.ts` |
+| `sequential-phases-with-brief` | Two or more children run serially; parent assembles a brief from phase 1's `emit_summary` output and passes it into phase 2's prompt. | (inline in `compositions.md` until `composer-scout-then-draft` lands) |
+| `rpc-delegator-over-concurrent-drafters` | Persistent RPC delegator LLM dispatches drafters via `run_deferred_writer` and reviews their drafts via `review`; LLM verdict is the gate. | `pi-sandbox/.pi/extensions/delegated-writer.ts` |
+
+## Always-on rails
+
+Every generated extension applies the rails in `rails.md`. Each
+rail cites a section in
+`pi-sandbox/skills/pi-agent-builder/references/defaults.md`; treat
+the rails file as the authoritative checklist.
+
+## Naming conventions
+
+Component names encode intent. Pick the bucket first; name the tool
+second. If no bucket fits, raise it — the library's coherence is
+worth the pause.
+
+| Prefix / name | Semantics | Examples |
+| --- | --- | --- |
+| `stage_*` | Child proposes a side effect; parent holds the commit. The stub returns immediately; the parent decides later whether to persist. | `stage_write`. Future candidates: `stage_exec`, `stage_http_call`. |
+| `emit_*` | Structured-output harvest; no side effect deferred. The parent receives a named piece of structured text to display / persist / forward. | `emit_summary`. Future candidates: `emit_finding`, `emit_metric`. |
+| role name | Purpose-specific stub. Used when no prefix family fits, typically because the tool is single-use inside one composition. | `review`, `run_deferred_writer`. Future candidate: `ask_user`. |
+
+## Anti-patterns
+
+- **Inventing a new component in a user session.** The library is
+  closed; if a new child-tool shape is needed, that's a GAP, not
+  an opportunity to improvise.
+- **Skipping cwd-guard on a write-capable child.** Non-negotiable
+  on every write-capable spawn; the one exception is a read-only +
+  `emit_summary`-only child. An agent that skips cwd-guard while
+  handing the child `sandbox_write` / `write` / `edit` / `bash` is
+  unsafe no matter how narrow the task looks.
+- **Skipping the `rails.md` checklist.** Rails encode the always-on
+  defaults from `pi-agent-builder/references/defaults.md`. Drift
+  here re-introduces bugs the components were written to prevent.
+- **Mixing composition topologies in one handler.** A single
+  command dispatches one topology. If the user wants both an
+  RPC-delegator and a separate drafter-with-approval flow, that's
+  two slash commands.
+
+## When to fall back to pi-agent-builder
+
+Load the `pi-agent-builder` skill instead when:
+
+- The user's request can't be decomposed into the known components
+  (the GAP message tells you this).
+- The user wants a non-sub-agent extension (a custom-UI widget, a
+  compaction strategy, an event-handler-only extension, a context
+  injector, session-persistence work, a pi package).
+- A composition *almost* matches but the user needs a variant that
+  would require a new kind of stub or a new NDJSON event type.
+  Authoring from primitives is pi-agent-builder's job.
+
+`pi-agent-builder` carries the API-surface references
+(`tool-recipe.md`, `events-recipe.md`, `command-recipe.md`,
+`compaction-recipe.md`, `context-and-memory.md`, `evals.md`,
+`packaging.md`, `production.md`, `skills-and-context.md`,
+`reading-short-prompts.md`) — use them for from-scratch authorship.

--- a/pi-sandbox/skills/pi-agent-composer/compositions.md
+++ b/pi-sandbox/skills/pi-agent-composer/compositions.md
@@ -1,0 +1,108 @@
+# Compositions
+
+Three topologies. Pick one with the cascade in `procedure.md` §3.
+Each entry below names the canonical reference (a working extension
+that already implements every rail) and the rails that apply.
+
+## single-spawn
+
+- **When:** one child, one phase. Recon-style (read-only +
+  `emit_summary`), confined-drafter (writes via `sandbox_write`),
+  drafter-with-approval (stages via `stage_write`, parent confirms,
+  parent promotes).
+- **Component sets that infer to this:**
+  - `[emit-summary]` — recon, no write channel.
+  - `[cwd-guard]` — confined drafter; child writes directly.
+  - `[cwd-guard, stage-write]` — drafter with approval (human gate).
+  - `[cwd-guard, stage-write, review]` — drafter with LLM review
+    gate, no fan-out (`run-deferred-writer ∉ components`).
+- **Canonical reference:** `pi-sandbox/.pi/extensions/deferred-writer.ts`
+  lines 52–128 (child spawn + NDJSON loop) + 278–306 (validation +
+  `ctx.ui.confirm` + promotion). The recon and confined-drafter
+  shapes are simplifications: drop the `stage_write` harvest, drop
+  the `ctx.ui.confirm` gate (recon has no writes; confined drafter
+  is unattended).
+- **Rails that apply:** 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12. Rail 11
+  (dashboard) does NOT apply — no fan-out state to track.
+
+## sequential-phases-with-brief
+
+- **When:** scout-then-draft. Phase 1 child surveys via
+  `emit_summary`; parent assembles a brief from the harvested
+  summaries; phase 2 drafter spawn receives the brief in-prompt and
+  stages writes via `stage_write`.
+- **Component sets that infer to this:** `[cwd-guard, emit-summary,
+  stage-write]` (when `review ∉ components` and
+  `run-deferred-writer ∉ components`).
+- **Canonical reference:** no single existing extension yet; inline
+  this worked example until `composer-scout-then-draft` lands and
+  takes over as the canonical reference.
+
+  ```ts
+  // Phase 1: scout child (emit-summary only, no write channel,
+  // PI_SANDBOX_ROOT NOT set on this spawn — rails 1, 2, 3, 4, 8, 12).
+  const scoutResult = await runChild({
+    args: ["-e", EMIT_SUMMARY, "--tools", "ls,read,grep,glob,emit_summary", ...],
+    env: { ...process.env },        // no PI_SANDBOX_ROOT
+  });
+  const brief = scoutResult.summaries
+    .map((s) => `## ${s.title}\n${s.body}`)
+    .join("\n\n");
+  if (Buffer.byteLength(brief, "utf8") > BRIEF_MAX_BYTES) {
+    throw new Error("brief exceeds budget");
+  }
+
+  // Phase 2: drafter child (cwd-guard + stage-write, full rail set).
+  // Spawn shape borrowed from
+  //   pi-sandbox/.pi/extensions/deferred-writer.ts:52-128 (spawn + NDJSON loop)
+  //   pi-sandbox/.pi/extensions/deferred-writer.ts:278-306 (promotion).
+  const drafterPrompt = `${userTask}\n\n<brief>\n${brief}\n</brief>`;
+  const drafterResult = await runChild({
+    args: ["-e", CWD_GUARD, "-e", STAGE_WRITE, "--tools", "stage_write,ls", ...],
+    env: { ...process.env, PI_SANDBOX_ROOT: sandboxRoot },
+    prompt: drafterPrompt,
+  });
+  // stage-write.finalize handles ctx.ui.confirm + promote (rail 10).
+  ```
+
+- **Rails that apply:** all single-spawn rails plus a bounded brief
+  size (`Buffer.byteLength(brief, "utf8") <= BRIEF_MAX_BYTES`,
+  typically 16 KB) before the second spawn.
+
+## rpc-delegator-over-concurrent-drafters
+
+- **When:** persistent RPC delegator LLM dispatches multiple
+  drafters via `run_deferred_writer` and reviews their drafts via
+  `review`; LLM verdict is the gate, not human confirm.
+- **Component sets that infer to this:**
+  - `[cwd-guard, stage-write, review, run-deferred-writer]` — full
+    orchestrator.
+  - Any set containing `run-deferred-writer` (always RPC).
+  - Any set containing `review` and not the above
+    sequential-phases-with-brief shape (per the cascade ordering;
+    catches `[cwd-guard, stage-write, review]` — single-drafter
+    LLM-gated, RPC delegator dispatches one drafter).
+- **Canonical reference:** `pi-sandbox/.pi/extensions/delegated-writer.ts`
+  lines 270–385 (RPC session management),
+  513–578 (dispatch fan-out via `Promise.all`),
+  623–666 (review verdict harvest + per-task feedback map).
+- **Rails that apply:** all single-spawn rails plus rail 11
+  (dashboard). The delegator spawn uses `--mode rpc` (not `--mode
+  json`); drafter spawns inside the dispatch handler use `--mode
+  json` as in single-spawn.
+
+## Composing the fragments
+
+This file is the jumping-off point — no full TypeScript skeletons
+live here. The canonical extensions (`deferred-writer.ts`,
+`delegated-writer.ts`) are always in scope as references, and each
+component's `parts/<name>.md` carries the parent-side wiring
+fragment (event anchor, args destructuring, accumulator shape,
+finalize behavior). The composer assembles those fragments under
+the chosen topology, following the rails checklist in `rails.md`.
+
+If a topology choice is ambiguous (the cascade gives one answer
+but the user's prose suggests another), prefer the cascade and
+note the implicit topology in a one-line comment at the top of the
+generated extension. The grader emits a P1 warning for implicit
+topology choices, surfacing them for review.

--- a/pi-sandbox/skills/pi-agent-composer/parts/cwd-guard.md
+++ b/pi-sandbox/skills/pi-agent-composer/parts/cwd-guard.md
@@ -1,0 +1,101 @@
+# Component: `cwd-guard.ts`
+
+**Location:** `pi-sandbox/.pi/components/cwd-guard.ts`
+
+## What it does
+
+Pi extension that registers two tools — `sandbox_write` and
+`sandbox_edit` — which validate every write/edit target against
+`$PI_SANDBOX_ROOT`. Both reject absolute paths and `..` segments
+that resolve outside the root.
+
+## When to use
+
+**Always, on every write-capable sub-pi spawn.** The child's
+`--tools` allowlist should include `sandbox_write,sandbox_edit`
+and exclude the built-in `write` / `edit`, so the only write path
+out of the child is validated.
+
+Exception: a read-only child whose only output channel is
+`emit_summary` (no filesystem contact, no write verbs in the
+allowlist). The recon-style single-spawn topology takes that
+exception.
+
+## Load mechanism
+
+```ts
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CWD_GUARD = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "components",
+  "cwd-guard.ts",
+);
+```
+
+Pass as `-e <CWD_GUARD>` in the child's spawn args. Compute the
+path from the parent extension's own file location so the layout
+ships with the project and doesn't depend on `$HOME` or the user's
+cwd.
+
+## Required `--tools` allowlist contribution
+
+```
+sandbox_write,sandbox_edit
+```
+
+Plus any read-only verbs the child role needs (`ls`, `read`,
+`grep`, `glob`). Do NOT include `write`, `edit`, or `bash` — those
+defeat the sandbox.
+
+## Required env contribution
+
+`PI_SANDBOX_ROOT` MUST be set to an absolute path in the child's
+env (typically the parent's `process.cwd()`). cwd-guard throws at
+load time if the env var is missing.
+
+## Parent-side wiring template
+
+`cwd-guard` is a **negative wiring case** — there's no parent
+harvest, because the child writes directly via `sandbox_write` /
+`sandbox_edit` (cwd-guard's own `execute` handles the
+`fs.writeFileSync` inside the child process, after validating the
+path).
+
+- **Event anchor:** none (no parent harvest of a stub call).
+- **Args destructuring:** none.
+- **State shape:** the parent does not accumulate writes from
+  cwd-guard. If you need to know what was written, list the
+  sandbox cwd after the child closes.
+- **Finalize behavior:** none beyond the standard close-event
+  cleanup (`clearTimeout`, cost aggregation, exit-code check).
+
+### Spawn snippet
+
+```ts
+const child = spawn(
+  "pi",
+  [
+    "-e", CWD_GUARD,
+    "--tools", "read,sandbox_write,sandbox_edit,ls,grep",
+    "--no-extensions",
+    "--mode", "json",
+    "--provider", "openrouter",
+    "--model", MODEL,
+    "--no-session",
+    "--thinking", "off",
+    "-p", agentPrompt,
+  ],
+  {
+    stdio: ["ignore", "pipe", "pipe"],
+    cwd: sandboxRoot,
+    env: { ...process.env, PI_SANDBOX_ROOT: sandboxRoot },
+  },
+);
+```
+
+`stdio: ["ignore", "pipe", "pipe"]` is mandatory — pi blocks
+reading stdin when it's a pipe even with `-p`, so we feed the
+prompt via argv and close stdin.

--- a/pi-sandbox/skills/pi-agent-composer/parts/emit-summary.md
+++ b/pi-sandbox/skills/pi-agent-composer/parts/emit-summary.md
@@ -1,0 +1,110 @@
+# Component: `emit-summary.ts`
+
+**Location:** `pi-sandbox/.pi/components/emit-summary.ts`
+
+## What it does
+
+Pi extension that registers a **stub** tool
+`emit_summary({title, body})`. The tool's `execute` is a no-op —
+it returns a confirm message but does NOT touch disk. The parent
+harvests each `tool_execution_start` event for `emit_summary` from
+the child's NDJSON stdout (`--mode json`) to recover
+`{title, body}`.
+
+`emit_*` is the structured-output counterpart to `stage_*`: no
+side effect is deferred, the child is simply handing the parent a
+named piece of structured text to display / persist / feed into a
+next phase.
+
+## When to use
+
+- **Recon-style single-spawn:** the child walks a directory /
+  codebase and hands back one or more structured summaries.
+  Replaces harvesting free-form assistant text from `message_end`.
+- **`sequential-phases-with-brief` topology, phase 1:** the recon
+  phase emits summaries that the parent assembles into a handoff
+  brief for the drafter phase.
+
+## When NOT to use
+
+- Any composition where the child needs to return a *side effect*
+  (a file write, an exec, an HTTP call). Use `stage_write` for
+  those.
+- Compositions where the parent genuinely wants the child's final
+  assistant prose (none in this library today).
+
+## Load mechanism
+
+```ts
+const EMIT_SUMMARY = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "components",
+  "emit-summary.ts",
+);
+```
+
+Pass `-e <EMIT_SUMMARY>` to the child. Resolve the path relative
+to the parent extension's own `import.meta.url`, NOT from `$HOME`
+or the user's cwd.
+
+## Required `--tools` allowlist contribution
+
+Include `emit_summary` plus whatever read-only verbs the child
+role needs. For recon:
+
+```
+ls,read,grep,glob,emit_summary
+```
+
+Never add `write`, `edit`, `stage_write`, or `bash` in a
+composition that uses `emit_summary` as its primary output channel
+— they undermine the "structured-output-only" contract.
+
+## Parent-side wiring template
+
+- **Event anchor:** `event.type === "tool_execution_start" &&
+  event.toolName === "emit_summary"`.
+- **Args destructuring:** `const { title, body } = event.args as
+  { title: string; body: string };`.
+- **State shape:** `const summaries: Array<{ title: string; body:
+  string }> = [];`. Apply per-body byte cap
+  (`Buffer.byteLength(body, "utf8") <= SUMMARY_BYTE_CAP`,
+  typically 16 KB) on push; reject and log if exceeded.
+- **Finalize behavior** depends on topology:
+  - **single-spawn (recon):** persist each summary to
+    `.pi/scratch/<safe-title>.md` (or join into one file). Final
+    `ctx.ui.notify` lists the persisted paths.
+  - **sequential-phases-with-brief:** join the summaries into a
+    brief — `summaries.map((s) => "## " + s.title + "\n" + s.body).join("\n\n")`
+    — assert the joined `Buffer.byteLength` is within
+    `BRIEF_MAX_BYTES`, then pass the brief into phase 2's prompt.
+
+### Spawn snippet
+
+```ts
+const child = spawn(
+  "pi",
+  [
+    "-e", EMIT_SUMMARY,
+    "--tools", "ls,read,grep,glob,emit_summary",
+    "--no-extensions",
+    "--mode", "json",
+    "--provider", "openrouter",
+    "--model", MODEL,
+    "--no-session",
+    "--thinking", "off",
+    "-p", agentPrompt,
+  ],
+  {
+    stdio: ["ignore", "pipe", "pipe"],
+    cwd: sandboxRoot,
+  },
+);
+```
+
+`PI_SANDBOX_ROOT` is NOT set on this spawn — `emit_summary` has
+no filesystem contact and the child's allowlist is read-only.
+Compositions that combine `emit_summary` with write-capable
+components (e.g. `sequential-phases-with-brief`'s phase 2) set
+`PI_SANDBOX_ROOT` only on the spawn that loads `cwd-guard.ts`.

--- a/pi-sandbox/skills/pi-agent-composer/parts/review.md
+++ b/pi-sandbox/skills/pi-agent-composer/parts/review.md
@@ -1,0 +1,103 @@
+# Component: `review.ts`
+
+**Location:** `pi-sandbox/.pi/components/review.ts`
+
+## What it does
+
+Pi extension that registers a **stub** tool `review({file_path,
+verdict, feedback?})` where `verdict` is a `StringEnum(["approve",
+"revise"])`. The `execute` is a no-op; the parent harvests each
+verdict from the child's NDJSON stream.
+
+The point: a reviewer LLM renders `approve`/`revise` on a staged
+draft; the parent treats `approve` as "promotable" and `revise`
+as "re-dispatch the drafter with this feedback."
+
+## When to use
+
+- Inside `rpc-delegator-over-concurrent-drafters` topology, paired
+  with `run-deferred-writer` (full orchestrator). Delegator
+  dispatches drafters and reviews their drafts.
+- Inside the same topology with a single drafter (no
+  `run-deferred-writer` in the set is also possible — the cascade
+  in `procedure.md` §3 routes any `review`-bearing set to RPC).
+
+When `review` is in the component set, the LLM verdict replaces
+the human gate: `ctx.ui.confirm` does NOT fire.
+
+## When NOT to use
+
+- Single-drafter human-gated flows. Use `stage-write` alone (with
+  `cwd-guard`) and let `ctx.ui.confirm` do the gating — don't
+  stack both gates.
+- Compositions with no revision loop. Review stub + one-and-done
+  drafter is an over-engineered shape; if there's no chance of
+  `revise`, the verdict adds latency without value.
+
+## Load mechanism
+
+```ts
+const REVIEW = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "components",
+  "review.ts",
+);
+```
+
+Loaded into the delegator child alongside `run-deferred-writer`:
+
+```ts
+spawn("pi", [
+  "-e", CWD_GUARD,
+  "-e", RUN_DEFERRED_WRITER,
+  "-e", REVIEW,
+  "--tools", "run_deferred_writer,review",
+  "--no-extensions",
+  "--mode", "rpc",
+  "--no-session",
+  "--thinking", "off",
+  "--provider", "openrouter",
+  "--model", LEAD_MODEL,
+]);
+```
+
+Note `--mode rpc` (persistent session), not `--mode json`. See
+`compositions.md` §`rpc-delegator-over-concurrent-drafters`.
+
+## Required `--tools` allowlist contribution
+
+```
+review
+```
+
+For the orchestrator shape, the delegator's allowlist is exactly
+`run_deferred_writer,review` — no read/write verbs. The delegator
+decides *what* to dispatch and *what to accept*, nothing else.
+
+## Parent-side wiring template
+
+- **Event anchor:** `event.type === "tool_execution_start" &&
+  event.toolName === "review"`.
+- **Args destructuring:** `const { file_path: reviewedPath,
+  verdict, feedback } = event.args as { file_path: string;
+  verdict: "approve" | "revise"; feedback?: string };`.
+- **State shape:** `const verdicts = new Map<string, { verdict:
+  "approve" | "revise"; feedback?: string }>();` keyed by the
+  staged draft's path. Also track `iterations` per file_path,
+  capped at `MAX_REVIEW_ITERATIONS` (typ. 3).
+- **Finalize behavior:**
+  - On `approve`: mark the staged draft promotable; pass through
+    to the stage-write finalize step.
+  - On `revise`: re-dispatch the drafter for that file_path with
+    `"Revision feedback: " + feedback` appended to the task
+    string. After `MAX_REVIEW_ITERATIONS`, bail with a `notify`
+    naming the file_path and surface accumulated cost.
+
+## Gotcha
+
+`StringEnum` for `verdict` must be imported from
+`@mariozechner/pi-ai`, not `Type.StringEnum(...)` (there's no
+such method on TypeBox's `Type`). This is already correct in
+`pi-sandbox/.pi/components/review.ts`; don't paraphrase the
+import.

--- a/pi-sandbox/skills/pi-agent-composer/parts/run-deferred-writer.md
+++ b/pi-sandbox/skills/pi-agent-composer/parts/run-deferred-writer.md
@@ -1,0 +1,123 @@
+# Component: `run-deferred-writer.ts`
+
+**Location:** `pi-sandbox/.pi/components/run-deferred-writer.ts`
+
+## What it does
+
+Pi extension that registers a **stub** tool
+`run_deferred_writer({task})`. The tool's `execute` is a no-op —
+the parent harvests each `tool_execution_start` event for
+`run_deferred_writer` to recover the `task` string, then runs an
+actual drafter child (single-spawn `cwd-guard + stage-write` shape)
+per harvested task — typically in parallel via `Promise.all`.
+
+This is the dispatch verb for the
+`rpc-delegator-over-concurrent-drafters` topology: the delegator
+LLM decides *what* sub-tasks to fan out; the parent owns the actual
+fan-out mechanics.
+
+## When to use
+
+- Inside `rpc-delegator-over-concurrent-drafters` topology, paired
+  with `review`. Loaded into the delegator's allowlist alongside
+  `review` only.
+
+## When NOT to use
+
+- Single-drafter shapes. Calling `run_deferred_writer` once with no
+  fan-out is a topology mismatch — use `single-spawn` with
+  `cwd-guard + stage-write` instead.
+- Outside an RPC delegator. The dispatch verb only makes sense
+  when one persistent LLM session is choosing how many drafters to
+  run; calling it from a one-shot `--mode json` child loses the
+  delegator's ability to react to draft outcomes.
+
+## Load mechanism
+
+```ts
+const RUN_DEFERRED_WRITER = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "components",
+  "run-deferred-writer.ts",
+);
+```
+
+Loaded into the delegator alongside `review.ts` and `cwd-guard.ts`:
+
+```ts
+spawn("pi", [
+  "-e", CWD_GUARD,
+  "-e", RUN_DEFERRED_WRITER,
+  "-e", REVIEW,
+  "--tools", "run_deferred_writer,review",
+  "--mode", "rpc",
+  ...,
+]);
+```
+
+## Required `--tools` allowlist contribution
+
+```
+run_deferred_writer
+```
+
+The delegator's full allowlist is `run_deferred_writer,review` —
+nothing else.
+
+## Parent-side wiring template
+
+- **Event anchor:** `event.type === "tool_execution_start" &&
+  event.toolName === "run_deferred_writer"`.
+- **Args destructuring:** `const { task } = event.args as {
+  task: string };`.
+- **State shape:** `const dispatched: Array<{ task: string;
+  draftPromise: Promise<DrafterResult> }> = [];`. Each call
+  spawns one drafter child (`cwd-guard + stage-write`,
+  single-spawn shape) and pushes its promise.
+- **Finalize behavior:**
+  1. `await Promise.all(dispatched.map((d) => d.draftPromise))`
+     to gather all drafter results before returning control to
+     the delegator.
+  2. For each drafter result, feed the staged file_path(s) back
+     into the delegator's RPC stdin as a follow-up prompt asking
+     for a `review` verdict.
+  3. After verdicts arrive (see `parts/review.md`), promote
+     `approve`d drafts via the standard stage-write promotion
+     path (rail 6).
+  4. Update the dashboard widget on each phase boundary
+     (dispatched / drafted / reviewed / promoted) per rail 11.
+
+### Spawn snippet for the dispatched drafter (per task)
+
+```ts
+const drafter = spawn(
+  "pi",
+  [
+    "-e", CWD_GUARD,
+    "-e", STAGE_WRITE,
+    "--tools", "stage_write,ls",
+    "--no-extensions",
+    "--mode", "json",
+    "--provider", "openrouter",
+    "--model", TASK_MODEL,
+    "--no-session",
+    "--thinking", "off",
+    "-p", task,
+  ],
+  {
+    stdio: ["ignore", "pipe", "pipe"],
+    cwd: sandboxRoot,
+    env: { ...process.env, PI_SANDBOX_ROOT: sandboxRoot },
+  },
+);
+```
+
+## Canonical assembled example
+
+`pi-sandbox/.pi/extensions/delegated-writer.ts` wires
+`run_deferred_writer` + `review` into the full
+`/delegated-writer <task>` slash command with RPC delegator,
+parallel drafter dispatch, and a per-task feedback map. Use it as
+the reference whenever the wiring template above leaves something
+ambiguous.

--- a/pi-sandbox/skills/pi-agent-composer/parts/stage-write.md
+++ b/pi-sandbox/skills/pi-agent-composer/parts/stage-write.md
@@ -1,0 +1,117 @@
+# Component: `stage-write.ts`
+
+**Location:** `pi-sandbox/.pi/components/stage-write.ts`
+
+## What it does
+
+Pi extension that registers a **stub** tool `stage_write({path,
+content})`. The tool's `execute` is a no-op — it returns a confirm
+message but does NOT touch disk. The parent harvests each
+`tool_execution_start` event for `stage_write` from the child's
+NDJSON stdout (`--mode json`) to recover `{path, content}`.
+
+This means drafts live purely in the parent's heap until the parent
+decides to promote them. A child crash, a timeout, or a rejected
+approval leaves zero files on disk.
+
+## When to use
+
+- The child should draft files the parent previews and approves
+  before anything hits disk.
+- Pair with `review` when an LLM (not a human) decides
+  approve/revise; pair with neither when the parent uses
+  `ctx.ui.confirm`.
+
+## When NOT to use
+
+- The child is trusted to write directly (use `cwd-guard`'s
+  `sandbox_write` instead). Staging + promotion adds an approval
+  gate that's the wrong shape for batch / scripted runs.
+
+## Load mechanism
+
+```ts
+const STAGE_WRITE = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "components",
+  "stage-write.ts",
+);
+```
+
+Pass `-e <STAGE_WRITE>` to the child. Pair with `-e <CWD_GUARD>`
+so the two are loaded together (stage-write does not provide its
+own write channel; cwd-guard's `sandbox_write` covers any
+non-staged scratch writes the child might also do).
+
+## Required `--tools` allowlist contribution
+
+```
+stage_write,ls
+```
+
+Add `read` ONLY if the drafter genuinely needs to read existing
+files — `read` weakens the "stage_write is the only write channel"
+guarantee by letting the drafter echo an existing file's contents
+back out. Prefer feeding relevant existing content into the prompt.
+
+Never add `write`, `edit`, or `bash` — they're real write channels
+and defeat the stub.
+
+## Parent-side wiring template
+
+- **Event anchor:** `event.type === "tool_execution_start" &&
+  event.toolName === "stage_write"`.
+- **Args destructuring:** `const { path: stagedPath, content }
+  = event.args as { path: string; content: string };`.
+- **State shape:** `const staged: Array<{ path: string; content:
+  string }> = [];` — push one entry per matched event. Cap at
+  `MAX_STAGED` (typ. 64) and bail if exceeded.
+- **Finalize behavior:**
+  1. Validate every staged path (absolute? `..`? exists already?)
+     per rail 5.
+  2. **If `review ∉ components`:** call `ctx.ui.confirm` with a
+     per-file preview (path + first ~20 lines). On `false`, notify
+     "cancelled" and return — leave nothing on disk.
+  3. **If `review ∈ components`:** the LLM verdict is the gate;
+     skip `ctx.ui.confirm` entirely. The parent receives `approve`
+     / `revise` from the review harvest and promotes only
+     `approve`d entries.
+  4. For each promotable entry: `fs.mkdirSync(path.dirname(dest),
+     { recursive: true }); fs.writeFileSync(dest, content);` then
+     `fs.readFileSync(dest)` + sha256 verify against staged
+     content.
+  5. Final `ctx.ui.notify` with the promoted file list and session
+     cost.
+
+### Spawn snippet
+
+```ts
+const child = spawn(
+  "pi",
+  [
+    "-e", CWD_GUARD,
+    "-e", STAGE_WRITE,
+    "--tools", "stage_write,ls",
+    "--no-extensions",
+    "--mode", "json",
+    "--provider", "openrouter",
+    "--model", MODEL,
+    "--no-session",
+    "--thinking", "off",
+    "-p", agentPrompt,
+  ],
+  {
+    stdio: ["ignore", "pipe", "pipe"],
+    cwd: sandboxRoot,
+    env: { ...process.env, PI_SANDBOX_ROOT: sandboxRoot },
+  },
+);
+```
+
+## Canonical assembled example
+
+`pi-sandbox/.pi/extensions/deferred-writer.ts` wires stage-write +
+cwd-guard into a `/deferred-writer <task>` slash command with a
+`ctx.ui.confirm` gate. Use it as the reference whenever the
+wiring template above leaves something ambiguous.

--- a/pi-sandbox/skills/pi-agent-composer/procedure.md
+++ b/pi-sandbox/skills/pi-agent-composer/procedure.md
@@ -1,0 +1,107 @@
+# Composition procedure
+
+Five-step flow. Step 5 is the escape hatch — use it the moment step
+1, 2, or 3 fails to converge.
+
+## 1. Read signals
+
+Read the user's request. Map each signal to one or more components
+using the 30-row signal table in
+`pi-sandbox/skills/pi-agent-builder/references/reading-short-prompts.md`.
+Examples (non-exhaustive — the table is authoritative):
+
+| User says… | Implies component(s) |
+| --- | --- |
+| "summarize", "survey", "audit", "explore", "map out", "index" (no draft step follows) | `emit-summary` |
+| "draft a file and show me", "stage, then approve", "preview before writing" | `cwd-guard`, `stage-write` |
+| "write X into `<dir>`", "no approval needed", batch / scripted run | `cwd-guard` |
+| "look at X, then write Y", "given what's there, produce the missing W" | `cwd-guard`, `emit-summary`, `stage-write` |
+| "dispatch several drafters then review", "orchestrator that reviews" | `cwd-guard`, `stage-write`, `review`, `run-deferred-writer` |
+| "have an LLM check each draft before saving" (single drafter, no fan-out) | `cwd-guard`, `stage-write`, `review` |
+
+**Stop early on network I/O.** Asks like "summarize an external API
+endpoint" echo the recon signals but require an I/O channel no
+component provides — `http`/`https`, websockets, webhooks, remote
+APIs, downloads. No component's `--tools` allowlist includes
+network verbs, and no component wraps `fetch`/`http` on behalf of a
+sub-pi. Emit GAP directly (step 5); do NOT improvise
+`node:child_process`, `globalThis.fetch`, or `curl` calls inside
+the parent handler — that violates the cardinal "compose, don't
+author" rule even when the component shape otherwise matches.
+
+If NO signal maps to any component, go straight to step 5.
+
+## 2. Pick parts
+
+Take the union of components implied by step 1's signals. Then
+apply the implicit-`cwd-guard` rule:
+
+- If the set contains any write-capable part (`stage-write`, or any
+  spawn that loads `cwd-guard.ts` for `sandbox_write`/`sandbox_edit`),
+  add `cwd-guard` to the set.
+- If the set contains only `emit-summary` (read-only child), do NOT
+  add `cwd-guard` — it's redundant and the rails grader will flag
+  the child's allowlist as wider than necessary.
+
+If a signal points at a component the library doesn't have (e.g.
+"open a websocket and stream events"), that's a GAP. Go to step 5.
+
+## 3. Pick composition topology
+
+`compositions.md` names three. Apply this cascade in order; the
+first match wins:
+
+```
+if run-deferred-writer ∈ components        → rpc-delegator-over-concurrent-drafters
+else if review ∈ components                → rpc-delegator-over-concurrent-drafters
+else if emit-summary ∈ components && stage-write ∈ components
+                                           → sequential-phases-with-brief
+else                                       → single-spawn
+```
+
+The `review`-before-emit-summary+stage-write ordering matters:
+without it, a `[cwd-guard, stage-write, review]` set (single
+drafter + LLM review, no RPC delegator, no fan-out) gets
+mis-inferred as `sequential-phases-with-brief`. Reviewing a single
+drafter's output is still RPC-delegator topology — the delegator
+just dispatches one drafter and reviews one draft.
+
+If none of the three topologies fits the user's ask (e.g. the user
+wants a fire-and-forget background drafter with no parent
+harvesting), go to step 5.
+
+## 4. Wire it
+
+For each component in the set, follow the **Parent-side wiring
+template** in `parts/<name>.md`. Apply every rail in `rails.md`
+(the grader asserts each one). Output goes to
+`.pi/extensions/<name>.ts`.
+
+The wiring templates are not skeletons — they are per-component
+fragments (event anchor, args destructuring, accumulator shape,
+finalize behavior) that the composer assembles into a single
+extension based on the chosen topology. The canonical references
+named in `compositions.md` show how the fragments combine for each
+topology.
+
+## 5. Flag the gap
+
+When step 1 produces no confident match, step 2 reveals a missing
+component, or step 3 has no fitting topology, emit EXACTLY this
+message and stop:
+
+```
+GAP: I don't have a component for "<user's ask, quoted>".
+Components I have: cwd-guard, stage-write, emit-summary, review, run-deferred-writer.
+Closest match: <"none" OR nearest part/topology + 1-sentence why it doesn't quite fit>.
+To cover this you'd need: <one sentence describing the missing part>.
+To continue anyway, load the pi-agent-builder skill.
+```
+
+Do NOT then go on to write an extension. The gap message is the
+whole deliverable. The user will decide whether to reshape the ask
+into the existing components or fall back to `pi-agent-builder`.
+
+The `GAP:` header and `I don't have a component` phrase are
+byte-identical to the assembler's GAP message. Both graders share
+the same regex; do not paraphrase.

--- a/pi-sandbox/skills/pi-agent-composer/rails.md
+++ b/pi-sandbox/skills/pi-agent-composer/rails.md
@@ -1,0 +1,38 @@
+# Always-on rails
+
+These twelve rails apply to every composer-generated extension.
+Each cites the corresponding section in
+`pi-sandbox/skills/pi-agent-builder/references/defaults.md` rather
+than re-prosing the rule; the grader (`scripts/grader/graders/composer.ts`)
+asserts each one.
+
+| # | Rail | Cite |
+| --- | --- | --- |
+| 1 | **Spawn frame.** `spawn("pi", [...args], { stdio: ["ignore", "pipe", "pipe"], cwd, env })` with `--mode {json|rpc}`, `--no-extensions`, `--no-session`, `--thinking off`, `--provider openrouter`, `--model` from `process.env.{TASK,LEAD,PLAN}_MODEL` matched to the role. | `defaults.md#canonical-drafter-spawn`, `#for-every-sub-agent-child-pi-process` |
+| 2 | **NDJSON line-parse loop.** `buffer += d.toString(); const lines = buffer.split("\n"); buffer = lines.pop() ?? ""; for (const line of lines) { try { const ev = JSON.parse(line); … } catch {} }`. Never call `JSON.parse(d.toString())` directly — multi-event chunks crash. | `defaults.md#for-every-sub-agent-child-pi-process` |
+| 3 | **Hard timeout.** `const timer = setTimeout(() => child.kill("SIGKILL"), TIMEOUT_MS); child.on("close", () => clearTimeout(timer)); child.on("error", () => clearTimeout(timer));`. SIGTERM is not enough; the LLM call inside pi ignores it. | `defaults.md#for-every-sub-agent-child-pi-process` |
+| 4 | **Cost extraction.** Read `event.message.usage.cost.total` on `message_end` events; accumulate into a session total; surface in the final `ctx.ui.notify`. | `defaults.md#cost-tracking-always-on` |
+| 5 | **Path validation.** Every harvested path: reject absolute (`path.isAbsolute`), reject `..` segments (`path.normalize` then check `startsWith("..")`), assert `resolved.startsWith(sandboxRoot + path.sep)`, and check `fs.existsSync` for the destination's parent dir. | `defaults.md#for-every-writer-mutator` |
+| 6 | **Promotion caps.** `MAX_FILES_PROMOTABLE` (typ. 20) and `MAX_CONTENT_BYTES_PER_FILE` (typ. 256 KB). After write, `fs.readFileSync(dest)` + sha256 + assert against the staged content. `fs.mkdirSync(path.dirname(dest), { recursive: true })` before write. | `defaults.md#deferred-approval-gated-side-effects`, `#in-memory-variant-preferred` |
+| 7 | **Output path.** All promoted files go under `.pi/extensions/<name>.ts` (or `.pi/scratch/<name>.md` for `emit-summary` persistence), never the cwd root. Reject any staged path that doesn't start with one of these prefixes. | `defaults.md#for-every-writer-mutator` |
+| 8 | **Tool allowlist.** `--tools` is the union of each selected component's `toolsContribution` (see `parts/<name>.md`). Never include `write`, `edit`, or `bash` — those defeat every stub in the library. | `defaults.md#tool-allowlist-always-on` |
+| 9 | **Sandbox root.** `PI_SANDBOX_ROOT: sandboxRoot` in the child's `env` whenever `cwd-guard.ts` is loaded. Compute `sandboxRoot` from the parent extension's own `import.meta.url`, not from `process.cwd()` or `$HOME`. | `defaults.md#for-every-writer-mutator` |
+| 10 | **Confirmation gate.** Required iff `stage-write ∈ components && review ∉ components`: call `ctx.ui.confirm` with a per-draft preview before any parent-side `fs.writeFileSync`. When `review ∈ components`, the LLM verdict is the gate — do NOT also call `ctx.ui.confirm` (double-gating breaks the orchestrator's autonomy). | `defaults.md#deferred-approval-gated-side-effects` |
+| 11 | **Dashboard (orchestrator-only).** When the topology is `rpc-delegator-over-concurrent-drafters`, call `ctx.ui.setWidget` + `ctx.ui.setStatus` on every state mutation (drafter spawned, draft staged, review verdict received, promotion done). Guard against absence — `ctx.ui.setWidget?.(…)` so non-TUI runners don't crash. | `defaults.md#ui-dashboards-and-notifies` |
+| 12 | **Phase-boundary notifies.** `ctx.ui.notify` once per phase boundary: child spawn, harvest complete, promotion complete (or GAP / cancellation paths). One multi-line message per phase — info-level notifies collapse in the TUI when issued back-to-back. | `defaults.md#ui-dashboards-and-notifies` |
+
+## Why these are the rails
+
+Pattern skeletons in `pi-agent-assembler/patterns/` enforce the
+same rails by-copy: each skeleton inlines the spawn frame, the
+NDJSON loop, the timeout, etc. The composer can't ship per-shape
+skeletons, so this checklist takes their place. `compositions.md`
+points at canonical extensions that already implement every rail
+(`deferred-writer.ts`, `delegated-writer.ts`); the composer's job
+is to verify each rail appears in its output, not to author the
+rail's mechanics from primitives.
+
+If a rail is missing, the grader marks it as a P0 wiring failure
+and the run does not pass. There is no "it's fine to skip the
+timeout for a small task" — every rail prevents a specific failure
+mode catalogued in `defaults.md`.

--- a/scripts/grader/__tests__/component-spec.test.ts
+++ b/scripts/grader/__tests__/component-spec.test.ts
@@ -1,0 +1,227 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  COMPONENTS,
+  forbiddenToolHits,
+  isKnownComponent,
+  type ComponentName,
+} from "../lib/component-spec.ts";
+import { findSpawnInvocations } from "../lib/artifact.ts";
+import { inferComposition } from "../lib/test-spec.ts";
+
+/* -------- Composition inference cascade ----------------------------- */
+
+describe("inferComposition", () => {
+  it("routes run-deferred-writer to rpc-delegator", () => {
+    assert.equal(
+      inferComposition([
+        "cwd-guard",
+        "stage-write",
+        "review",
+        "run-deferred-writer",
+      ]),
+      "rpc-delegator-over-concurrent-drafters",
+    );
+  });
+
+  it("routes review-without-fanout to rpc-delegator (review branch precedes brief branch)", () => {
+    // The cascade ordering matters: a [cwd-guard, stage-write, review]
+    // set is single-drafter LLM-gated, RPC-shaped — not
+    // sequential-phases-with-brief.
+    assert.equal(
+      inferComposition(["cwd-guard", "stage-write", "review"]),
+      "rpc-delegator-over-concurrent-drafters",
+    );
+  });
+
+  it("routes emit-summary + stage-write to sequential-phases-with-brief", () => {
+    assert.equal(
+      inferComposition(["cwd-guard", "emit-summary", "stage-write"]),
+      "sequential-phases-with-brief",
+    );
+  });
+
+  it("routes single-component sets to single-spawn", () => {
+    assert.equal(inferComposition(["emit-summary"]), "single-spawn");
+    assert.equal(inferComposition(["cwd-guard"]), "single-spawn");
+    assert.equal(
+      inferComposition(["cwd-guard", "stage-write"]),
+      "single-spawn",
+    );
+  });
+});
+
+/* -------- isKnownComponent ----------------------------------------- */
+
+describe("isKnownComponent", () => {
+  it("accepts the five canonical names", () => {
+    for (const n of [
+      "cwd-guard",
+      "stage-write",
+      "emit-summary",
+      "review",
+      "run-deferred-writer",
+    ]) {
+      assert.ok(isKnownComponent(n), `${n} should be a known component`);
+    }
+  });
+  it("rejects unknown names", () => {
+    assert.equal(isKnownComponent("not-a-component"), false);
+    assert.equal(isKnownComponent("stage_write"), false);
+  });
+});
+
+/* -------- forbiddenToolHits ---------------------------------------- */
+
+describe("forbiddenToolHits", () => {
+  it("flags write/edit/bash in any spawn", () => {
+    const src = `
+      const c = spawn("pi", ["-e", "cwd-guard.ts", "--tools", "sandbox_write,bash,ls", "--no-extensions", "-p", "x"]);
+    `;
+    const spawns = findSpawnInvocations(src);
+    assert.deepEqual(forbiddenToolHits(spawns), ["bash"]);
+  });
+  it("returns empty for safe allowlists", () => {
+    const src = `
+      const c = spawn("pi", ["-e", "cwd-guard.ts", "--tools", "sandbox_write,sandbox_edit,ls,read", "--no-extensions", "-p", "x"]);
+    `;
+    const spawns = findSpawnInvocations(src);
+    assert.deepEqual(forbiddenToolHits(spawns), []);
+  });
+});
+
+/* -------- Per-component wiringChecks -------------------------------- */
+
+const FAKE_BLOB_DRAFTER_APPROVAL = `
+  const STAGE_WRITE = "/abs/components/stage-write.ts";
+  const CWD_GUARD = "/abs/components/cwd-guard.ts";
+  spawn("pi", ["-e", CWD_GUARD, "-e", STAGE_WRITE, "--mode", "json", "--tools", "stage_write,ls", "--no-extensions", "-p", "x"], { env: { PI_SANDBOX_ROOT: r } });
+  // tool_execution_start handling
+  if (event.toolName === "stage_write") staged.push(event.args);
+  ctx.ui.confirm("promote?");
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.writeFileSync(dest, content);
+  createHash("sha256").update(content);
+`;
+
+const FAKE_BLOB_REVIEW_GATED = `
+  const STAGE_WRITE = "/abs/components/stage-write.ts";
+  const CWD_GUARD = "/abs/components/cwd-guard.ts";
+  const REVIEW = "/abs/components/review.ts";
+  spawn("pi", ["-e", CWD_GUARD, "-e", REVIEW, "--mode", "rpc", "--tools", "review,run_deferred_writer", "--no-extensions", "-p", "x"], { env: { PI_SANDBOX_ROOT: r } });
+  // tool_execution_start handling for review
+  if (event.toolName === "review") verdicts.push(event.args);
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.writeFileSync(dest, content);
+`;
+
+const FAKE_BLOB_EMIT_ONLY = `
+  const EMIT = "/abs/components/emit-summary.ts";
+  spawn("pi", ["-e", EMIT, "--mode", "json", "--tools", "emit_summary,ls,read,grep,glob", "--no-extensions", "-p", "x"]);
+  if (event.type === "tool_execution_start" && event.toolName === "emit_summary") {
+    const safe = body.slice(0, 16384);
+    summaries.push({ title: args.title, body: safe });
+  }
+  Buffer.byteLength(joined, "utf8");
+`;
+
+function makeArt(blob: string) {
+  return {
+    extensions: ["fake.ts"],
+    childTools: [],
+    strays: [],
+    all: ["fake.ts"],
+    extBlob: blob.replace(/\s+/g, " "),
+    allBlob: blob.replace(/\s+/g, " "),
+    layoutOk: true,
+    layoutNotes: [],
+  };
+}
+
+describe("wiringChecks: cwd-guard", () => {
+  it("passes when PI_SANDBOX_ROOT and -e cwd-guard.ts present", () => {
+    const art = makeArt(FAKE_BLOB_DRAFTER_APPROVAL);
+    const spawns = findSpawnInvocations(FAKE_BLOB_DRAFTER_APPROVAL);
+    const components = new Set<ComponentName>(["cwd-guard", "stage-write"]);
+    const marks = COMPONENTS["cwd-guard"].wiringChecks({ art, spawns, components });
+    assert.ok(marks.every((m) => m.status === "pass"), JSON.stringify(marks));
+  });
+});
+
+describe("wiringChecks: stage-write", () => {
+  it("requires ctx.ui.confirm when review ∉ components", () => {
+    const art = makeArt(FAKE_BLOB_DRAFTER_APPROVAL);
+    const spawns = findSpawnInvocations(FAKE_BLOB_DRAFTER_APPROVAL);
+    const components = new Set<ComponentName>(["cwd-guard", "stage-write"]);
+    const marks = COMPONENTS["stage-write"].wiringChecks({ art, spawns, components });
+    const confirmMark = marks.find((m) =>
+      m.name.includes("ctx.ui.confirm before disk write"),
+    );
+    assert.ok(confirmMark);
+    assert.equal(confirmMark!.status, "pass");
+  });
+
+  it("forbids ctx.ui.confirm when review ∈ components", () => {
+    // Synthetic: stage-write present, review present, AND ctx.ui.confirm
+    // present — should fail the review-mode gate.
+    const blob = FAKE_BLOB_DRAFTER_APPROVAL; // has confirm
+    const art = makeArt(blob);
+    const spawns = findSpawnInvocations(blob);
+    const components = new Set<ComponentName>([
+      "cwd-guard",
+      "stage-write",
+      "review",
+    ]);
+    const marks = COMPONENTS["stage-write"].wiringChecks({ art, spawns, components });
+    const noConfirmMark = marks.find((m) =>
+      m.name.includes("no ctx.ui.confirm when review"),
+    );
+    assert.ok(noConfirmMark);
+    assert.equal(noConfirmMark!.status, "fail");
+  });
+});
+
+describe("wiringChecks: emit-summary", () => {
+  it("flags ctx.ui.confirm in summary-only flows", () => {
+    const blobWithConfirm = FAKE_BLOB_EMIT_ONLY + " ctx.ui.confirm('?')";
+    const art = makeArt(blobWithConfirm);
+    const spawns = findSpawnInvocations(blobWithConfirm);
+    const components = new Set<ComponentName>(["emit-summary"]);
+    const marks = COMPONENTS["emit-summary"].wiringChecks({
+      art,
+      spawns,
+      components,
+    });
+    const noConfirmMark = marks.find((m) =>
+      m.name.includes("no ctx.ui.confirm in summary-only flow"),
+    );
+    assert.ok(noConfirmMark);
+    assert.equal(noConfirmMark!.status, "fail");
+  });
+
+  it("passes with bounded body and no confirm", () => {
+    const art = makeArt(FAKE_BLOB_EMIT_ONLY);
+    const spawns = findSpawnInvocations(FAKE_BLOB_EMIT_ONLY);
+    const components = new Set<ComponentName>(["emit-summary"]);
+    const marks = COMPONENTS["emit-summary"].wiringChecks({
+      art,
+      spawns,
+      components,
+    });
+    assert.ok(marks.every((m) => m.status === "pass"), JSON.stringify(marks));
+  });
+});
+
+describe("wiringChecks: review", () => {
+  it("requires --mode rpc and review in tools", () => {
+    const art = makeArt(FAKE_BLOB_REVIEW_GATED);
+    const spawns = findSpawnInvocations(FAKE_BLOB_REVIEW_GATED);
+    const components = new Set<ComponentName>([
+      "cwd-guard",
+      "stage-write",
+      "review",
+    ]);
+    const marks = COMPONENTS["review"].wiringChecks({ art, spawns, components });
+    assert.ok(marks.every((m) => m.status === "pass"), JSON.stringify(marks));
+  });
+});

--- a/scripts/grader/graders/assembler.ts
+++ b/scripts/grader/graders/assembler.ts
@@ -48,6 +48,11 @@ export function gradeAssemblerTask(args: AssemblerGraderArgs): AssemblerGraderRe
     gradeGap(rubric, args);
     return { rubric, kind: "gap" };
   }
+  if (spec.expectation.kind !== "assembly") {
+    throw new Error(
+      `assembler grader received non-assembly expectation: ${spec.expectation.kind}`,
+    );
+  }
   const patternName = spec.expectation.pattern;
   const pattern = loadPatternSpec(args.repoRoot, patternName);
   gradeAssembly(rubric, args, pattern);

--- a/scripts/grader/graders/composer.ts
+++ b/scripts/grader/graders/composer.ts
@@ -1,0 +1,437 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  discoverArtifacts,
+  extractCommandName,
+  findSpawnInvocations,
+  type ArtifactSet,
+  type SpawnInvocation,
+} from "../lib/artifact.ts";
+import {
+  COMPONENTS,
+  forbiddenToolHits,
+  isKnownComponent,
+  type ComponentName,
+  type Mark,
+} from "../lib/component-spec.ts";
+import {
+  gradeNdjsonParsing,
+  gradeNegativeAnchors,
+  gradePathValidation,
+  gradeRegisterToolShape,
+  gradeRegistration,
+  gradeSubprocessRails,
+} from "../lib/core-rails.ts";
+import { runBehavioralProbe, runLoadProbe, type ProbeContext } from "../lib/probes.ts";
+import { Rubric } from "../lib/rubric.ts";
+import { readFinalAssistantText } from "../lib/events.ts";
+import {
+  inferComposition,
+  type CompositionExpectation,
+  type CompositionTopology,
+  type TestSpec,
+} from "../lib/test-spec.ts";
+
+export interface ComposerGraderArgs {
+  repoRoot: string;
+  logDir: string;
+  model: string;
+  task: string;
+  spec: TestSpec;
+}
+
+export interface ComposerGraderResult {
+  rubric: Rubric;
+  kind: "composition" | "gap";
+  composition?: CompositionTopology;
+  components?: ComponentName[];
+}
+
+export function gradeComposerTask(args: ComposerGraderArgs): ComposerGraderResult {
+  const { spec } = args;
+  const rubric = new Rubric();
+
+  rubric.say(`# Grade — ${args.model}`);
+  rubric.say("");
+  rubric.say(`Task: \`${args.task}\` · skill: \`${spec.skill}\``);
+  rubric.say("");
+
+  if (spec.expectation.kind === "gap") {
+    gradeGap(rubric, args);
+    return { rubric, kind: "gap" };
+  }
+  if (spec.expectation.kind !== "composition") {
+    throw new Error(
+      `composer grader received non-composition expectation: ${spec.expectation.kind}`,
+    );
+  }
+  const composition = gradeComposition(rubric, args, spec.expectation);
+  return {
+    rubric,
+    kind: "composition",
+    composition,
+    components: spec.expectation.components as ComponentName[],
+  };
+}
+
+/* -------------------- GAP case -------------------------------------- */
+
+function gradeGap(rubric: Rubric, args: ComposerGraderArgs): void {
+  rubric.say("## Expected: GAP flag");
+  const art = discoverArtifacts(args.logDir);
+  const artifactCount = art.extensions.length + art.childTools.length;
+  rubric.p0(
+    "no artifacts produced (GAP case)",
+    artifactCount === 0 ? "pass" : "fail",
+    artifactCount === 0 ? undefined : `found ${artifactCount} file(s)`,
+  );
+
+  const eventsPath = path.join(args.logDir, "events.ndjson");
+  const finalText = readFinalAssistantText(eventsPath);
+  if (finalText === null) {
+    rubric.p0(
+      "GAP marker present in final assistant message",
+      "fail",
+      "events.ndjson missing or contains no message_end",
+    );
+    return;
+  }
+  // Same regex as the assembler GAP check — both skills emit byte-identical
+  // GAP headers so graders share this anchor pair.
+  const hasGap =
+    /\bGAP\b/.test(finalText) && /I don't have a component/.test(finalText);
+  rubric.p0(
+    "GAP marker present in final assistant message",
+    hasGap ? "pass" : "fail",
+    hasGap
+      ? undefined
+      : "no 'GAP … I don\\'t have a component' in final message_end text",
+  );
+}
+
+/* -------------------- Composition case ------------------------------ */
+
+function gradeComposition(
+  rubric: Rubric,
+  args: ComposerGraderArgs,
+  expectation: CompositionExpectation,
+): CompositionTopology {
+  const declaredComponents = expectation.components as ComponentName[];
+  const declaredSet = new Set<ComponentName>(declaredComponents);
+
+  // Resolve composition: explicit on the spec, or inferred. Inferred
+  // emits a P1 warning so it's surfaced for review.
+  let composition: CompositionTopology;
+  let inferred = false;
+  if (expectation.composition) {
+    composition = expectation.composition;
+  } else {
+    composition = inferComposition(declaredComponents);
+    inferred = true;
+  }
+
+  rubric.say(`## Expected: composition \`${composition}\`${inferred ? " (inferred)" : ""}`);
+  rubric.say(`- components: ${declaredComponents.join(", ")}`);
+  rubric.say(
+    `- tools: ${unionToolsContribution(declaredComponents, expectation.extra_tools).join(",")}`,
+  );
+  rubric.say("");
+
+  const art = discoverArtifacts(args.logDir, (_p, src) => classifyComposerStray(src));
+  emitArtifactHeader(rubric, art, args.logDir);
+
+  if (art.extensions.length === 0 && art.childTools.length === 0) {
+    rubric.p0("at least one .ts artifact produced", "fail", "no output");
+    return composition;
+  }
+
+  // Structural + layout
+  rubric.say("## Structural");
+  rubric.p0(
+    "Extension file produced",
+    art.extensions.length >= 1 ? "pass" : "fail",
+    art.extensions.length >= 1 ? undefined : "no extension",
+  );
+  rubric.p0(
+    "files placed at canonical .pi/extensions path",
+    art.layoutOk && art.extensions.length > 0 ? "pass" : "fail",
+    art.layoutOk ? undefined : art.layoutNotes.join("; "),
+  );
+
+  const cmdName = extractCommandName(art.extensions);
+  const spawns = art.extensions.flatMap((f) =>
+    findSpawnInvocations(fs.readFileSync(f, "utf8")),
+  );
+
+  gradeRegistration(rubric, art, cmdName);
+  gradeRegisterToolShape(rubric, art);
+  gradeSubprocessRails(rubric, art, spawns);
+  gradeNdjsonParsing(rubric, art);
+
+  // Composition-fidelity: each declared component's spawn-args + tool
+  // contributions must appear in at least one spawn.
+  gradeCompositionFidelity(rubric, declaredComponents, expectation, spawns);
+
+  // Per-component wiring.
+  gradePerComponentWiring(rubric, declaredComponents, art, spawns, declaredSet);
+
+  // Composition-topology check.
+  gradeTopology(rubric, composition, art, spawns, inferred);
+
+  // Path validation when stage-write is in play (parent promotes; needs
+  // the validation rail).
+  if (declaredSet.has("stage-write")) {
+    gradePathValidation(rubric, art);
+  }
+
+  gradeNegativeAnchors(rubric, art);
+
+  // Probes
+  if (!process.env.TASK_MODEL && !process.env.SKIP_LOAD) {
+    rubric.say("## Load smoke");
+    rubric.loadStatus = "skip";
+    rubric.loadNote = "TASK_MODEL unset";
+    rubric.say("- [-] skipped (TASK_MODEL unset)");
+  } else {
+    const ctx: ProbeContext = {
+      repoRoot: args.repoRoot,
+      logDir: args.logDir,
+      cmdName,
+      taskModel: process.env.TASK_MODEL ?? "anthropic/claude-haiku-4.5",
+      probeArgs: args.spec.probe?.args ?? "",
+      evidenceAnchor: args.spec.probe?.evidence_anchor,
+    };
+    runLoadProbe(rubric, ctx, art);
+    // Recon mode iff emit-summary is the only harvest channel (no writes).
+    const reconMode =
+      declaredSet.has("emit-summary") &&
+      !declaredSet.has("stage-write") &&
+      !declaredSet.has("cwd-guard");
+    runBehavioralProbe(rubric, ctx, reconMode ? "recon" : "writer");
+  }
+
+  return composition;
+}
+
+function classifyComposerStray(src: string): "ext" | "child" | "ignore" {
+  if (/registerCommand/.test(src)) return "ext";
+  if (
+    /registerTool/.test(src) &&
+    /stage_write|emit_summary|sandbox_write|review\b|run_deferred_writer/.test(src)
+  ) {
+    return "child";
+  }
+  return "ignore";
+}
+
+function emitArtifactHeader(rubric: Rubric, art: ArtifactSet, logDir: string): void {
+  const artRoot = path.join(logDir, "artifacts");
+  rubric.say("Artifacts:");
+  rubric.say(`- extensions (+promoted strays): ${art.extensions.length} file(s)`);
+  for (const f of art.extensions) rubric.say(`  - ${path.relative(artRoot, f)}`);
+  rubric.say(`- child-tools (+promoted strays): ${art.childTools.length} file(s)`);
+  for (const f of art.childTools) rubric.say(`  - ${path.relative(artRoot, f)}`);
+  if (!art.layoutOk) {
+    rubric.say("- layout issues:");
+    for (const note of art.layoutNotes) rubric.say(`  - ${note}`);
+  }
+  rubric.say("");
+}
+
+/* -------------------- Composition fidelity --------------------------- */
+
+function gradeCompositionFidelity(
+  rubric: Rubric,
+  declaredComponents: ComponentName[],
+  expectation: CompositionExpectation,
+  spawns: SpawnInvocation[],
+): void {
+  rubric.say(`## Composition fidelity`);
+  if (spawns.length === 0) {
+    rubric.p0("at least one spawn('pi', [...]) call", "fail", "no spawn found");
+    return;
+  }
+  rubric.p0("at least one spawn('pi', [...]) call", "pass");
+
+  const expectedFilenames = new Set(
+    declaredComponents.map((c) => COMPONENTS[c].filename),
+  );
+  const loadedFilenames = new Set<string>();
+  for (const s of spawns) for (const c of s.eFlagComponents) loadedFilenames.add(c);
+
+  const missing = [...expectedFilenames].filter((f) => !loadedFilenames.has(f));
+  if (missing.length === 0) {
+    rubric.p0(
+      "components loaded via -e match declared component set",
+      "pass",
+      `[${[...expectedFilenames].join(", ")}]`,
+    );
+  } else {
+    rubric.p0(
+      "components loaded via -e match declared component set",
+      "fail",
+      `missing: [${missing.join(", ")}]; loaded: [${[...loadedFilenames].join(", ")}]`,
+    );
+  }
+
+  // P1: no unexpected components beyond the declared set. Allow any
+  // .ts file that's not in the canonical component library to slip
+  // through (test fixtures, ad-hoc helpers loaded for other reasons).
+  const knownComponentFiles = new Set(
+    Object.values(COMPONENTS).map((c) => c.filename),
+  );
+  const unexpected = [...loadedFilenames].filter(
+    (f) => knownComponentFiles.has(f) && !expectedFilenames.has(f),
+  );
+  if (unexpected.length > 0) {
+    rubric.p1(
+      "no unexpected components loaded beyond declared set",
+      "fail",
+      `extra: [${unexpected.join(", ")}]`,
+    );
+  } else {
+    rubric.p1("no unexpected components loaded beyond declared set", "pass");
+  }
+
+  // Tool allowlist: union of each component's contribution + extra_tools.
+  // Each spawn's tools must be a subset of (allowed ∪ {ls, read, grep,
+  // glob} — the read-only verbs are always safe).
+  const allowedTools = new Set<string>(
+    unionToolsContribution(declaredComponents, expectation.extra_tools),
+  );
+  const safeReadExtras = new Set(["ls", "read", "grep", "glob"]);
+  let allSpawnsOk = true;
+  const violations: string[] = [];
+  for (const s of spawns) {
+    if (!s.toolsCsv) {
+      allSpawnsOk = false;
+      violations.push("spawn missing --tools flag");
+      continue;
+    }
+    for (const t of s.tools) {
+      if (!allowedTools.has(t) && !safeReadExtras.has(t)) {
+        allSpawnsOk = false;
+        violations.push(`unexpected tool: ${t}`);
+      }
+    }
+  }
+  rubric.p0(
+    `--tools allowlist matches component union (allowed: ${[...allowedTools].join(",")})`,
+    allSpawnsOk ? "pass" : "fail",
+    allSpawnsOk ? undefined : violations.join("; "),
+  );
+
+  // Forbidden tools: write/edit/bash never appear, regardless of
+  // composition.
+  const forbiddenHits = forbiddenToolHits(spawns);
+  rubric.p0(
+    "no write/edit/bash in child tool allowlist",
+    forbiddenHits.length === 0 ? "pass" : "fail",
+    forbiddenHits.length === 0
+      ? undefined
+      : `forbidden: [${forbiddenHits.join(", ")}]`,
+  );
+}
+
+function unionToolsContribution(
+  components: ReadonlyArray<string>,
+  extras: ReadonlyArray<string> | undefined,
+): string[] {
+  const tools = new Set<string>();
+  for (const c of components) {
+    if (!isKnownComponent(c)) continue;
+    for (const t of COMPONENTS[c].toolsContribution) tools.add(t);
+  }
+  for (const t of extras ?? []) tools.add(t);
+  return [...tools];
+}
+
+/* -------------------- Per-component wiring --------------------------- */
+
+function gradePerComponentWiring(
+  rubric: Rubric,
+  declaredComponents: ComponentName[],
+  art: ArtifactSet,
+  spawns: SpawnInvocation[],
+  components: Set<ComponentName>,
+): void {
+  rubric.say(`## Per-component wiring`);
+  for (const name of declaredComponents) {
+    if (!isKnownComponent(name)) continue;
+    const marks = COMPONENTS[name].wiringChecks({ art, spawns, components });
+    for (const m of marks) emitMark(rubric, m);
+  }
+}
+
+function emitMark(rubric: Rubric, m: Mark): void {
+  if (m.severity === "P0") rubric.p0(m.name, m.status, m.note);
+  else rubric.p1(m.name, m.status, m.note);
+}
+
+/* -------------------- Composition-topology check --------------------- */
+
+function gradeTopology(
+  rubric: Rubric,
+  composition: CompositionTopology,
+  art: ArtifactSet,
+  spawns: SpawnInvocation[],
+  inferred: boolean,
+): void {
+  rubric.say(`## Composition topology`);
+  if (inferred) {
+    rubric.p1(
+      "topology is explicit on the test spec",
+      "fail",
+      "no `composition:` field — inferred from component set",
+    );
+  }
+
+  switch (composition) {
+    case "single-spawn": {
+      const ok = spawns.length === 1;
+      rubric.p0(
+        "single-spawn: exactly one spawn('pi', [...])",
+        ok ? "pass" : "fail",
+        ok ? undefined : `found ${spawns.length}`,
+      );
+      break;
+    }
+    case "sequential-phases-with-brief": {
+      const enoughSpawns = spawns.length >= 2;
+      rubric.p0(
+        "sequential-phases-with-brief: at least two spawn('pi', [...]) calls",
+        enoughSpawns ? "pass" : "fail",
+        enoughSpawns ? undefined : `found ${spawns.length}`,
+      );
+      const briefAssembled =
+        /Buffer\.byteLength\(/.test(art.extBlob) &&
+        /(brief|summary|survey|Context\s*[—-])/i.test(art.extBlob);
+      rubric.p0(
+        "sequential-phases-with-brief: brief assembled with bounded byte length",
+        briefAssembled ? "pass" : "fail",
+      );
+      break;
+    }
+    case "rpc-delegator-over-concurrent-drafters": {
+      const rpcSpawn = spawns.some((s) => s.mode === "rpc");
+      rubric.p0(
+        "rpc-delegator: a spawn uses --mode rpc",
+        rpcSpawn ? "pass" : "fail",
+      );
+      // Concurrent dispatch only required when run-deferred-writer is in
+      // the set; a [stage-write, review] composition is RPC-shaped but
+      // single-drafter, so Promise.all isn't mandatory there.
+      const dispatchToolListed = spawns.some((s) =>
+        s.tools.includes("run_deferred_writer"),
+      );
+      if (dispatchToolListed) {
+        const hasParallel = /Promise\.all\(/.test(art.extBlob);
+        rubric.p0(
+          "rpc-delegator: Promise.all dispatch when run-deferred-writer ∈ components",
+          hasParallel ? "pass" : "fail",
+        );
+      }
+      break;
+    }
+  }
+}

--- a/scripts/grader/index.ts
+++ b/scripts/grader/index.ts
@@ -17,6 +17,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { gradeAssemblerTask } from "./graders/assembler.ts";
+import { gradeComposerTask } from "./graders/composer.ts";
 import { FRAMEWORK_ROOT, REPO_ROOT } from "./lib/paths.ts";
 import { loadTestSpec } from "./lib/test-spec.ts";
 
@@ -47,23 +48,41 @@ function main(): void {
 
   const spec = loadTestSpec(taskDir);
 
-  const { rubric, kind, pattern } = gradeAssemblerTask({
-    repoRoot: REPO_ROOT,
-    logDir,
-    model,
-    task,
-    spec,
-  });
+  let rubricResult;
+  if (spec.skill === "pi-agent-composer") {
+    const { rubric, kind, composition, components } = gradeComposerTask({
+      repoRoot: REPO_ROOT,
+      logDir,
+      model,
+      task,
+      spec,
+    });
+    rubricResult = {
+      rubric,
+      kind: kind as "composition" | "gap",
+      pattern: composition,
+      components,
+    };
+  } else {
+    const { rubric, kind, pattern } = gradeAssemblerTask({
+      repoRoot: REPO_ROOT,
+      logDir,
+      model,
+      task,
+      spec,
+    });
+    rubricResult = { rubric, kind: kind as "assembly" | "gap", pattern };
+  }
 
-  const md = rubric.emitMarkdown();
+  const md = rubricResult.rubric.emitMarkdown();
   process.stdout.write(md);
 
-  rubric.writeJson(path.join(logDir, "grade.json"), {
+  rubricResult.rubric.writeJson(path.join(logDir, "grade.json"), {
     model,
     task,
     skill: spec.skill,
-    kind,
-    pattern,
+    kind: rubricResult.kind,
+    pattern: rubricResult.pattern,
   });
 }
 

--- a/scripts/grader/lib/component-spec.ts
+++ b/scripts/grader/lib/component-spec.ts
@@ -1,0 +1,247 @@
+import type { ArtifactSet, SpawnInvocation } from "./artifact.ts";
+
+/**
+ * Per-component wiring-check registry. The composer grader iterates
+ * `expectation.components`, looks up each ComponentSpec here, and
+ * applies its wiring checks against the harvested artifacts and
+ * spawn invocations.
+ *
+ * The regex anchors here are the same ones used in the assembler
+ * grader's per-pattern checks (`scripts/grader/graders/assembler.ts`),
+ * re-homed per-component instead of per-pattern. A pattern that uses
+ * stage-write triggers exactly the stage-write wiring checks; a
+ * pattern that uses stage-write + review triggers stage-write's
+ * checks adjusted for the LLM-gate variant.
+ */
+
+export const COMPONENT_NAMES = [
+  "cwd-guard",
+  "stage-write",
+  "emit-summary",
+  "review",
+  "run-deferred-writer",
+] as const;
+
+export type ComponentName = (typeof COMPONENT_NAMES)[number];
+
+export function isKnownComponent(name: string): name is ComponentName {
+  return (COMPONENT_NAMES as readonly string[]).includes(name);
+}
+
+export interface Mark {
+  severity: "P0" | "P1";
+  name: string;
+  status: "pass" | "fail";
+  note?: string;
+}
+
+export interface WiringContext {
+  art: ArtifactSet;
+  spawns: SpawnInvocation[];
+  /** Full component set declared on the test spec. */
+  components: Set<ComponentName>;
+}
+
+export interface ComponentSpec {
+  name: ComponentName;
+  /** The basename loaded via `pi -e <abs path>/<filename>`. */
+  filename: string;
+  /** Tokens this component contributes to the child's --tools allowlist. */
+  toolsContribution: string[];
+  /** Per-component wiring assertions; receives the full component set so
+   *  cross-component predicates (e.g. confirm-gate when stage-write ∈ but
+   *  review ∉) can vary their behavior. */
+  wiringChecks(ctx: WiringContext): Mark[];
+}
+
+const FORBIDDEN_TOOLS = new Set(["write", "edit", "bash"]);
+
+export const COMPONENTS: Record<ComponentName, ComponentSpec> = {
+  "cwd-guard": {
+    name: "cwd-guard",
+    filename: "cwd-guard.ts",
+    toolsContribution: ["sandbox_write", "sandbox_edit"],
+    wiringChecks({ art, spawns }) {
+      const out: Mark[] = [];
+      const sandboxEnv = /PI_SANDBOX_ROOT/.test(art.extBlob);
+      out.push({
+        severity: "P0",
+        name: "cwd-guard: PI_SANDBOX_ROOT in child env",
+        status: sandboxEnv ? "pass" : "fail",
+      });
+      const writeCapableSpawn = spawns.some(
+        (s) =>
+          s.tools.includes("sandbox_write") || s.tools.includes("sandbox_edit"),
+      );
+      const cwdGuardLoaded = spawns.some((s) =>
+        s.eFlagComponents.includes("cwd-guard.ts"),
+      );
+      out.push({
+        severity: "P0",
+        name: "cwd-guard: -e cwd-guard.ts on every write-capable spawn",
+        status: writeCapableSpawn && !cwdGuardLoaded ? "fail" : "pass",
+        note:
+          writeCapableSpawn && !cwdGuardLoaded
+            ? "spawn lists sandbox_write/sandbox_edit but did not load cwd-guard.ts"
+            : undefined,
+      });
+      return out;
+    },
+  },
+  "stage-write": {
+    name: "stage-write",
+    filename: "stage-write.ts",
+    toolsContribution: ["stage_write"],
+    wiringChecks({ art, components }) {
+      const out: Mark[] = [];
+      const blob = art.extBlob;
+      const hasStageHarvest =
+        /["'`]stage_write["'`]/.test(blob) && /tool_execution_start/.test(blob);
+      out.push({
+        severity: "P0",
+        name: "stage-write: harvest stage_write from tool_execution_start",
+        status: hasStageHarvest ? "pass" : "fail",
+      });
+      const hasWrite = /fs\.writeFileSync\(/.test(blob);
+      const hasMkdir = /fs\.mkdirSync\([\s\S]{0,200}?recursive[\s\S]{0,60}?true/.test(
+        blob,
+      );
+      out.push({
+        severity: "P0",
+        name: "stage-write: fs.writeFileSync + mkdirSync recursive on promote",
+        status: hasWrite && hasMkdir ? "pass" : "fail",
+      });
+      const hasSha = /createHash\(["']sha256["']\)/i.test(blob);
+      out.push({
+        severity: "P1",
+        name: "stage-write: sha256 post-write verify",
+        status: hasSha ? "pass" : "fail",
+      });
+      // Confirm-gate predicate: required iff stage-write ∈ && review ∉.
+      const hasConfirm = /ctx\.ui\.confirm/.test(blob);
+      const reviewInSet = components.has("review");
+      if (reviewInSet) {
+        out.push({
+          severity: "P0",
+          name: "stage-write: no ctx.ui.confirm when review ∈ components (LLM is the gate)",
+          status: hasConfirm ? "fail" : "pass",
+          note: hasConfirm
+            ? "found ctx.ui.confirm alongside review — double-gating breaks orchestrator autonomy"
+            : undefined,
+        });
+      } else {
+        out.push({
+          severity: "P0",
+          name: "stage-write: ctx.ui.confirm before disk write (review ∉ components)",
+          status: hasConfirm ? "pass" : "fail",
+        });
+      }
+      return out;
+    },
+  },
+  "emit-summary": {
+    name: "emit-summary",
+    filename: "emit-summary.ts",
+    toolsContribution: ["emit_summary"],
+    wiringChecks({ art, components }) {
+      const out: Mark[] = [];
+      const blob = art.extBlob;
+      const hasEmitHarvest =
+        /["'`]emit_summary["'`]/.test(blob) && /tool_execution_start/.test(blob);
+      out.push({
+        severity: "P0",
+        name: "emit-summary: harvest emit_summary from tool_execution_start",
+        status: hasEmitHarvest ? "pass" : "fail",
+      });
+      const bounded =
+        /Buffer\.byteLength\(/.test(blob) || /\.slice\(0,\s*[0-9]+\)/.test(blob);
+      out.push({
+        severity: "P0",
+        name: "emit-summary: per-body byte cap (Buffer.byteLength or .slice(0, N))",
+        status: bounded ? "pass" : "fail",
+      });
+      // When emit-summary is the ONLY harvest channel (no stage-write),
+      // the parent must not call ctx.ui.confirm — there's nothing to gate.
+      if (!components.has("stage-write")) {
+        const hasConfirm = /ctx\.ui\.confirm/.test(blob);
+        out.push({
+          severity: "P0",
+          name: "emit-summary: no ctx.ui.confirm in summary-only flow",
+          status: hasConfirm ? "fail" : "pass",
+          note: hasConfirm
+            ? "found ctx.ui.confirm in a read-only summary flow"
+            : undefined,
+        });
+      }
+      return out;
+    },
+  },
+  review: {
+    name: "review",
+    filename: "review.ts",
+    toolsContribution: ["review"],
+    wiringChecks({ art, spawns }) {
+      const out: Mark[] = [];
+      const blob = art.extBlob;
+      const rpcSpawn = spawns.find((s) => s.mode === "rpc");
+      out.push({
+        severity: "P0",
+        name: "review: a spawn uses --mode rpc (delegator)",
+        status: rpcSpawn ? "pass" : "fail",
+      });
+      const reviewToolListed = spawns.some((s) => s.tools.includes("review"));
+      out.push({
+        severity: "P0",
+        name: "review: --tools includes review on the delegator spawn",
+        status: reviewToolListed ? "pass" : "fail",
+      });
+      const hasVerdictHarvest =
+        /["'`]review["'`]/.test(blob) && /tool_execution_start/.test(blob);
+      out.push({
+        severity: "P0",
+        name: "review: harvest review verdict from tool_execution_start",
+        status: hasVerdictHarvest ? "pass" : "fail",
+      });
+      return out;
+    },
+  },
+  "run-deferred-writer": {
+    name: "run-deferred-writer",
+    filename: "run-deferred-writer.ts",
+    toolsContribution: ["run_deferred_writer"],
+    wiringChecks({ art, spawns }) {
+      const out: Mark[] = [];
+      const blob = art.extBlob;
+      const dispatchToolListed = spawns.some((s) =>
+        s.tools.includes("run_deferred_writer"),
+      );
+      out.push({
+        severity: "P0",
+        name: "run-deferred-writer: --tools includes run_deferred_writer on delegator",
+        status: dispatchToolListed ? "pass" : "fail",
+      });
+      const hasDispatchHarvest =
+        /run_deferred_writer/.test(blob) && /tool_execution_start/.test(blob);
+      out.push({
+        severity: "P0",
+        name: "run-deferred-writer: harvest run_deferred_writer from tool_execution_start",
+        status: hasDispatchHarvest ? "pass" : "fail",
+      });
+      const hasParallel = /Promise\.all\(/.test(blob);
+      out.push({
+        severity: "P0",
+        name: "run-deferred-writer: Promise.all for concurrent drafter dispatch",
+        status: hasParallel ? "pass" : "fail",
+      });
+      return out;
+    },
+  },
+};
+
+export function forbiddenToolHits(spawns: SpawnInvocation[]): string[] {
+  const hits: string[] = [];
+  for (const s of spawns) {
+    for (const t of s.tools) if (FORBIDDEN_TOOLS.has(t)) hits.push(t);
+  }
+  return hits;
+}

--- a/scripts/grader/lib/signal-map.ts
+++ b/scripts/grader/lib/signal-map.ts
@@ -1,0 +1,126 @@
+import type { ComponentName } from "./component-spec.ts";
+
+/**
+ * Hand-mirrored signal → component table, derived from
+ * `pi-sandbox/skills/pi-agent-builder/references/reading-short-prompts.md`.
+ *
+ * Keep in sync with the markdown table above. A parser-driven drift
+ * test is planned in `parts-first-plan/60-open-questions.md §4`; until
+ * it lands, this file is the single source of truth for the prompt
+ * validator (`scripts/grader/validate-prompt.ts`).
+ *
+ * Each row's pattern matches a *signal*; the components are the
+ * canonical mapping for that signal. The validator unions the matches.
+ *
+ * Note on `cwd-guard`: it's implicit for any write-capable shape and
+ * is therefore not surfaced as a standalone signal here — the
+ * validator special-cases it (declared `cwd-guard` is always allowed
+ * even if not signal-derived, when any write-capable component is
+ * declared).
+ */
+
+export interface SignalRow {
+  pattern: RegExp;
+  components: ReadonlyArray<ComponentName>;
+  /** Short human-readable handle for error messages. */
+  description: string;
+}
+
+export const SIGNAL_MAP: ReadonlyArray<SignalRow> = [
+  // Recon / read-only / survey → emit-summary
+  {
+    pattern: /\b(read-only|survey|recon|explore|map out|index|audit|summari[sz]e)\b/i,
+    components: ["emit-summary"],
+    description: "recon-style read-only survey",
+  },
+
+  // Approval / confirm / preview → stage-write (parent gate)
+  {
+    pattern:
+      /\b(after the user confirms?|with approval|the user (decides?|approves?)|preview before writing|stage,? then approve|draft .* (and )?show me)\b/i,
+    components: ["stage-write"],
+    description: "user-approval gate over drafts",
+  },
+
+  // Buffered / staged / in-memory writes → stage-write
+  {
+    pattern:
+      /\b(buffered|staged|staging|in[- ]memory|in[- ]?buffer|buffers? writes|writes? to (a )?file in buffer|don't actually write yet|writes? on approval|waits? for (the )?user to approve before|show me what it would do|approve before (the )?writes? go through)\b/i,
+    components: ["stage-write"],
+    description: "buffered / staged write semantics",
+  },
+
+  // Confined / sandboxed → cwd-guard
+  {
+    pattern:
+      /\b(can'?t get outside|stays? inside|sandboxed to|scoped to (this )?(directory|dir)|confined (drafter|to)|inside (a )?sandbox|under .*\.pi|writes? (in|into|to) (the )?sandbox)\b/i,
+    components: ["cwd-guard"],
+    description: "sandbox / confined writes",
+  },
+
+  // Sequential phases — scout-then-draft style → emit-summary + stage-write
+  {
+    pattern:
+      /\b(two phases|first .{0,40} then|propose .{0,40} then commit|look at .{0,40} then write|survey .{0,40} (and|then) (add|write|generate|create|produce)|given what'?s there,? (produce|generate|write))\b/i,
+    components: ["emit-summary", "stage-write"],
+    description: "sequential phases (scout + draft)",
+  },
+
+  // Parallel fan-out → run-deferred-writer
+  {
+    pattern: /\b(in parallel|fan ?out|N tasks at once|multiple drafters|several drafters|parallel drafters)\b/i,
+    components: ["run-deferred-writer"],
+    description: "parallel drafter fan-out",
+  },
+
+  // Orchestrator / LLM-review → review + run-deferred-writer
+  {
+    pattern:
+      /\b(orchestrate[sd]?|orchestrator|delegate[sd]? to|decides? how many|calls? .{0,30} N times|LLM picks the subtasks?|reviewer (approves?|revises?)|review (verdict|step)|have an LLM (review|check|approve)|break this into sub-?tasks)\b/i,
+    components: ["review", "run-deferred-writer"],
+    description: "orchestrator with LLM review",
+  },
+
+  // Single-drafter LLM review (no fan-out) → review (no run-deferred-writer)
+  {
+    pattern:
+      /\b(LLM (gate|review)s? (the |each )?draft|automatic(ally)? approve|review before (saving|promoting|writing))\b/i,
+    components: ["review"],
+    description: "single-drafter LLM review",
+  },
+];
+
+/**
+ * Tokens a prompt may NOT contain — the prompt should not name the
+ * components it expects. The agent has to *choose* them from the ask.
+ */
+export const FORBIDDEN_LITERALS: ReadonlyArray<string> = [
+  "stage-write",
+  "stage_write",
+  "emit-summary",
+  "emit_summary",
+  "cwd-guard",
+  "sandbox_write",
+  "sandbox_edit",
+  "run_deferred_writer",
+  "run-deferred-writer",
+];
+
+/**
+ * Compute the inferred component set for a prompt. Returns the union
+ * of every matched row's components.
+ */
+export function inferComponentsFromPrompt(prompt: string): Set<ComponentName> {
+  const out = new Set<ComponentName>();
+  for (const row of SIGNAL_MAP) {
+    if (row.pattern.test(prompt)) {
+      for (const c of row.components) out.add(c);
+    }
+  }
+  return out;
+}
+
+export function findForbiddenLiterals(prompt: string): string[] {
+  const lower = prompt.toLowerCase();
+  return FORBIDDEN_LITERALS.filter((lit) => lower.includes(lit.toLowerCase()));
+}

--- a/scripts/grader/lib/test-spec.ts
+++ b/scripts/grader/lib/test-spec.ts
@@ -2,12 +2,28 @@ import fs from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
 import { z } from "zod";
+import { COMPONENT_NAMES } from "./component-spec.ts";
 
 const AssemblyExpectation = z.object({
   kind: z.literal("assembly"),
   pattern: z.string().min(1),
   extra_tools: z.array(z.string()).optional(),
   extra_components: z.array(z.string()).optional(),
+});
+
+const ComponentNameEnum = z.enum(COMPONENT_NAMES);
+
+const COMPOSITION_TOPOLOGIES = [
+  "single-spawn",
+  "sequential-phases-with-brief",
+  "rpc-delegator-over-concurrent-drafters",
+] as const;
+
+const CompositionExpectation = z.object({
+  kind: z.literal("composition"),
+  components: z.array(ComponentNameEnum).min(1),
+  composition: z.enum(COMPOSITION_TOPOLOGIES).optional(),
+  extra_tools: z.array(z.string()).optional(),
 });
 
 const GapExpectation = z.object({
@@ -21,15 +37,23 @@ const Probe = z.object({
 });
 
 export const TestSpecSchema = z.object({
-  skill: z.enum(["pi-agent-assembler", "pi-agent-builder"]).default("pi-agent-assembler"),
-  expectation: z.discriminatedUnion("kind", [AssemblyExpectation, GapExpectation]),
+  skill: z
+    .enum(["pi-agent-assembler", "pi-agent-composer", "pi-agent-builder"])
+    .default("pi-agent-assembler"),
+  expectation: z.discriminatedUnion("kind", [
+    AssemblyExpectation,
+    CompositionExpectation,
+    GapExpectation,
+  ]),
   prompt: z.string().min(1),
   probe: Probe.optional(),
 });
 
 export type TestSpec = z.infer<typeof TestSpecSchema>;
 export type AssemblyExpectation = z.infer<typeof AssemblyExpectation>;
+export type CompositionExpectation = z.infer<typeof CompositionExpectation>;
 export type GapExpectation = z.infer<typeof GapExpectation>;
+export type CompositionTopology = (typeof COMPOSITION_TOPOLOGIES)[number];
 
 export function loadTestSpec(taskDir: string): TestSpec {
   const specPath = path.join(taskDir, "test.yaml");
@@ -46,4 +70,26 @@ export function loadTestSpec(taskDir: string): TestSpec {
     throw new Error(`Invalid test.yaml at ${specPath}:\n${issues}`);
   }
   return result.data;
+}
+
+/**
+ * Composition-inference cascade. The `review` branch must precede the
+ * `emit-summary && stage-write` branch — otherwise a
+ * [cwd-guard, stage-write, review] set (single-drafter LLM-gated, no
+ * fan-out) gets mis-inferred as sequential-phases-with-brief.
+ */
+export function inferComposition(
+  components: ReadonlyArray<string>,
+): CompositionTopology {
+  const set = new Set(components);
+  if (set.has("run-deferred-writer")) {
+    return "rpc-delegator-over-concurrent-drafters";
+  }
+  if (set.has("review")) {
+    return "rpc-delegator-over-concurrent-drafters";
+  }
+  if (set.has("emit-summary") && set.has("stage-write")) {
+    return "sequential-phases-with-brief";
+  }
+  return "single-spawn";
 }

--- a/scripts/grader/lib/types.ts
+++ b/scripts/grader/lib/types.ts
@@ -12,7 +12,7 @@ export interface GradeJson {
   model: string;
   task: string;
   skill: string;
-  kind: "assembly" | "gap" | "unknown";
+  kind: "assembly" | "composition" | "gap" | "unknown";
   pattern?: string;
   p0_passed: string;
   p1_passed: string;

--- a/scripts/grader/validate-prompt.ts
+++ b/scripts/grader/validate-prompt.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * validate-prompt.ts — authoring-time lint for composer task prompts.
+ *
+ * Usage:   validate-prompt.ts [--dir <tasks-dir>]
+ *
+ * Walks every `composer-*` test.yaml under scripts/task-runner/tasks/,
+ * loads its prompt + declared component set, and asserts:
+ *
+ * 1. The prompt does not contain any literal component name
+ *    (FORBIDDEN_LITERALS in signal-map.ts). The agent has to *choose*
+ *    components from the ask, not be told.
+ * 2. The set inferred from the prompt's signals is a superset of the
+ *    declared set, modulo `cwd-guard` (which is implicit for any
+ *    write-capable shape — rarely phrased in user prompts).
+ *
+ * Exits 0 if all tasks pass, 1 otherwise. Run via:
+ *   npm run validate-prompts
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { FRAMEWORK_ROOT } from "./lib/paths.ts";
+import { loadTestSpec, type CompositionExpectation } from "./lib/test-spec.ts";
+import {
+  findForbiddenLiterals,
+  inferComponentsFromPrompt,
+} from "./lib/signal-map.ts";
+import type { ComponentName } from "./lib/component-spec.ts";
+
+interface TaskReport {
+  task: string;
+  declared: ComponentName[];
+  inferred: ComponentName[];
+  missingFromPrompt: ComponentName[];
+  forbiddenHits: string[];
+  ok: boolean;
+}
+
+function main(): void {
+  const tasksDir = path.join(FRAMEWORK_ROOT, "task-runner", "tasks");
+  if (!fs.existsSync(tasksDir)) {
+    console.error(`tasks dir not found: ${tasksDir}`);
+    process.exit(2);
+  }
+
+  const reports: TaskReport[] = [];
+  const entries = fs.readdirSync(tasksDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!entry.name.startsWith("composer-")) continue;
+    const taskDir = path.join(tasksDir, entry.name);
+    const specPath = path.join(taskDir, "test.yaml");
+    if (!fs.existsSync(specPath)) continue;
+
+    const spec = loadTestSpec(taskDir);
+    if (spec.expectation.kind !== "composition") {
+      // GAP-kind composer tasks are out of scope for the prompt
+      // validator — a GAP prompt by definition has no declared set
+      // to compare against.
+      continue;
+    }
+    reports.push(validateTask(entry.name, spec.prompt, spec.expectation));
+  }
+
+  printReport(reports);
+  const failed = reports.filter((r) => !r.ok).length;
+  if (failed > 0) process.exit(1);
+}
+
+function validateTask(
+  task: string,
+  prompt: string,
+  expectation: CompositionExpectation,
+): TaskReport {
+  const declared = expectation.components as ComponentName[];
+  const inferredSet = inferComponentsFromPrompt(prompt);
+  const inferred = [...inferredSet];
+
+  // cwd-guard is implicit for any write-capable shape — declared
+  // cwd-guard is allowed even if the prompt doesn't trigger the
+  // sandbox-phrasing signal, when the rest of the declared set
+  // contains a write-capable component.
+  const declaredHasWriteCapable =
+    declared.includes("stage-write") || declared.includes("run-deferred-writer");
+  const missingFromPrompt = declared.filter((c) => {
+    if (inferredSet.has(c)) return false;
+    if (c === "cwd-guard" && declaredHasWriteCapable) return false;
+    return true;
+  });
+
+  const forbiddenHits = findForbiddenLiterals(prompt);
+  const ok = missingFromPrompt.length === 0 && forbiddenHits.length === 0;
+  return { task, declared, inferred, missingFromPrompt, forbiddenHits, ok };
+}
+
+function printReport(reports: TaskReport[]): void {
+  if (reports.length === 0) {
+    console.log("No composer-* tasks found — nothing to validate.");
+    return;
+  }
+  console.log(`Validated ${reports.length} composer task(s):\n`);
+  for (const r of reports) {
+    const status = r.ok ? "OK" : "FAIL";
+    console.log(`[${status}] ${r.task}`);
+    console.log(`  declared:  [${r.declared.join(", ")}]`);
+    console.log(`  inferred:  [${r.inferred.join(", ")}]`);
+    if (r.missingFromPrompt.length > 0) {
+      console.log(
+        `  missing from prompt: [${r.missingFromPrompt.join(", ")}]`,
+      );
+    }
+    if (r.forbiddenHits.length > 0) {
+      console.log(
+        `  forbidden literals in prompt: [${r.forbiddenHits.join(", ")}]`,
+      );
+    }
+    console.log("");
+  }
+  const failed = reports.filter((r) => !r.ok).length;
+  console.log(
+    `Summary: ${reports.length - failed}/${reports.length} passed${
+      failed > 0 ? `, ${failed} failed` : ""
+    }`,
+  );
+}
+
+main();

--- a/scripts/task-runner/tasks/composer-drafter-approval/test.yaml
+++ b/scripts/task-runner/tasks/composer-drafter-approval/test.yaml
@@ -1,0 +1,10 @@
+skill: pi-agent-composer
+expectation:
+  kind: composition
+  components: [cwd-guard, stage-write]
+  composition: single-spawn
+prompt: |
+  Write me an agent that writes to a file in buffer that waits for the
+  user to approve before the writes go through.
+probe:
+  args: " create a file hello-probe.md with the text hi"


### PR DESCRIPTION
## Summary

This PR introduces the `pi-agent-composer` skill, a parts-first alternative to the fixed-pattern `pi-agent-assembler`. Instead of picking one of five predefined patterns, the composer allows users to select any combination of five reusable components and automatically infers the composition topology from the selected set.

## Key Changes

### New Composer Skill & Components
- **`pi-agent-composer/` skill directory** with comprehensive documentation:
  - `SKILL.md`: Overview and cardinal rules for composition
  - `procedure.md`: Five-step composition workflow with signal-to-component mapping
  - `compositions.md`: Three topology types (single-spawn, sequential-phases-with-brief, rpc-delegator-over-concurrent-drafters)
  - `rails.md`: Twelve always-on validation rails
  - Component guides: `cwd-guard.md`, `stage-write.md`, `emit-summary.md`, `review.md`, `run-deferred-writer.md`

### Grader Implementation
- **`scripts/grader/graders/composer.ts`** (437 lines): Complete grader for composer tasks
  - Handles both "composition" and "gap" expectations
  - Validates structural layout, registration, subprocess rails, NDJSON parsing
  - Grades composition fidelity (declared components match spawned components)
  - Per-component wiring checks via `ComponentSpec` registry
  - Topology validation and load/behavioral probes
  - Artifact classification and discovery

### Component Specification System
- **`scripts/grader/lib/component-spec.ts`**: Registry of five components with:
  - `ComponentSpec` interface defining filename, tools contribution, and wiring checks
  - Per-component validation rules (e.g., cwd-guard requires `PI_SANDBOX_ROOT`, stage-write requires sha256 verification)
  - Context-aware checks (e.g., stage-write behavior differs when `review` is in the component set)
  - `forbiddenToolHits()` utility to flag unsafe tool allowlists (write, edit, bash)

### Signal-to-Component Mapping
- **`scripts/grader/lib/signal-map.ts`**: Hand-mirrored signal table with 30+ regex patterns
  - Maps user request phrases to component sets (e.g., "preview before writing" → stage-write)
  - Supports composition inference from prompt text
  - Identifies forbidden literals that would give away component names

### Prompt Validation Tool
- **`scripts/grader/validate-prompt.ts`**: Authoring-time linter for composer task prompts
  - Validates that prompts don't contain literal component names
  - Confirms inferred component set is a superset of declared set
  - Runs via `npm run validate-prompts`

### Test Infrastructure
- **`scripts/grader/__tests__/component-spec.test.ts`**: Comprehensive test suite
  - Tests composition inference cascade (run-deferred-writer → rpc-delegator, review → rpc-delegator, etc.)
  - Tests `isKnownComponent()` type guard
  - Tests `forbiddenToolHits()` detection
  - Tests per-component wiring checks with realistic code blobs

### Integration Updates
- **`scripts/grader/lib/test-spec.ts`**: Extended schema to support composition expectations
  - Added `CompositionExpectation` with components array and optional topology
  - Added `COMPOSITION_TOPOLOGIES` enum
  - Integrated with existing assembly/gap expectations
  
- **`scripts/grader/index.ts`**: Dispatcher for composer vs. assembler graders
  - Routes `pi-agent-composer` skill to `gradeComposerTask()`
  - Maintains backward compatibility with assembler grading

- **`scripts/grader/graders/assembler.ts`**: Added guard to reject non-assembly expectations

- **`scripts/grader/lib/types.ts`**: Extended `GradeJson.kind` to include "composition"

- **`package.json`**: Added `validate-prompts` npm script

### Example Task
- **`scripts/task-runner/tasks/composer-drafter

https://claude.ai/code/session_01LbzWyGmtqrVzPTNriNFQW9