### PR TITLE
Add parts-first plan: sibling pi-agent-composer skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,8 +65,20 @@ gitignored `.env` instead.
 ## Creating pi agents
 
 Pi ships no sub-agent feature by default. Use pi itself with one of
-two bundled skills; they split on "compose vs author":
+three bundled skills; they split on "emit YAML vs. compose-from-patterns
+vs. author-TS":
 
+- **`pi-agent-composer`** *(forward-looking, YAML)* — emits a
+  declarative YAML spec via the `emit_agent_spec` tool. The
+  auto-discovered runner (`pi-sandbox/.pi/extensions/yaml-agent-runner.ts`)
+  reads `.pi/agents/*.yml` and registers a slash command per spec,
+  dispatching each phase via `delegate()`. Covers `single-spawn`
+  and `sequential-phases-with-brief`; emits GAP for the
+  orchestrator topology. Driven by `npm run agent-composer` /
+  `:i`, which runs pi with the composer skill loaded and a tool
+  allowlist that exposes ONLY `read,ls,grep,emit_agent_spec` — no
+  write verbs, so the model cannot author code, only declare a
+  spec.
 - **`pi-agent-assembler`** — composes already-tested parts from
   `pi-sandbox/.pi/components/` (cwd-guard, stage-write, review)
   into agents matching one of four patterns: `recon`,
@@ -75,14 +87,17 @@ two bundled skills; they split on "compose vs author":
   safer path. If no pattern fits, the skill emits a GAP message
   and stops — that's the signal to fall back to the builder.
 - **`pi-agent-builder`** — from-scratch authorship. Use when the
-  assembler flagged a gap, or for shapes the assembler doesn't
-  cover (custom UI widgets, compaction strategies, event-only
+  assembler/composer flagged a gap, or for shapes neither covers
+  (custom UI widgets, compaction strategies, event-only
   extensions, context injection, session persistence, pi
-  packages).
+  packages, RPC orchestrator).
 
-Pick per-run via `-s <skill-name>` on `agent-maker.sh`. Default is
-`pi-agent-builder` for now — shift to assembler-first once it's
-settled.
+Pick per-run via `-s <skill-name>` on `agent-maker.sh` (assembler /
+builder), or via the dedicated `npm run agent-composer` script
+(composer). Default for `agent-maker.sh` is `pi-agent-builder`.
+The composer is the eventual replacement for `agent-maker.sh` once
+the assembler/builder skills also migrate to YAML output;
+`agent-maker.sh` stays in place until then.
 
 ### Invoking the skill
 
@@ -96,6 +111,11 @@ cwd. The shared `pi-sandbox/.pi/{extensions,components}/` is never
 touched, so concurrent invocations don't race.
 
 ```sh
+# Composer (YAML output, write-restricted spawn):
+npm run agent-composer -- -p "Drafter that stages writes for approval"
+npm run agent-composer:i                                 # interactive
+
+# Assembler / Builder (TS output via agent-maker):
 # One-shot (task-driven, auto-graded):
 npm run agent-maker -- recon-agent -m anthropic/claude-haiku-4.5 --grade
 
@@ -112,8 +132,12 @@ npm run agent-maker:i -- -m google/gemini-3-flash-preview
 scripts/task-runner/run-task.sh recon-agent -r my-label
 ```
 
-Both npm scripts source `models.env` first, so `$TASK_MODEL` etc. are
-already in scope.
+All three npm scripts source `models.env` first, so `$TASK_MODEL` etc.
+are already in scope.
+
+Composer output lands at `pi-sandbox/.pi/agents/<name>.yml`. The
+runner picks it up on the next pi startup; restart any active
+`npm run pi` session to register newly emitted slash commands.
 
 Legacy ad-hoc path (no isolation, no tool scoping — avoid for batch work):
 
@@ -399,7 +423,14 @@ generation), a separate class of issues surfaces:
     the parent. See `stage-write.ts` for the pattern. Distinct from
     pi's per-cwd `.pi/child-tools/` convention (which a generated
     extension writes to under its own cwd); this directory is the
-    repo's *curated* library.
+    repo's *curated* library. `emit-agent-spec.ts` is the one
+    parent-side outlier — loaded via `-e` into the composer pi
+    session, where its `execute()` writes YAML specs.
+  - `pi-sandbox/.pi/agents/` — composer-emitted YAML specs
+    (`.yml` per agent). Picked up by
+    `pi-sandbox/.pi/extensions/yaml-agent-runner.ts` on pi startup,
+    which registers one slash command per spec. Tracked in git
+    once intentional; `.pi/scratch/` covers throwaway runs.
   - `pi-sandbox/.pi/scratch/` — throwaway prompt files, raw pi output,
     anything you don't want to check in. Gitignored.
   - `pi-sandbox/skills/pi-agent-builder/` — pi skill that teaches pi how

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "pi": "bash -c 'set -a && source models.env && set +a && cd pi-sandbox && exec pi --no-context-files --provider openrouter \"$@\"' --",
     "agent-maker": "bash -c 'set -a && source models.env && set +a && exec scripts/task-runner/agent-maker.sh \"$@\"' --",
     "agent-maker:i": "bash -c 'set -a && source models.env && set +a && exec scripts/task-runner/agent-maker.sh --interactive \"$@\"' --",
+    "agent-composer": "bash -c 'set -a && source models.env && set +a && exec scripts/agent-composer.sh \"$@\"' --",
+    "agent-composer:i": "bash -c 'set -a && source models.env && set +a && exec scripts/agent-composer.sh -i \"$@\"' --",
     "reverse-pipeline": "bash -c 'set -a && source models.env && set +a && exec tsx scripts/reverse-pipeline/index.ts \"$@\"' --",
     "test:reverse-pipeline": "node --test --import tsx/esm scripts/reverse-pipeline/__tests__/*.test.ts",
     "test:grader": "node --test --import tsx/esm scripts/grader/__tests__/*.test.ts",

