### PR TITLE
Add Claude settings configuration for session startup hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          { "type": "command", "command": "npm install" }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This change introduces a Claude settings configuration file that defines hooks to be executed during session startup and resume events.

## Key Changes
- Added `.claude/settings.json` configuration file with SessionStart hooks
- Configured automatic `npm install` execution when a session starts or resumes
- This ensures dependencies are installed whenever the development environment is initialized or resumed

## Implementation Details
The settings file uses a hook matcher pattern to trigger the `npm install` command on both "startup" and "resume" events, helping maintain a consistent development environment state across session transitions.

https://claude.ai/code/session_01AxX4G4KQ8hqXSVqr7wDD71