--- a/pi-sandbox/.pi/components/emit-agent-spec.ts
+++ b/pi-sandbox/.pi/components/emit-agent-spec.ts
@@ -1,0 +1,217 @@
+// emit-agent-spec.ts — output channel for the pi-agent-composer skill.
+//
+// Loaded into the PARENT pi session (the composer LLM) via `pi -e <path>`.
+// Unlike the other components in this directory — which ship a child-side
+// stub plus a parentSide harvester for `delegate()` to consume — this file
+// registers a real parent-side tool whose `execute()` writes a YAML spec
+// to `<PI_SANDBOX_ROOT>/.pi/agents/<spec.name>.yml`. The composer's tool
+// allowlist exposes ONLY `emit_agent_spec` plus read verbs, so the LLM
+// has no other write channel; the tool's TypeBox schema IS the YAML spec
+// shape, eliminating manual YAML formatting by the model.
+//
+// At runtime the file is read back by `.pi/extensions/yaml-agent-runner.ts`
+// (auto-discovered when pi runs in `pi-sandbox/`), which globs
+// `.pi/agents/*.yml` and registers one slash command per spec.
+//
+// No `parentSide` export — this is not a delegate()-driven component.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { StringEnum } from "@mariozechner/pi-ai";
+import { Type } from "typebox";
+import { stringify as yamlStringify } from "yaml";
+
+const COMPONENT_NAMES = [
+  "cwd-guard",
+  "stage-write",
+  "emit-summary",
+  "review",
+  "run-deferred-writer",
+] as const;
+
+const COMPOSITIONS = [
+  "single-spawn",
+  "sequential-phases-with-brief",
+] as const;
+
+const NAME_RE = /^[a-z][a-z0-9-]{1,40}$/;
+const SLASH_RE = /^[a-z][a-z0-9-]{1,40}$/;
+
+export default function (pi: ExtensionAPI) {
+  const ROOT = process.env.PI_SANDBOX_ROOT;
+  if (!ROOT) {
+    throw new Error("emit-agent-spec.ts: PI_SANDBOX_ROOT must be set");
+  }
+  const ROOT_ABS = path.resolve(ROOT);
+  const AGENTS_DIR = path.join(ROOT_ABS, ".pi", "agents");
+
+  pi.registerTool({
+    name: "emit_agent_spec",
+    label: "Emit Agent Spec",
+    description:
+      "Emit a composed agent specification as a YAML file. Use this IN " +
+      "PLACE of writing TypeScript by hand — you cannot author code in " +
+      "this session, only declare a spec. The runner extension reads " +
+      "the YAML and registers a slash command that wires the declared " +
+      "components via delegate(). Call exactly once per agent.",
+    parameters: Type.Object({
+      name: Type.String({
+        description:
+          "Spec filename (no extension, no path). Lowercase letters, " +
+          "digits, dashes; 2-41 chars. Becomes `.pi/agents/<name>.yml`.",
+      }),
+      slash: Type.String({
+        description:
+          "Slash command the runner will register, without leading `/`. " +
+          "Lowercase letters, digits, dashes; 2-41 chars.",
+      }),
+      description: Type.String({
+        description:
+          "One-line description shown in pi's slash-command help. " +
+          "Keep under 120 chars.",
+      }),
+      composition: StringEnum(COMPOSITIONS as unknown as string[], {
+        description:
+          "`single-spawn` for one child phase. " +
+          "`sequential-phases-with-brief` for a 2-phase scout→draft flow " +
+          "where the runner assembles a brief from phase-1 emit_summary " +
+          "calls and substitutes it into phase-2's prompt as `{brief}`. " +
+          "Orchestrator (RPC delegator) is NOT supported here — emit GAP " +
+          "for those asks.",
+      }),
+      phases: Type.Array(
+        Type.Object({
+          name: Type.Optional(
+            Type.String({
+              description:
+                "Optional phase label for logs (e.g. `scout`, `draft`).",
+            }),
+          ),
+          components: Type.Array(
+            StringEnum(COMPONENT_NAMES as unknown as string[]),
+            {
+              description:
+                "Components the runner imports as `parentSide` and passes " +
+                "to delegate(). cwd-guard is implicit for any write-capable " +
+                "phase but should still be listed explicitly.",
+              minItems: 1,
+              maxItems: 5,
+            },
+          ),
+          prompt: Type.String({
+            description:
+              "Prompt sent to the child for this phase. Supports template " +
+              "variables: `{args}` (the slash-command argument the user " +
+              "passes at runtime) and `{sandboxRoot}` (absolute path of " +
+              "the pi-sandbox cwd). For phase 2 of " +
+              "sequential-phases-with-brief, also `{brief}` (the assembled " +
+              "phase-1 summaries).",
+          }),
+        }),
+        { minItems: 1, maxItems: 2 },
+      ),
+    }),
+    async execute(_id, params) {
+      validateNames(params.name, params.slash);
+      validatePhases(
+        params.composition as (typeof COMPOSITIONS)[number],
+        params.phases,
+      );
+
+      const dest = path.join(AGENTS_DIR, `${params.name}.yml`);
+      const destReal = path.resolve(dest);
+      if (
+        destReal !== AGENTS_DIR &&
+        !destReal.startsWith(AGENTS_DIR + path.sep)
+      ) {
+        throw new Error(
+          `path escapes agents dir: ${params.name} -> ${destReal}`,
+        );
+      }
+      if (fs.existsSync(destReal)) {
+        throw new Error(
+          `${params.name}.yml already exists. Pick a different name; ` +
+            `existing specs are immutable in this session.`,
+        );
+      }
+
+      fs.mkdirSync(AGENTS_DIR, { recursive: true });
+      const yaml = yamlStringify(params, { lineWidth: 0 });
+      fs.writeFileSync(destReal, yaml, "utf8");
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Wrote spec to .pi/agents/${params.name}.yml. ` +
+              `Restart pi to register /${params.slash}.`,
+          },
+        ],
+        details: {
+          name: params.name,
+          path: destReal,
+          composition: params.composition,
+        },
+      };
+    },
+  });
+}
+
+function validateNames(name: string, slash: string): void {
+  if (!NAME_RE.test(name)) {
+    throw new Error(
+      `name must match ${NAME_RE} (lowercase + digits + dash, 2-41 chars): ${name}`,
+    );
+  }
+  if (!SLASH_RE.test(slash)) {
+    throw new Error(
+      `slash must match ${SLASH_RE} (lowercase + digits + dash, 2-41 chars): ${slash}`,
+    );
+  }
+}
+
+function validatePhases(
+  composition: (typeof COMPOSITIONS)[number],
+  phases: ReadonlyArray<{ components: string[] }>,
+): void {
+  for (const p of phases) {
+    if (p.components.includes("review") || p.components.includes("run-deferred-writer")) {
+      throw new Error(
+        "review and run-deferred-writer require the rpc-delegator " +
+          "topology, which the YAML composer does not cover. Emit a GAP " +
+          "message and instruct the user to load pi-agent-builder.",
+      );
+    }
+  }
+  if (composition === "single-spawn") {
+    if (phases.length !== 1) {
+      throw new Error(
+        `single-spawn requires exactly 1 phase, got ${phases.length}`,
+      );
+    }
+    return;
+  }
+  if (composition === "sequential-phases-with-brief") {
+    if (phases.length !== 2) {
+      throw new Error(
+        `sequential-phases-with-brief requires exactly 2 phases, got ${phases.length}`,
+      );
+    }
+    if (!phases[0].components.includes("emit-summary")) {
+      throw new Error(
+        "sequential-phases-with-brief: phase 1 must include `emit-summary` " +
+          "(the brief is built from its harvested summaries).",
+      );
+    }
+    if (!phases[1].components.includes("stage-write")) {
+      throw new Error(
+        "sequential-phases-with-brief: phase 2 must include `stage-write` " +
+          "(the brief is consumed by a drafter).",
+      );
+    }
+    return;
+  }
+  throw new Error(`unknown composition: ${composition}`);
+}

--- a/pi-sandbox/.pi/extensions/yaml-agent-runner.ts
+++ b/pi-sandbox/.pi/extensions/yaml-agent-runner.ts
@@ -1,0 +1,239 @@
+// yaml-agent-runner.ts — auto-discovered runtime for YAML agent specs
+// emitted by the pi-agent-composer skill.
+//
+// On extension load, globs `.pi/agents/*.yml` (relative to pi's cwd, which
+// is `pi-sandbox/` for every npm-script entry point), parses each, and
+// registers one slash command per spec. Each handler dispatches the
+// declared phases via `delegate()` from `../lib/delegate.ts`, mapping
+// component names to the canonical `parentSide` exports. For
+// `sequential-phases-with-brief`, the runner harvests phase-1
+// `emit_summary` calls into a bounded brief and substitutes it into
+// phase-2's prompt as `{brief}`.
+//
+// Orchestrator topology (rpc-delegator-over-concurrent-drafters) is NOT
+// runnable here — `delegate()` is single-spawn json-mode only. Specs
+// declaring it (or hand-edited specs requesting `review` /
+// `run-deferred-writer` components) are rejected at registration with a
+// pointer to pi-agent-builder. The composer's `emit_agent_spec` enforces
+// the same rule at write time; this is defense in depth for hand edits.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { parse as yamlParse } from "yaml";
+import { parentSide as CWD_GUARD } from "../components/cwd-guard.ts";
+import { parentSide as EMIT_SUMMARY } from "../components/emit-summary.ts";
+import { parentSide as STAGE_WRITE } from "../components/stage-write.ts";
+import type { EmitSummaryResult, ParentSide } from "../components/_parent-side.ts";
+import { delegate } from "../lib/delegate.ts";
+
+const AGENTS_DIR = path.resolve(process.cwd(), ".pi", "agents");
+const MAX_BRIEF_BYTES = 16_000;
+
+// Static name → parentSide map. Kept to the components a single-spawn or
+// sequential-phases-with-brief runner can actually drive: cwd-guard,
+// stage-write, emit-summary. Adding `review` / `run-deferred-writer`
+// here would not make them work — `delegate()` doesn't manage the RPC
+// loop they require — so they are rejected at validation time instead
+// (see `validateSpec`).
+const COMPONENTS: Record<string, ParentSide<any, unknown>> = {
+  "cwd-guard": CWD_GUARD,
+  "stage-write": STAGE_WRITE,
+  "emit-summary": EMIT_SUMMARY,
+};
+
+interface PhaseSpec {
+  name?: string;
+  components: string[];
+  prompt: string;
+}
+
+interface AgentSpec {
+  name: string;
+  slash: string;
+  description: string;
+  composition: "single-spawn" | "sequential-phases-with-brief";
+  phases: PhaseSpec[];
+}
+
+export default function (pi: ExtensionAPI) {
+  if (!fs.existsSync(AGENTS_DIR)) return;
+
+  const files = fs
+    .readdirSync(AGENTS_DIR)
+    .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+    .sort();
+
+  for (const file of files) {
+    const abs = path.join(AGENTS_DIR, file);
+    let spec: AgentSpec;
+    try {
+      const raw = fs.readFileSync(abs, "utf8");
+      spec = validateSpec(yamlParse(raw), file);
+    } catch (e) {
+      console.warn(
+        `[yaml-agent-runner] skipping ${file}: ${(e as Error).message}`,
+      );
+      continue;
+    }
+
+    pi.registerCommand(spec.slash, {
+      description: spec.description,
+      handler: async (args, ctx) => {
+        if (!args.trim()) {
+          ctx.ui.notify(
+            `Usage: /${spec.slash} <task description>`,
+            "warning",
+          );
+          return;
+        }
+        const sandboxRoot = path.resolve(process.cwd());
+        const baseSubs = { args: args.trim(), sandboxRoot };
+
+        if (spec.composition === "single-spawn") {
+          const phase = spec.phases[0];
+          await delegate(ctx, {
+            components: phase.components.map((n) => COMPONENTS[n]),
+            prompt: substitute(phase.prompt, baseSubs),
+          });
+          return;
+        }
+
+        // sequential-phases-with-brief
+        const scoutPhase = spec.phases[0];
+        const draftPhase = spec.phases[1];
+        const scoutResult = await delegate(ctx, {
+          components: scoutPhase.components.map((n) => COMPONENTS[n]),
+          prompt: substitute(scoutPhase.prompt, baseSubs),
+        });
+        const summaries =
+          (scoutResult.byComponent.get("emit-summary") as
+            | EmitSummaryResult
+            | undefined)?.summaries ?? [];
+        if (summaries.length === 0) {
+          ctx.ui.notify(
+            "scout phase emitted no summaries; aborting before drafter",
+            "error",
+          );
+          return;
+        }
+        const brief = summaries
+          .map((s) => `## ${s.title}\n${s.body}`)
+          .join("\n\n");
+        if (Buffer.byteLength(brief, "utf8") > MAX_BRIEF_BYTES) {
+          ctx.ui.notify(
+            `brief is ${Buffer.byteLength(brief, "utf8")} bytes > ${MAX_BRIEF_BYTES} budget; aborting`,
+            "error",
+          );
+          return;
+        }
+        await delegate(ctx, {
+          components: draftPhase.components.map((n) => COMPONENTS[n]),
+          prompt: substitute(draftPhase.prompt, { ...baseSubs, brief }),
+        });
+      },
+    });
+  }
+}
+
+function substitute(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  return template.replace(/\{(args|sandboxRoot|brief)\}/g, (m, key) => {
+    const v = vars[key];
+    return v === undefined ? m : v;
+  });
+}
+
+function validateSpec(raw: unknown, file: string): AgentSpec {
+  if (!raw || typeof raw !== "object") {
+    throw new Error(`${file}: not an object`);
+  }
+  const r = raw as Record<string, unknown>;
+  const name = expectString(r, "name", file);
+  const slash = expectString(r, "slash", file);
+  const description = expectString(r, "description", file);
+  const composition = expectString(r, "composition", file);
+  if (
+    composition !== "single-spawn" &&
+    composition !== "sequential-phases-with-brief"
+  ) {
+    throw new Error(
+      `${file}: composition "${composition}" not runnable here. ` +
+        `Only single-spawn and sequential-phases-with-brief are supported. ` +
+        `Use pi-agent-builder for orchestrator topologies.`,
+    );
+  }
+  const phasesRaw = r.phases;
+  if (!Array.isArray(phasesRaw) || phasesRaw.length === 0) {
+    throw new Error(`${file}: phases must be a non-empty array`);
+  }
+  const phases: PhaseSpec[] = phasesRaw.map((p, i) => {
+    if (!p || typeof p !== "object") {
+      throw new Error(`${file}: phases[${i}] is not an object`);
+    }
+    const pr = p as Record<string, unknown>;
+    const components = pr.components;
+    if (!Array.isArray(components) || components.length === 0) {
+      throw new Error(`${file}: phases[${i}].components must be non-empty`);
+    }
+    for (const c of components) {
+      if (typeof c !== "string") {
+        throw new Error(`${file}: phases[${i}].components has non-string entry`);
+      }
+      if (c === "review" || c === "run-deferred-writer") {
+        throw new Error(
+          `${file}: phases[${i}] declares "${c}", which requires the ` +
+            `RPC-delegator topology. Not runnable via delegate(). ` +
+            `Use pi-agent-builder.`,
+        );
+      }
+      if (!COMPONENTS[c]) {
+        throw new Error(
+          `${file}: phases[${i}] unknown component "${c}". ` +
+            `Known: ${Object.keys(COMPONENTS).join(", ")}.`,
+        );
+      }
+    }
+    const promptRaw = pr.prompt;
+    if (typeof promptRaw !== "string" || promptRaw.length === 0) {
+      throw new Error(`${file}: phases[${i}].prompt must be a non-empty string`);
+    }
+    const nameRaw = pr.name;
+    return {
+      name: typeof nameRaw === "string" ? nameRaw : undefined,
+      components: components as string[],
+      prompt: promptRaw,
+    };
+  });
+
+  if (composition === "single-spawn" && phases.length !== 1) {
+    throw new Error(
+      `${file}: single-spawn requires exactly 1 phase, got ${phases.length}`,
+    );
+  }
+  if (
+    composition === "sequential-phases-with-brief" &&
+    phases.length !== 2
+  ) {
+    throw new Error(
+      `${file}: sequential-phases-with-brief requires exactly 2 phases, ` +
+        `got ${phases.length}`,
+    );
+  }
+
+  return { name, slash, description, composition, phases };
+}
+
+function expectString(
+  r: Record<string, unknown>,
+  key: string,
+  file: string,
+): string {
+  const v = r[key];
+  if (typeof v !== "string" || v.length === 0) {
+    throw new Error(`${file}: missing or non-string "${key}"`);
+  }
+  return v;
+}

--- a/pi-sandbox/skills/pi-agent-composer/SKILL.md
+++ b/pi-sandbox/skills/pi-agent-composer/SKILL.md
@@ -1,40 +1,41 @@
 ---
 name: pi-agent-composer
-description: Composes pi agents from a committed library of components (cwd-guard, stage-write, emit-summary, review, run-deferred-writer) without being constrained to fixed patterns. Use this skill when the user wants to compose a pi-coding-agent extension parts-first — pick whichever components the ask requires and wire them with one of three composition topologies (single-spawn, sequential-phases-with-brief, rpc-delegator-over-concurrent-drafters). Trigger on phrases like "compose pi agent", "parts-first", "component-driven", "pi extension that uses cwd-guard / stage-write / emit-summary / review / run-deferred-writer", or any ask of the form "build a pi agent that uses X" / "pi extension with component Y". This skill does NOT author from scratch — if the ask doesn't decompose into the known components, it STOPS and emits a GAP message so the user can fall back to `pi-agent-builder`.
+description: Composes pi agents by emitting a YAML spec (components + per-phase prompts) via the `emit_agent_spec` tool. Use this skill when the user wants to compose a pi-coding-agent extension parts-first — pick whichever components the ask requires and declare them with one of two composition topologies (single-spawn, sequential-phases-with-brief). Trigger on phrases like "compose pi agent", "parts-first", "component-driven", "pi extension that uses cwd-guard / stage-write / emit-summary", or any ask of the form "build a pi agent that uses X". This skill does NOT author code — it emits a YAML spec the auto-discovered runner extension turns into a slash command. Orchestrator topology (RPC delegator + review + run-deferred-writer) is deferred — emit GAP for those asks. If the ask doesn't decompose into the runnable components, STOP and emit a GAP message so the user can fall back to `pi-agent-builder`.
 ---
 
 # Pi Agent Composer
 
-This skill composes agents by **picking components and wiring them
-with a composition topology**. It is the parts-first counterpart to
-`pi-agent-assembler`: where the assembler picks one of five fixed
-patterns, the composer picks any subset of the five components and
-infers the topology from the set.
+This skill composes agents by **picking components and emitting a
+YAML spec** via the `emit_agent_spec` tool. The runner extension
+(`pi-sandbox/.pi/extensions/yaml-agent-runner.ts`, auto-discovered)
+reads the YAML and registers a slash command that wires the
+declared components via `delegate()`.
 
-If the user's request cannot be expressed in terms of the known
-components, the skill **stops and emits a GAP message**. The gap
-message is the whole point: when the library can't cover a shape,
-you want that known rather than a confabulated extension.
+If the user's request cannot be expressed in terms of the runnable
+components and topologies, the skill **stops and emits a GAP
+message**. The gap message is the whole point: when the library
+can't cover a shape, you want that known rather than a
+confabulated agent.
 
 ## Cardinal rules
 
 1. **Compose, don't author.** The components in
    `pi-sandbox/.pi/components/` are the vocabulary. Do not invent
    new child-tools, new stub shapes, or new NDJSON harvesters
-   inside this skill.
-2. **`cwd-guard.ts` on every write-capable sub-pi spawn.** Every
-   generated agent that spawns a child pi process with a
-   write-capable tool in its allowlist MUST load
-   `pi-sandbox/.pi/components/cwd-guard.ts` via `-e <abs path>` and
-   pin `PI_SANDBOX_ROOT` in the child's env. The sole exception is
-   a read-only child whose only output channel is `emit_summary`
-   (no filesystem contact, no write verbs in the allowlist).
-3. **Output under `.pi/extensions/<name>.ts`, never the cwd root.**
-   Pi auto-discovers extensions from `.pi/extensions/` under its
-   cwd. A file at `./<name>.ts` loads as nothing; the user then
-   sees "no artifacts" even though the model produced correct
-   TypeScript. When invoking the sandboxed write tool, the `path`
-   argument must start with `.pi/extensions/`.
+   inside this skill. You also cannot author TypeScript — your
+   tool allowlist exposes `emit_agent_spec` plus read verbs only.
+2. **`cwd-guard` on every write-capable phase.** Every phase whose
+   `components` array includes a write-capable part (`stage-write`,
+   or any future direct-write component) MUST also include
+   `cwd-guard`. The runner pins `PI_SANDBOX_ROOT` automatically via
+   `cwd-guard`'s `parentSide.env`. The sole exception is a
+   read-only phase whose only output channel is `emit_summary`.
+3. **Output via `emit_agent_spec` only.** The tool writes
+   `.pi/agents/<name>.yml`; the runner picks it up on the next pi
+   startup. You cannot write `.ts`, `.yml`, or any other file
+   directly — you have no `write` / `edit` / `sandbox_write`
+   tools. A run that finishes without calling `emit_agent_spec`
+   produced nothing.
 
 ## Parts catalog
 
@@ -51,16 +52,23 @@ template" the parent extension copy-adapts).
 | `review.ts` | Stub reviewer verdict | A reviewer LLM renders `approve`/`revise` on staged drafts. Parent harvests verdicts; `approve` ⇒ promote, `revise` ⇒ re-dispatch the drafter with the feedback string. When `review` is in the component set, the LLM is the gate — no `ctx.ui.confirm` fires. |
 | `run-deferred-writer.ts` | Stub dispatch verb | A delegator LLM dispatches one drafter per call. Parent harvests `{task}` strings and runs drafter children in parallel via `Promise.all`. Pair with `review.ts` inside an RPC delegator session. |
 
+## Output channel
+
+The composer's only write tool is `emit_agent_spec` (loaded into
+the parent session via `pi -e .pi/components/emit-agent-spec.ts`).
+It validates the spec against composition rules and writes
+`.pi/agents/<name>.yml`. Detail in `parts/emit-agent-spec.md`.
+
 ## Compositions catalog
 
-Three topologies. Pick one based on the component set; full detail
-in `compositions.md`.
+Two runnable topologies plus one deferred. Pick one based on the
+component set; full detail in `compositions.md`.
 
-| Topology | When | Canonical reference |
+| Topology | When | What the runner does |
 | --- | --- | --- |
-| `single-spawn` | One child, one phase. Covers recon-style, confined-drafter, and drafter-with-approval shapes. | `pi-sandbox/.pi/extensions/deferred-writer.ts` — 41-line thin agent over `delegate()`. |
-| `sequential-phases-with-brief` | Two or more children run serially; parent assembles a brief from phase 1's `emit_summary` output and passes it into phase 2's prompt. | Two `delegate()` calls; see worked example in `compositions.md`. |
-| `rpc-delegator-over-concurrent-drafters` | Persistent RPC delegator LLM dispatches drafters via `run_deferred_writer` and reviews their drafts via `review`; LLM verdict is the gate. | `pi-sandbox/.pi/extensions/delegated-writer.ts` — delegator spawn stays custom (`--mode rpc`); drafter fan-out uses `delegate(autoPromote: false)`. |
+| `single-spawn` | One child, one phase. Covers recon-style, confined-drafter, and drafter-with-approval shapes. | One `delegate()` call. Reference: `pi-sandbox/.pi/extensions/deferred-writer.ts` (41-line thin agent over `delegate()`). |
+| `sequential-phases-with-brief` | Two phases run serially; the runner assembles a brief from phase 1's `emit_summary` output and substitutes it into phase 2's prompt as `{brief}`. | Two `delegate()` calls bracketing brief assembly. |
+| `rpc-delegator-over-concurrent-drafters` | Persistent RPC delegator LLM dispatches drafters via `run_deferred_writer` and reviews their drafts via `review`. | **Deferred — emit GAP.** `delegate()` is single-spawn json-mode only. Reference for hand-authored RPC: `pi-sandbox/.pi/extensions/delegated-writer.ts`. Use `pi-agent-builder`. |
 
 ## Always-on rails
 
@@ -86,18 +94,21 @@ worth the pause.
 - **Inventing a new component in a user session.** The library is
   closed; if a new child-tool shape is needed, that's a GAP, not
   an opportunity to improvise.
-- **Skipping cwd-guard on a write-capable child.** Non-negotiable
-  on every write-capable spawn; the one exception is a read-only +
-  `emit_summary`-only child. An agent that skips cwd-guard while
-  handing the child `sandbox_write` / `write` / `edit` / `bash` is
-  unsafe no matter how narrow the task looks.
+- **Trying to write TypeScript.** You have no `write` / `edit` /
+  `sandbox_write` tools. The only way to commit a result is
+  `emit_agent_spec`. A finished session that didn't call it
+  produced nothing.
+- **Skipping cwd-guard on a write-capable phase.** Non-negotiable
+  on every phase whose components include `stage-write` or any
+  future direct-write part. The one exception is a read-only
+  phase whose only output channel is `emit_summary`.
+- **Declaring `review` or `run-deferred-writer` in a phase.**
+  `emit_agent_spec` rejects these and the runner refuses to
+  register the resulting spec. The orchestrator topology lives in
+  `pi-agent-builder`'s scope.
 - **Skipping the `rails.md` checklist.** Rails encode the always-on
   defaults from `pi-agent-builder/references/defaults.md`. Drift
   here re-introduces bugs the components were written to prevent.
-- **Mixing composition topologies in one handler.** A single
-  command dispatches one topology. If the user wants both an
-  RPC-delegator and a separate drafter-with-approval flow, that's
-  two slash commands.
 
 ## When to fall back to pi-agent-builder
 

--- a/pi-sandbox/skills/pi-agent-composer/compositions.md
+++ b/pi-sandbox/skills/pi-agent-composer/compositions.md
@@ -1,8 +1,24 @@
 # Compositions
 
-Three topologies. Pick one with the cascade in `procedure.md` §3.
-Each entry below names the canonical reference (a working extension
-that already implements every rail) and the rails that apply.
+Two topologies the YAML composer can emit. Pick one with the cascade
+in `procedure.md` §3. The third — `rpc-delegator-over-concurrent-drafters`
+— is **deferred**; the composer emits GAP for it (see §"orchestrator"
+below).
+
+The runner that consumes these YAML specs lives at
+`pi-sandbox/.pi/extensions/yaml-agent-runner.ts`. It auto-discovers when
+pi runs in `pi-sandbox/`, globs `.pi/agents/*.yml`, and registers one
+slash command per spec.
+
+## Template variables
+
+Phase prompts may reference these — the runner substitutes them just
+before each `delegate()` call:
+
+- `{args}` — the slash-command argument the user passes at runtime.
+- `{sandboxRoot}` — absolute path of the pi-sandbox cwd.
+- `{brief}` — phase 2 of `sequential-phases-with-brief` only; built
+  from phase 1's `emit_summary` calls, capped at 16 KB.
 
 ## single-spawn
 
@@ -14,112 +30,76 @@ that already implements every rail) and the rails that apply.
   - `[emit-summary]` — recon, no write channel.
   - `[cwd-guard]` — confined drafter; child writes directly.
   - `[cwd-guard, stage-write]` — drafter with approval (human gate).
-  - `[cwd-guard, stage-write, review]` — drafter with LLM review
-    gate, no fan-out (`run-deferred-writer ∉ components`).
-- **Canonical reference:** a single `delegate()` call from
-  `pi-sandbox/.pi/lib/delegate.ts`. The shared runtime owns the
-  subprocess rails (spawn frame, NDJSON loop, timeout, cost
-  extraction, path validation, confirm/promote). The generated
-  extension body is the slash-command registration + one
-  `await delegate(ctx, { components, prompt })`. Reference
-  implementation: `pi-sandbox/.pi/extensions/deferred-writer.ts`
-  (41 lines after the Phase 2.3 refactor).
-
-  ```ts
-  await delegate(ctx, {
-    components: [CWD_GUARD, STAGE_WRITE],   // substitute declared set
-    prompt,
-  });
+- **YAML to emit:**
+  ```yaml
+  name: my-drafter
+  slash: my-drafter
+  description: Drafts files; user approves before disk
+  composition: single-spawn
+  phases:
+    - components: [cwd-guard, stage-write]
+      prompt: |
+        You are a DRAFTER. Task: {args}.
+        Stage files via stage_write under {sandboxRoot}.
+        Reply DONE when finished.
   ```
-
-  For `[emit-summary]` (read-only recon) drop `CWD_GUARD` —
-  `delegate()` infers `$TASK_MODEL` and the emit-summary
-  harvester; the caller then persists
-  `result.byComponent.get("emit-summary").summaries` to
-  `.pi/scratch/<title>.md`. For `[cwd-guard]` (confined drafter)
-  drop `STAGE_WRITE` — the child writes directly via
-  `sandbox_write`.
-- **Rails that apply:** 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12. Rail 11
-  (dashboard) does NOT apply — no fan-out state to track.
+- **What the runner does:** one `delegate()` call. Component name →
+  `parentSide` resolution from a static map; tier inference picks
+  `$TASK_MODEL` (no `review` / `run-deferred-writer` present).
+- **Confirm/promote gate:** auto-applied by `delegate()` when
+  `stage-write ∈ components` (rails.md §10).
 
 ## sequential-phases-with-brief
 
 - **When:** scout-then-draft. Phase 1 child surveys via
-  `emit_summary`; parent assembles a brief from the harvested
-  summaries; phase 2 drafter spawn receives the brief in-prompt and
-  stages writes via `stage_write`.
-- **Component sets that infer to this:** `[cwd-guard, emit-summary,
-  stage-write]` (when `review ∉ components` and
-  `run-deferred-writer ∉ components`).
-- **Canonical reference:** two `delegate()` calls — one per phase
-  — with the brief assembled in between. The scout call uses
-  `[EMIT_SUMMARY]` (no cwd-guard, read-only child). The drafter
-  call uses `[CWD_GUARD, STAGE_WRITE]` and receives the brief
-  interpolated into its prompt.
+  `emit_summary`; the runner assembles a brief from harvested
+  summaries; phase 2 drafter receives the brief in-prompt as
+  `{brief}` and stages writes via `stage_write`.
+- **Required component sets (enforced by `emit_agent_spec`):**
+  phase 1 must include `emit-summary`; phase 2 must include
+  `stage-write`.
+- **YAML to emit:**
+  ```yaml
+  name: scout-then-draft
+  slash: scout-then-draft
+  description: Survey {args}, then draft missing pieces
+  composition: sequential-phases-with-brief
+  phases:
+    - name: scout
+      components: [emit-summary]
+      prompt: |
+        Survey {args}. Use emit_summary for each finding.
+    - name: draft
+      components: [cwd-guard, stage-write]
+      prompt: |
+        Task: {args}
 
-  ```ts
-  const scout = await delegate(ctx, {
-    components: [EMIT_SUMMARY],
-    prompt: `Survey ${target}. Use emit_summary for each finding.`,
-  });
-  const summaries =
-    (scout.byComponent.get("emit-summary") as
-      | { summaries: { title: string; body: string }[] }
-      | undefined)?.summaries ?? [];
-  const brief = summaries
-    .map((s) => `## ${s.title}\n${s.body}`)
-    .join("\n\n");
-  if (Buffer.byteLength(brief, "utf8") > BRIEF_MAX_BYTES /* typ. 16 KB */) {
-    ctx.ui.notify("brief exceeds budget; aborting", "error");
-    return;
-  }
+        <brief>
+        {brief}
+        </brief>
 
-  await delegate(ctx, {
-    components: [CWD_GUARD, STAGE_WRITE],
-    prompt: `${userTask}\n\n<brief>\n${brief}\n</brief>`,
-  });
-  // delegate() runs the rails.md §10 confirm/promote gate
-  // automatically because review ∉ components on this spawn.
+        Stage missing pieces under {sandboxRoot}. Reply DONE.
   ```
+- **What the runner does:** phase-1 `delegate()`, harvest
+  `byComponent.get("emit-summary").summaries`, build the brief
+  (cap 16 KB byte length, abort with notify if exceeded), template-
+  substitute `{brief}` into phase-2's prompt, phase-2 `delegate()`.
+- **Confirm/promote gate:** auto-applied on phase 2 (`stage-write`
+  present, `review` absent).
 
-- **Rails that apply:** all single-spawn rails plus a bounded brief
-  size (`Buffer.byteLength(brief, "utf8") <= BRIEF_MAX_BYTES`,
-  typically 16 KB) before the second spawn.
-
-## rpc-delegator-over-concurrent-drafters
+## orchestrator (deferred — emit GAP)
 
 - **When:** persistent RPC delegator LLM dispatches multiple
   drafters via `run_deferred_writer` and reviews their drafts via
   `review`; LLM verdict is the gate, not human confirm.
-- **Component sets that infer to this:**
-  - `[cwd-guard, stage-write, review, run-deferred-writer]` — full
-    orchestrator.
-  - Any set containing `run-deferred-writer` (always RPC).
-  - Any set containing `review` and not the above
-    sequential-phases-with-brief shape (per the cascade ordering;
-    catches `[cwd-guard, stage-write, review]` — single-drafter
-    LLM-gated, RPC delegator dispatches one drafter).
-- **Canonical reference:** `pi-sandbox/.pi/extensions/delegated-writer.ts`
-  lines 270–385 (RPC session management),
-  513–578 (dispatch fan-out via `Promise.all`),
-  623–666 (review verdict harvest + per-task feedback map).
-- **Rails that apply:** all single-spawn rails plus rail 11
-  (dashboard). The delegator spawn uses `--mode rpc` (not `--mode
-  json`); drafter spawns inside the dispatch handler use `--mode
-  json` as in single-spawn.
-
-## Composing the fragments
-
-This file is the jumping-off point — no full TypeScript skeletons
-live here. The canonical extensions (`deferred-writer.ts`,
-`delegated-writer.ts`) are always in scope as references, and each
-component's `parts/<name>.md` carries the parent-side wiring
-fragment (event anchor, args destructuring, accumulator shape,
-finalize behavior). The composer assembles those fragments under
-the chosen topology, following the rails checklist in `rails.md`.
-
-If a topology choice is ambiguous (the cascade gives one answer
-but the user's prose suggests another), prefer the cascade and
-note the implicit topology in a one-line comment at the top of the
-generated extension. The grader emits a P1 warning for implicit
-topology choices, surfacing them for review.
+- **Component sets that would imply this:** any set containing
+  `review` or `run-deferred-writer`.
+- **Status:** the YAML runner cannot drive an RPC session —
+  `delegate()` is single-spawn json-mode only, and the orchestrator
+  needs a persistent `--mode rpc` channel with phase-dependent
+  prompts (see `pi-sandbox/.pi/extensions/delegated-writer.ts`).
+  Both `emit_agent_spec` and the runner reject these component
+  sets.
+- **What to do:** the composer skill emits GAP via procedure.md
+  step 5 and instructs the user to load `pi-agent-builder` for the
+  orchestrator shape. Do NOT attempt to express it in YAML.

--- a/pi-sandbox/skills/pi-agent-composer/parts/emit-agent-spec.md
+++ b/pi-sandbox/skills/pi-agent-composer/parts/emit-agent-spec.md
@@ -1,0 +1,92 @@
+# Component: `emit-agent-spec.ts`
+
+**Location:** `pi-sandbox/.pi/components/emit-agent-spec.ts`
+
+## What it does
+
+Pi extension loaded into the **parent** composer session via
+`pi -e <path>`. Registers a single tool `emit_agent_spec` whose
+TypeBox schema IS the YAML spec shape. The tool's `execute()` is
+**not** a stub — it validates the args against composition rules
+and writes `<PI_SANDBOX_ROOT>/.pi/agents/<spec.name>.yml`.
+
+Differs from every other component in this catalog: it is loaded
+into the parent, not delegated to a child, and has no `parentSide`
+export. The composer LLM calls it directly.
+
+## When to use
+
+- **Always.** It is the composer's only output channel. The
+  `agent-composer.sh` tool allowlist exposes `emit_agent_spec`
+  plus read verbs — there is no other way to commit a result.
+
+## When NOT to use
+
+- Never inside a phase declaration. `emit_agent_spec` is parent-
+  side; child phases use the canonical five components
+  (cwd-guard, stage-write, emit-summary, review, run-deferred-writer).
+
+## Tool schema (call it like this)
+
+```
+emit_agent_spec({
+  name: "<filename-no-ext>",         // [a-z][a-z0-9-]{1,40}
+  slash: "<slash-command-no-prefix>",// [a-z][a-z0-9-]{1,40}
+  description: "<one-line>",         // shown in pi's /help
+  composition: "single-spawn" | "sequential-phases-with-brief",
+  phases: [
+    {
+      name: "<optional log label>",
+      components: ["cwd-guard", "stage-write", ...],
+      prompt: "<phase prompt with template vars>",
+    },
+    // up to 2 phases
+  ],
+})
+```
+
+## Validation rules (enforced by `execute`)
+
+- `single-spawn` → exactly 1 phase.
+- `sequential-phases-with-brief` → exactly 2 phases. Phase 1 must
+  include `emit-summary`; phase 2 must include `stage-write`.
+- `review` and `run-deferred-writer` are **rejected** with a
+  pointer to `pi-agent-builder` — the YAML composer does not
+  cover the orchestrator topology.
+- `name` collision with an existing `.pi/agents/<name>.yml` is
+  rejected (specs are immutable in a session — pick a new name).
+- Path validation against `$PI_SANDBOX_ROOT` rejects `..` segments
+  and absolute paths.
+
+## Template variables (substituted by the runner at call time)
+
+- `{args}` — the slash-command argument the user passes when
+  invoking the agent.
+- `{sandboxRoot}` — absolute path of the pi-sandbox cwd.
+- `{brief}` — phase 2 of `sequential-phases-with-brief` only;
+  built from phase 1's `emit_summary` calls, capped at 16 KB.
+
+Use them inside the `prompt:` strings; the runner replaces them
+just before each `delegate()` call.
+
+## Required `--tools` allowlist contribution
+
+`emit_agent_spec`. The composer harness adds `read,ls,grep`
+alongside; no write verbs are exposed.
+
+## Parent-side wiring
+
+None — this component does not have a `parentSide` export. The
+composer harness loads it via `-e` directly into the parent pi
+session.
+
+## What the runner does with the YAML
+
+Once `<name>.yml` exists, the auto-discovered
+`pi-sandbox/.pi/extensions/yaml-agent-runner.ts` registers
+`/<spec.slash>` on the next pi startup. The handler imports the
+declared components' `parentSide` exports from a static map and
+dispatches each phase via `delegate()`. The runner refuses to
+register specs with composition values it cannot drive
+(`rpc-delegator-over-concurrent-drafters`) or with components it
+cannot wire (`review`, `run-deferred-writer`).

--- a/pi-sandbox/skills/pi-agent-composer/procedure.md
+++ b/pi-sandbox/skills/pi-agent-composer/procedure.md
@@ -48,153 +48,120 @@ If a signal points at a component the library doesn't have (e.g.
 
 ## 3. Pick composition topology
 
-`compositions.md` names three. Apply this cascade in order; the
-first match wins:
+`compositions.md` names two the YAML composer can emit. Apply this
+cascade in order; the first match wins:
 
 ```
-if run-deferred-writer ∈ components        → rpc-delegator-over-concurrent-drafters
-else if review ∈ components                → rpc-delegator-over-concurrent-drafters
+if run-deferred-writer ∈ components        → GAP (orchestrator deferred)
+else if review ∈ components                → GAP (orchestrator deferred)
 else if emit-summary ∈ components && stage-write ∈ components
                                            → sequential-phases-with-brief
 else                                       → single-spawn
 ```
 
-The `review`-before-emit-summary+stage-write ordering matters:
-without it, a `[cwd-guard, stage-write, review]` set (single
-drafter + LLM review, no RPC delegator, no fan-out) gets
-mis-inferred as `sequential-phases-with-brief`. Reviewing a single
-drafter's output is still RPC-delegator topology — the delegator
-just dispatches one drafter and reviews one draft.
+The `review` / `run-deferred-writer` branches go straight to step 5
+because the YAML runner cannot drive an RPC delegator session —
+both `emit_agent_spec` and the runner reject those components. Do
+NOT try to express orchestrator shapes in YAML; the gap message
+points the user at `pi-agent-builder`, which authors RPC
+extensions from primitives.
 
-If none of the three topologies fits the user's ask (e.g. the user
+If neither remaining topology fits the user's ask (e.g. the user
 wants a fire-and-forget background drafter with no parent
 harvesting), go to step 5.
 
-## 4. Wire it
+## 4. Emit the spec
 
-Emit a thin extension at `.pi/extensions/<name>.ts` that imports
-the declared components' `parentSide` values and calls the
-`delegate()` runtime from `../lib/delegate.ts`. `delegate()` owns
-every subprocess rail (spawn frame, NDJSON loop, timeout, cost,
-path validation, confirm/promote per rails.md §10) so the
-extension body collapses to the slash-command registration and a
-single `delegate()` call.
+Call `emit_agent_spec` exactly once with the structured fields.
+The tool's TypeBox schema IS the YAML spec shape — you cannot
+write YAML or TypeScript by hand. The tool writes
+`.pi/agents/<name>.yml`; the auto-discovered runner registers
+`/<slash>` on the next pi startup and dispatches each phase via
+`delegate()`.
 
-### Template (single-spawn — covers `[emit-summary]`,
+Phase prompts may use `{args}` (the slash-command argument the
+user passes at runtime), `{sandboxRoot}` (absolute path of
+pi-sandbox), and — phase 2 of `sequential-phases-with-brief` only
+— `{brief}` (assembled from phase-1 `emit_summary` calls).
+
+### Example (single-spawn — covers `[emit-summary]`,
 ### `[cwd-guard]`, `[cwd-guard, stage-write]`)
 
-```ts
-import path from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { parentSide as CWD_GUARD } from "../components/cwd-guard.ts";
-import { parentSide as STAGE_WRITE } from "../components/stage-write.ts";
-import { delegate } from "../lib/delegate.ts";
-
-export default function (pi: ExtensionAPI) {
-  pi.registerCommand("<slug>", {
-    description: "<short description>",
-    handler: async (args, ctx) => {
-      if (!args.trim()) {
-        ctx.ui.notify("Usage: /<slug> <task>", "warning");
-        return;
-      }
-      const sandboxRoot = path.resolve(process.cwd());
-      const prompt = `<agent instructions referencing ${sandboxRoot}>`;
-      await delegate(ctx, {
-        components: [CWD_GUARD, STAGE_WRITE],  // ← declared set
-        prompt,
-      });
-    },
-  });
-}
+```
+emit_agent_spec({
+  name: "<filename>",
+  slash: "<slash-command-no-leading-/>",
+  description: "<one line>",
+  composition: "single-spawn",
+  phases: [
+    {
+      components: ["cwd-guard", "stage-write"],   // ← declared set
+      prompt: "You are a DRAFTER. Task: {args}. Stage files via stage_write under {sandboxRoot}. Reply DONE when finished."
+    }
+  ]
+})
 ```
 
-Substitute the `components` array for the declared component set.
-Drop `CWD_GUARD` from both the import and the array when the set
-is `[emit-summary]` (read-only recon, no write channel). The
-`delegate()` call's tier inference picks `$TASK_MODEL` or
-`$LEAD_MODEL` automatically based on whether `review` or
-`run-deferred-writer` are in the set — no `--model` override
-needed in the composer's output.
+Drop `cwd-guard` from the array when the set is `[emit-summary]`
+(read-only recon, no write channel). The runner's `delegate()`
+calls infer the model tier automatically — `$TASK_MODEL` here
+because neither `review` nor `run-deferred-writer` are present.
 
-### Template (sequential-phases-with-brief — covers
+### Example (sequential-phases-with-brief — covers
 ### `[cwd-guard, emit-summary, stage-write]`)
 
-Two `delegate()` calls. Harvest phase-1 summaries from
-`byComponent.get("emit-summary")`, assemble into a brief with a
-bounded byte-length, and interpolate into phase-2's prompt. The
-same `export default function(pi) { pi.registerCommand(...) }`
-shell wraps the body — do NOT substitute `export async function
-handler(ctx)` or `export const handler = …`; pi's loader only
-calls the default export, and anything else silently registers
-no command (grader reports it as "command not registered").
-Always include the empty-args short-circuit so the load probe
-(which invokes `/<slug>` with no args) exits cleanly without
-triggering either phase's LLM call.
-
-```ts
-export default function (pi: ExtensionAPI) {
-  pi.registerCommand("<slug>", {
-    description: "<short description>",
-    handler: async (args, ctx) => {
-      if (!args.trim()) {
-        ctx.ui.notify("Usage: /<slug> <target>", "warning");
-        return;
-      }
-      const target = args.trim();
-
-      const scout = await delegate(ctx, {
-        components: [EMIT_SUMMARY],           // read-only scout, no CWD_GUARD
-        prompt: `Survey ${target}. Use emit_summary for each finding.`,
-      });
-      const summaries =
-        (scout.byComponent.get("emit-summary") as
-          | { summaries: { title: string; body: string }[] }
-          | undefined)?.summaries ?? [];
-      const brief = summaries
-        .map((s) => `## ${s.title}\n${s.body}`)
-        .join("\n\n");
-      if (Buffer.byteLength(brief, "utf8") > 16_000) {
-        ctx.ui.notify("brief exceeds budget; aborting", "error");
-        return;
-      }
-      await delegate(ctx, {
-        components: [CWD_GUARD, STAGE_WRITE],
-        prompt: `${target}\n\n<brief>\n${brief}\n</brief>`,
-      });
+```
+emit_agent_spec({
+  name: "<filename>",
+  slash: "<slash-command>",
+  description: "<one line>",
+  composition: "sequential-phases-with-brief",
+  phases: [
+    {
+      name: "scout",
+      components: ["emit-summary"],          // read-only; no cwd-guard
+      prompt: "Survey {args}. Use emit_summary for each finding."
     },
-  });
-}
+    {
+      name: "draft",
+      components: ["cwd-guard", "stage-write"],
+      prompt: "Task: {args}\n\n<brief>\n{brief}\n</brief>\n\nStage missing pieces under {sandboxRoot}. Reply DONE."
+    }
+  ]
+})
 ```
 
-### rpc-delegator-over-concurrent-drafters
+The runner enforces phase-1 ⊇ `{emit-summary}` and phase-2 ⊇
+`{stage-write}` for this composition. Any `{brief}` reference
+outside phase 2 of `sequential-phases-with-brief` is left
+unsubstituted at runtime.
 
-Does NOT use `delegate()` for the delegator spawn — `delegate()` is
-json-mode only, the delegator needs `--mode rpc` with a persistent
-stdin channel driven through multiple phases. The drafter spawns
-inside the orchestrator's `Promise.all` DO go through
-`delegate(autoPromote: false)`; after review, promotion uses the
-exported `promote()` helper. Reference
-`pi-sandbox/.pi/extensions/delegated-writer.ts` for the whole
-shape; this composer emits a copy-adapted skeleton of it.
+### orchestrator (deferred — emit GAP)
+
+`emit_agent_spec` rejects any phase containing `review` or
+`run-deferred-writer`. The runner cannot drive an RPC delegator
+session — that topology stays in `pi-agent-builder`'s scope. If
+the user's ask requires fan-out + LLM review, jump to step 5
+(GAP) instead of trying to express it in YAML.
 
 ## 5. Flag the gap
 
 When step 1 produces no confident match, step 2 reveals a missing
-component, or step 3 has no fitting topology, emit EXACTLY this
+component, step 3 cascades to the orchestrator branch (the YAML
+runner doesn't drive RPC), or no topology fits, emit EXACTLY this
 message and stop:
 
 ```
 GAP: I don't have a component for "<user's ask, quoted>".
 Components I have: cwd-guard, stage-write, emit-summary, review, run-deferred-writer.
 Closest match: <"none" OR nearest part/topology + 1-sentence why it doesn't quite fit>.
-To cover this you'd need: <one sentence describing the missing part>.
+To cover this you'd need: <one sentence describing the missing part, OR "the YAML composer doesn't cover orchestrator topology yet — load pi-agent-builder">.
 To continue anyway, load the pi-agent-builder skill.
 ```
 
-Do NOT then go on to write an extension. The gap message is the
-whole deliverable. The user will decide whether to reshape the ask
-into the existing components or fall back to `pi-agent-builder`.
+Do NOT then call `emit_agent_spec`. The gap message is the whole
+deliverable. The user will decide whether to reshape the ask into
+the existing components or fall back to `pi-agent-builder`.
 
 The `GAP:` header and `I don't have a component` phrase are
 byte-identical to the assembler's GAP message. Both graders share

--- a/pi-sandbox/skills/pi-agent-composer/rails.md
+++ b/pi-sandbox/skills/pi-agent-composer/rails.md
@@ -6,33 +6,43 @@ Each cites the corresponding section in
 than re-prosing the rule; the grader (`scripts/grader/graders/composer.ts`)
 asserts each one.
 
-## Who owns each rail after Phase 2.2
+## Who owns each rail in the YAML composer
 
 `pi-sandbox/.pi/lib/delegate.ts` — the shared runtime — owns
 rails **1, 2, 3, 4, 5, 6, 7, 8, 9, 10, and 12** for every
-`single-spawn` and `sequential-phases-with-brief` composition:
-the thin agent you emit contains an `import` + one `delegate(ctx,
-{ components, prompt })` call; the library enforces the rail
-mechanics. The grader short-circuits those rails to pass when it
-detects the delegate() shape (see §2.5 of
-`parts-first-plan/40-components-heavy-phase2.md`).
+`single-spawn` and `sequential-phases-with-brief` composition.
+The runner extension (`pi-sandbox/.pi/extensions/yaml-agent-runner.ts`)
+calls `delegate()` once per phase, so the library enforces the
+rail mechanics on the YAML's behalf — no wiring escapes into the
+spec file.
 
-Thin-agent authorship responsibilities collapse to:
+`emit_agent_spec` and the runner together own:
 
-- **rail 11 (dashboard)** — applies only to the
-  `rpc-delegator-over-concurrent-drafters` topology, which keeps
-  its custom RPC loop. The drafter fan-out inside that loop goes
-  through `delegate(autoPromote: false)` and then `promote()`;
-  the delegator spawn + `ctx.ui.setWidget`/`setStatus` updates
-  stay hand-rolled.
-- **choosing the component set correctly** — the rest of this
-  procedure (steps 1–3) covers this.
+- **input validation** — `emit_agent_spec` rejects orphan
+  components, missing phase fields, and `review` /
+  `run-deferred-writer` declarations (those require the deferred
+  RPC topology).
+- **template substitution** — the runner substitutes `{args}`,
+  `{sandboxRoot}`, and (phase 2 only) `{brief}` before each
+  `delegate()` call.
+- **brief budget** — the runner aborts if the assembled brief
+  exceeds 16 KB before spawning phase 2.
 
-The per-rail table below still describes the *mechanics*; treat
-it as the library's contract, not your own checklist. If you find
-yourself writing inline spawn/NDJSON code for a single-spawn or
-sequential-phases agent, stop — you're drifting back toward
-pre-2.2 authorship.
+Composer-skill authorship responsibilities collapse to:
+
+- **picking the component set correctly** — steps 1–3 of
+  `procedure.md`.
+- **writing prompts that hold their own** — the YAML's `prompt:`
+  fields are the only thing the model gets to write. Make them
+  task-shaped and reference the template variables explicitly.
+
+Rail **11 (dashboard)** does not apply — it is orchestrator-only,
+and the orchestrator topology is deferred (composer emits GAP).
+
+The per-rail table below describes the *mechanics* the runtime
+enforces; treat it as the library's contract, not your own
+checklist. If you find yourself wanting to author TS, stop — you
+have no write tool, and the YAML spec is the entire deliverable.
 
 | # | Rail | Cite |
 | --- | --- | --- |

--- a/scripts/agent-composer.sh
+++ b/scripts/agent-composer.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# agent-composer.sh — drive the pi-agent-composer skill in a tight,
+# write-restricted pi spawn whose only output channel is the
+# `emit_agent_spec` tool. Output lands at
+# pi-sandbox/.pi/agents/<spec.name>.yml and is picked up by the
+# auto-discovered yaml-agent-runner extension on the next pi run.
+#
+# Standalone — does NOT wrap scripts/task-runner/agent-maker.sh.
+# agent-maker is the legacy author-the-TS path used by pi-agent-builder
+# and pi-agent-assembler; agent-composer is the forward-looking emit-the-
+# YAML path. They share patterns but no code.
+#
+# Usage:
+#   agent-composer.sh -p "<prompt>"  [-m <model>]
+#   agent-composer.sh -i             [-m <model>]
+#
+# Examples:
+#   agent-composer.sh -p "Drafter that stages writes for approval"
+#   agent-composer.sh -i -m google/gemini-3-flash-preview
+#
+# The npm wrapper (`npm run agent-composer`) sources models.env first so
+# $TASK_MODEL is in scope. Direct invocation needs the same.
+
+set -euo pipefail
+
+INTERACTIVE=0
+PROMPT=""
+MODEL_OVERRIDE=""
+
+usage() { sed -n '2,23p' "$0"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -i|--interactive) INTERACTIVE=1; shift ;;
+    -p) PROMPT="$2"; shift 2 ;;
+    -m) MODEL_OVERRIDE="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "Unknown flag: $1" >&2; usage >&2; exit 2 ;;
+    *) echo "Unexpected positional arg: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ $INTERACTIVE -eq 0 && -z "$PROMPT" ]]; then
+  echo "Need either -i (interactive) or -p \"<prompt>\" (one-shot)." >&2
+  usage >&2
+  exit 2
+fi
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+SANDBOX="$REPO/pi-sandbox"
+EMIT="$SANDBOX/.pi/components/emit-agent-spec.ts"
+SKILL="$SANDBOX/skills/pi-agent-composer"
+
+if [[ -z "${OPENROUTER_API_KEY:-}" ]]; then
+  echo "OPENROUTER_API_KEY not set; pi cannot call openrouter." >&2
+  exit 1
+fi
+
+if [[ -z "${TASK_MODEL:-}" && -f "$REPO/models.env" ]]; then
+  # shellcheck disable=SC1091
+  set -a; source "$REPO/models.env"; set +a
+fi
+
+MODEL="${MODEL_OVERRIDE:-${TASK_MODEL:-}}"
+if [[ -z "$MODEL" ]]; then
+  echo "No model: pass -m <model> or export TASK_MODEL." >&2
+  exit 2
+fi
+
+if [[ ! -f "$EMIT" ]]; then
+  echo "emit-agent-spec.ts not found at $EMIT." >&2
+  exit 2
+fi
+if [[ ! -d "$SKILL" ]]; then
+  echo "pi-agent-composer skill not found at $SKILL." >&2
+  exit 2
+fi
+
+mkdir -p "$SANDBOX/.pi/agents"
+
+echo ">>> agent-composer model=$MODEL mode=$( [[ $INTERACTIVE -eq 1 ]] && echo interactive || echo one-shot )"
+echo "    output=$SANDBOX/.pi/agents/"
+
+if [[ $INTERACTIVE -eq 1 ]]; then
+  (
+    cd "$SANDBOX"
+    exec env \
+      PI_SKIP_UPDATE_CHECK=1 \
+      PI_SANDBOX_ROOT="$SANDBOX" \
+      "$REPO/node_modules/.bin/pi" \
+        --no-context-files --no-session --no-skills \
+        --provider openrouter --model "$MODEL" \
+        --skill "$SKILL" \
+        -e "$EMIT" \
+        --tools "read,ls,grep,emit_agent_spec"
+  )
+  exit 0
+fi
+
+# One-shot mode. Wrap the prompt to point the LLM at the skill explicitly,
+# matching agent-maker's "Use the <skill> skill to: <prompt>." framing.
+WRAPPED="Use the pi-agent-composer skill to: ${PROMPT}."
+(
+  cd "$SANDBOX"
+  exec env \
+    PI_SKIP_UPDATE_CHECK=1 \
+    PI_SANDBOX_ROOT="$SANDBOX" \
+    "$REPO/node_modules/.bin/pi" \
+      --no-context-files --no-session --no-skills \
+      --provider openrouter --model "$MODEL" \
+      --skill "$SKILL" \
+      -e "$EMIT" \
+      --tools "read,ls,grep,emit_agent_spec" \
+      --mode json \
+      -p "$WRAPPED"
+)


### PR DESCRIPTION
Plans a new skill + grader alongside pi-agent-assembler rather than
refactoring in place, so baseline grades stay intact and A/B is a
single -s flag flip. Phase 2 grows components with parentSide exports
so a delegate() runtime collapses agent glue from ~200 lines to ~15.

https://claude.ai/code/session_01VS9WJbvBcFwFURCLBQcmcm