### PR TITLE
Refactor agent system to recipe-driven runner with sandbox isolation (#30)

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -30,8 +30,11 @@ agent gets five baseline extensions:
 - `agent-footer` — replaces pi's default footer. Line 1 shows
   `sandbox: <root>` on the left and `tools: <name1, name2, ...>` (from
   `pi.getActiveTools()`, i.e. the recipe's `tools:` allowlist plus any
-  extension-registered tools) on the right. Line 2 mirrors pi's default
-  stats/model line. Line 3 is the extension-status line.
+  extension-registered tools) on the right. Line 2 shows `$cost` and
+  the context-usage percent on the left, model id on the right —
+  pi's default token-flow stats (↑input, ↓output, cache R/W, context
+  window size) are intentionally dropped. Line 3 is the
+  extension-status line.
 - `hide-extensions-list` — strips pi's `[Extensions]` section (added by
   `showLoadedResources` to the chat history at startup) since the
   agent-footer already shows the active tools and the path listing is

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -4,7 +4,7 @@ Day-to-day, the way to launch a focused agent is `npm run agent -- <name>`.
 The runner (`scripts/run-agent.mjs`) reads a YAML recipe from
 `pi-sandbox/agents/<name>.yaml`, resolves the model tier, and execs `pi`
 from the directory you invoked it from (or `--sandbox <dir>`). Every
-agent gets four baseline extensions:
+agent gets five baseline extensions:
 
 - `sandbox` — blocks `bash` outright and rejects any path-bearing tool
   call whose `path` resolves outside the sandbox root. The set of
@@ -15,6 +15,11 @@ agent gets four baseline extensions:
 - `no-startup-help` — suppresses pi's default startup header (logo,
   keybinding cheatsheet, onboarding tips) since most of those keybindings
   reference features focused agents don't use.
+- `agent-header` — replaces the (now-empty) header with a banner that
+  shows the agent name (bold accent) and the recipe's `description:`
+  field on the next line (dim). Reads `AGENT_NAME` and
+  `AGENT_DESCRIPTION` from the environment; both are set by the runner
+  from the recipe filename and `description:` field.
 - `agent-footer` — replaces pi's default footer. Line 1 shows
   `sandbox: <root>` on the left and `tools: <name1, name2, ...>` (from
   `pi.getActiveTools()`, i.e. the recipe's `tools:` allowlist plus any
@@ -38,10 +43,11 @@ npm run agent -- deferred-writer -p "draft a README" --thinking off   # passthro
 ```yaml
 # pi-sandbox/agents/<name>.yaml
 model: TASK_RABBIT_MODEL          # tier name from models.env, or a literal model ID
+description: Drafts files...      # optional; shown by agent-header in the TUI
 prompt: |                         # replaces pi's default system prompt
   You are a careful drafter...
 tools: [read, ls, grep, deferred_write]
-extensions: [deferred-write]      # merged with the [sandbox, no-startup-help, agent-footer, hide-extensions-list] baseline
+extensions: [deferred-write]      # merged with the [sandbox, no-startup-help, agent-header, agent-footer, hide-extensions-list] baseline
 skills: [pi-agent-builder]        # optional; resolved against pi-sandbox/skills/
 provider: openrouter              # optional; defaults to openrouter
 noEditAdd: [my_writer]            # optional; force-include in no-edit rail

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -4,12 +4,18 @@ Day-to-day, the way to launch a focused agent is `npm run agent -- <name>`.
 The runner (`scripts/run-agent.mjs`) reads a YAML recipe from
 `pi-sandbox/agents/<name>.yaml`, resolves the model tier, and execs `pi`
 from the directory you invoked it from (or `--sandbox <dir>`). Every
-agent gets the `sandbox` baseline extension, which blocks `bash` outright
-and rejects any path-bearing tool call whose `path` resolves outside the
-sandbox root. The set of path-bearing tools is discovered at session
-start from `pi.getAllTools()` (any tool whose schema declares
-`path: string`), with a static fallback of `{read, write, edit, ls,
-grep, find}` for the installed pi 0.69 built-ins.
+agent gets two baseline extensions:
+
+- `sandbox` — blocks `bash` outright, rejects any path-bearing tool call
+  whose `path` resolves outside the sandbox root, and replaces pi's
+  footer cwd/branch line with `sandbox: <root>`. The set of path-bearing
+  tools is discovered at session start from `pi.getAllTools()` (any tool
+  whose schema declares `path: string`), with a static fallback of
+  `{read, write, edit, ls, grep, find}` for the installed pi 0.69
+  built-ins.
+- `no-startup-help` — suppresses pi's default startup header (logo,
+  keybinding cheatsheet, onboarding tips) since most of those keybindings
+  reference features focused agents don't use.
 
 ```sh
 set -a; source models.env; set +a
@@ -26,7 +32,7 @@ model: TASK_RABBIT_MODEL          # tier name from models.env, or a literal mode
 prompt: |                         # replaces pi's default system prompt
   You are a careful drafter...
 tools: [read, ls, grep, deferred_write]
-extensions: [deferred-write]      # merged with the [sandbox] baseline
+extensions: [deferred-write]      # merged with the [sandbox, no-startup-help] baseline
 skills: [pi-agent-builder]        # optional; resolved against pi-sandbox/skills/
 provider: openrouter              # optional; defaults to openrouter
 noEditAdd: [my_writer]            # optional; force-include in no-edit rail

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -4,7 +4,7 @@ Day-to-day, the way to launch a focused agent is `npm run agent -- <name>`.
 The runner (`scripts/run-agent.mjs`) reads a YAML recipe from
 `pi-sandbox/agents/<name>.yaml`, resolves the model tier, and execs `pi`
 from the directory you invoked it from (or `--sandbox <dir>`). Every
-agent gets three baseline extensions:
+agent gets four baseline extensions:
 
 - `sandbox` — blocks `bash` outright and rejects any path-bearing tool
   call whose `path` resolves outside the sandbox root. The set of
@@ -20,6 +20,11 @@ agent gets three baseline extensions:
   `pi.getActiveTools()`, i.e. the recipe's `tools:` allowlist plus any
   extension-registered tools) on the right. Line 2 mirrors pi's default
   stats/model line. Line 3 is the extension-status line.
+- `hide-extensions-list` — strips pi's `[Extensions]` section (added by
+  `showLoadedResources` to the chat history at startup) since the
+  agent-footer already shows the active tools and the path listing is
+  noise. Reaches into private TUI state via `setWidget`+`setTimeout(0)`
+  because pi has no public API to suppress per-section.
 
 ```sh
 set -a; source models.env; set +a
@@ -36,7 +41,7 @@ model: TASK_RABBIT_MODEL          # tier name from models.env, or a literal mode
 prompt: |                         # replaces pi's default system prompt
   You are a careful drafter...
 tools: [read, ls, grep, deferred_write]
-extensions: [deferred-write]      # merged with the [sandbox, no-startup-help, agent-footer] baseline
+extensions: [deferred-write]      # merged with the [sandbox, no-startup-help, agent-footer, hide-extensions-list] baseline
 skills: [pi-agent-builder]        # optional; resolved against pi-sandbox/skills/
 provider: openrouter              # optional; defaults to openrouter
 noEditAdd: [my_writer]            # optional; force-include in no-edit rail

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -27,8 +27,8 @@ agent gets five baseline extensions:
   than a tier var). Each flag can be passed on the `npm run agent --`
   line to override the recipe (passthrough flags come after
   recipe-derived ones, so the CLI value wins).
-- `agent-footer` — replaces pi's default footer. Line 1 shows
-  `sandbox: <root>` on the left and `tools: <name1, name2, ...>` (from
+- `agent-footer` — replaces pi's default footer. Line 1 shows the
+  sandbox root on the left and the comma-separated active tools (from
   `pi.getActiveTools()`, i.e. the recipe's `tools:` allowlist plus any
   extension-registered tools) on the right. Line 2 shows `$cost` and
   the context-usage percent on the left, model id on the right —

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -4,18 +4,22 @@ Day-to-day, the way to launch a focused agent is `npm run agent -- <name>`.
 The runner (`scripts/run-agent.mjs`) reads a YAML recipe from
 `pi-sandbox/agents/<name>.yaml`, resolves the model tier, and execs `pi`
 from the directory you invoked it from (or `--sandbox <dir>`). Every
-agent gets two baseline extensions:
+agent gets three baseline extensions:
 
-- `sandbox` — blocks `bash` outright, rejects any path-bearing tool call
-  whose `path` resolves outside the sandbox root, and replaces pi's
-  footer cwd/branch line with `sandbox: <root>`. The set of path-bearing
-  tools is discovered at session start from `pi.getAllTools()` (any tool
-  whose schema declares `path: string`), with a static fallback of
-  `{read, write, edit, ls, grep, find}` for the installed pi 0.69
-  built-ins.
+- `sandbox` — blocks `bash` outright and rejects any path-bearing tool
+  call whose `path` resolves outside the sandbox root. The set of
+  path-bearing tools is discovered at session start from
+  `pi.getAllTools()` (any tool whose schema declares `path: string`),
+  with a static fallback of `{read, write, edit, ls, grep, find}` for
+  the installed pi 0.69 built-ins.
 - `no-startup-help` — suppresses pi's default startup header (logo,
   keybinding cheatsheet, onboarding tips) since most of those keybindings
   reference features focused agents don't use.
+- `agent-footer` — replaces pi's default footer. Line 1 shows
+  `sandbox: <root>` on the left and `tools: <name1, name2, ...>` (from
+  `pi.getActiveTools()`, i.e. the recipe's `tools:` allowlist plus any
+  extension-registered tools) on the right. Line 2 mirrors pi's default
+  stats/model line. Line 3 is the extension-status line.
 
 ```sh
 set -a; source models.env; set +a
@@ -32,7 +36,7 @@ model: TASK_RABBIT_MODEL          # tier name from models.env, or a literal mode
 prompt: |                         # replaces pi's default system prompt
   You are a careful drafter...
 tools: [read, ls, grep, deferred_write]
-extensions: [deferred-write]      # merged with the [sandbox, no-startup-help] baseline
+extensions: [deferred-write]      # merged with the [sandbox, no-startup-help, agent-footer] baseline
 skills: [pi-agent-builder]        # optional; resolved against pi-sandbox/skills/
 provider: openrouter              # optional; defaults to openrouter
 noEditAdd: [my_writer]            # optional; force-include in no-edit rail

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -11,15 +11,19 @@ agent gets five baseline extensions:
   path-bearing tools is discovered at session start from
   `pi.getAllTools()` (any tool whose schema declares `path: string`),
   with a static fallback of `{read, write, edit, ls, grep, find}` for
-  the installed pi 0.69 built-ins.
+  the installed pi 0.69 built-ins. Owns the `--sandbox-root <path>`
+  flag (read by `agent-footer`, `deferred-write`, and `no-edit` via
+  `pi.getFlag`); falls back to `ctx.cwd` when the flag is unset.
 - `no-startup-help` — suppresses pi's default startup header (logo,
   keybinding cheatsheet, onboarding tips) since most of those keybindings
   reference features focused agents don't use.
 - `agent-header` — replaces the (now-empty) header with a banner that
   shows the agent name (bold accent) and the recipe's `description:`
-  field on the next line (dim). Reads `AGENT_NAME` and
-  `AGENT_DESCRIPTION` from the environment; both are set by the runner
-  from the recipe filename and `description:` field.
+  field on the next line (dim). Reads the `--agent-name` and
+  `--agent-description` flags; the runner sets both from the recipe
+  filename and `description:` field. Either flag can be passed on the
+  `npm run agent --` line to override the recipe (passthrough flags
+  come after recipe-derived ones, so the CLI value wins).
 - `agent-footer` — replaces pi's default footer. Line 1 shows
   `sandbox: <root>` on the left and `tools: <name1, name2, ...>` (from
   `pi.getActiveTools()`, i.e. the recipe's `tools:` allowlist plus any
@@ -57,8 +61,11 @@ noEditSkip: [deferred_write]      # optional; exempt from no-edit rail
 The runner always passes `--no-extensions --no-skills --no-context-files`
 to pi, so only what the recipe declares is loaded. Tool names go through
 pi's `--tools` allowlist (built-in + extension-registered tools both
-qualify). The sandbox extension reads `AGENT_SANDBOX_ROOT` (set by the
-runner) to know where to clamp paths.
+qualify). Recipe-derived values reach the extensions as registered CLI
+flags: `--sandbox-root <path>` (always set), `--agent-name <name>`
+(always set), `--agent-description <text>` (when `description:` is set),
+and `--no-edit-add` / `--no-edit-skip` (when the matching list is
+non-empty). All five appear under "Extension CLI Flags" in `pi --help`.
 
 ## Where agent code lives
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -18,12 +18,15 @@ agent gets five baseline extensions:
   keybinding cheatsheet, onboarding tips) since most of those keybindings
   reference features focused agents don't use.
 - `agent-header` — replaces the (now-empty) header with a banner that
-  shows the agent name (bold accent) and the recipe's `description:`
-  field on the next line (dim). Reads the `--agent-name` and
-  `--agent-description` flags; the runner sets both from the recipe
-  filename and `description:` field. Either flag can be passed on the
-  `npm run agent --` line to override the recipe (passthrough flags
-  come after recipe-derived ones, so the CLI value wins).
+  shows the agent name (bold accent), optionally suffixed dim with the
+  model tier (e.g. `deferred-writer · Task Rabbit`), and the recipe's
+  `description:` field on the next line (dim). Reads the `--agent-name`,
+  `--agent-description`, and `--agent-tier` flags; the runner sets all
+  three from the recipe filename, `description:`, and `model:` (the
+  tier suffix is skipped when `model:` is a literal model ID rather
+  than a tier var). Each flag can be passed on the `npm run agent --`
+  line to override the recipe (passthrough flags come after
+  recipe-derived ones, so the CLI value wins).
 - `agent-footer` — replaces pi's default footer. Line 1 shows
   `sandbox: <root>` on the left and `tools: <name1, name2, ...>` (from
   `pi.getActiveTools()`, i.e. the recipe's `tools:` allowlist plus any
@@ -64,8 +67,9 @@ pi's `--tools` allowlist (built-in + extension-registered tools both
 qualify). Recipe-derived values reach the extensions as registered CLI
 flags: `--sandbox-root <path>` (always set), `--agent-name <name>`
 (always set), `--agent-description <text>` (when `description:` is set),
-and `--no-edit-add` / `--no-edit-skip` (when the matching list is
-non-empty). All five appear under "Extension CLI Flags" in `pi --help`.
+`--agent-tier <TIER_VAR>` (when `model:` is a tier var name), and
+`--no-edit-add` / `--no-edit-skip` (when the matching list is
+non-empty). All six appear under "Extension CLI Flags" in `pi --help`.
 
 ## Where agent code lives
 

--- a/pi-sandbox/.pi/extensions/agent-footer.ts
+++ b/pi-sandbox/.pi/extensions/agent-footer.ts
@@ -9,11 +9,11 @@
 //                  registered by extensions. Truncated with an ellipsis
 //                  on narrow terminals; dropped entirely if there is no
 //                  room for a 2-column gap after the sandbox label.
-//   line 2, left:  `$cost / <bar>` — accumulated assistant cost from
-//                  session history plus a 5-cell eighths-block bar for
-//                  the context-usage percent (warning tint > 70%,
-//                  error tint > 90%). pi's default token-flow stats
-//                  (↑input, ↓output, cache R/W, /<window-size>) are
+//   line 2, left:  `<bar>| $cost` — 5-cell eighths-block context-usage
+//                  bar (warning tint > 70%, error tint > 90%), followed
+//                  by the accumulated assistant cost from session
+//                  history. pi's default token-flow stats (↑input,
+//                  ↓output, cache R/W, /<window-size>) are
 //                  intentionally dropped.
 //   line 2, right: model id.
 //   line 3 (opt):  extension status texts set via ctx.ui.setStatus().
@@ -91,18 +91,17 @@ export default function (pi: ExtensionAPI) {
 
         const ctxPct = ctx.getContextUsage()?.percent;
 
-        const stats: string[] = [];
-        if (cost) stats.push(`$${cost.toFixed(3)}`);
-
         const ctxStr = typeof ctxPct === "number" ? renderBar(ctxPct, 5) : "?";
         let ctxColored = ctxStr;
         if (typeof ctxPct === "number") {
           if (ctxPct > 90) ctxColored = theme.fg("error", ctxStr);
           else if (ctxPct > 70) ctxColored = theme.fg("warning", ctxStr);
         }
-        stats.push(ctxColored);
 
-        const left = stats.join(" / ");
+        const stats: string[] = [ctxColored];
+        if (cost) stats.push(`$${cost.toFixed(3)}`);
+
+        const left = stats.join("| ");
         const right = ctx.model?.id || "no-model";
         const leftW = visibleWidth(left);
         const rightW = visibleWidth(right);

--- a/pi-sandbox/.pi/extensions/agent-footer.ts
+++ b/pi-sandbox/.pi/extensions/agent-footer.ts
@@ -1,14 +1,14 @@
 // agent-footer — replaces pi's default footer with one that fits the
 // `npm run agent` rails:
-//   line 1, left:  `sandbox: <root>` (the `--sandbox-root` flag value,
-//                  with home replaced by ~), instead of pi's `cwd (branch)`. The
-//                  agent can't escape the sandbox so the host cwd /
-//                  branch are misleading noise.
-//   line 1, right: `tools: <name1, name2, ...>` from pi.getActiveTools(),
-//                  i.e. the recipe's `tools:` allowlist plus any tools
+//   line 1, left:  the `--sandbox-root` flag value (home replaced by
+//                  ~), instead of pi's `cwd (branch)`. The agent can't
+//                  escape the sandbox so the host cwd / branch are
+//                  misleading noise.
+//   line 1, right: comma-separated active tools from pi.getActiveTools()
+//                  — the recipe's `tools:` allowlist plus any tools
 //                  registered by extensions. Truncated with an ellipsis
 //                  on narrow terminals; dropped entirely if there is no
-//                  room for a 2-column gap after the sandbox label.
+//                  room for a 2-column gap after the sandbox path.
 //   line 2, left:  `<bar>| $cost` — 5-cell eighths-block context-usage
 //                  bar (warning tint > 70%, error tint > 90%), followed
 //                  by the accumulated assistant cost from session
@@ -59,14 +59,14 @@ export default function (pi: ExtensionAPI) {
     ctx.ui.setFooter((_tui, theme, footerData) => ({
       invalidate() {},
       render(width: number): string[] {
-        const sandboxLabel = `sandbox: ${displayRoot}`;
+        const sandboxLabel = displayRoot;
         let activeTools: string[] = [];
         try {
           activeTools = pi.getActiveTools();
         } catch {
           // getActiveTools may not be ready in some session states.
         }
-        const toolsLabel = activeTools.length > 0 ? `tools: ${activeTools.join(", ")}` : "";
+        const toolsLabel = activeTools.length > 0 ? activeTools.join(", ") : "";
         const sbW = visibleWidth(sandboxLabel);
         const tlW = visibleWidth(toolsLabel);
         const minGap = 2;

--- a/pi-sandbox/.pi/extensions/agent-footer.ts
+++ b/pi-sandbox/.pi/extensions/agent-footer.ts
@@ -9,11 +9,12 @@
 //                  registered by extensions. Truncated with an ellipsis
 //                  on narrow terminals; dropped entirely if there is no
 //                  room for a 2-column gap after the sandbox label.
-//   line 2, left:  `$cost  CTX%` — accumulated assistant cost from
-//                  session history plus the context-usage percent.
-//                  pi's default token-flow stats (↑input, ↓output,
-//                  cache R/W, /<window-size>) are intentionally
-//                  dropped.
+//   line 2, left:  `$cost / <bar>` — accumulated assistant cost from
+//                  session history plus a 5-cell eighths-block bar for
+//                  the context-usage percent (warning tint > 70%,
+//                  error tint > 90%). pi's default token-flow stats
+//                  (↑input, ↓output, cache R/W, /<window-size>) are
+//                  intentionally dropped.
 //   line 2, right: model id.
 //   line 3 (opt):  extension status texts set via ctx.ui.setStatus().
 
@@ -22,6 +23,21 @@ import path from "node:path";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+
+// Eighths-block horizontal bar. 5 cells × 8 eighths = 40 buckets, so each
+// bucket covers ~2.5% of context. Empty cells render `░` so the track is
+// visible even at 0%; partial cells use the standard left-fill set.
+const BAR_BLOCKS = ["░", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"];
+function renderBar(percent: number, width: number): string {
+  const max = width * 8;
+  const totalEighths = Math.max(0, Math.min(max, Math.round((percent / 100) * max)));
+  let out = "";
+  for (let i = 0; i < width; i++) {
+    const cellEighths = Math.max(0, Math.min(8, totalEighths - i * 8));
+    out += BAR_BLOCKS[cellEighths];
+  }
+  return out;
+}
 
 function homeReplace(p: string): string {
   const home = os.homedir();
@@ -78,7 +94,7 @@ export default function (pi: ExtensionAPI) {
         const stats: string[] = [];
         if (cost) stats.push(`$${cost.toFixed(3)}`);
 
-        const ctxStr = typeof ctxPct === "number" ? `${ctxPct.toFixed(1)}%` : "?";
+        const ctxStr = typeof ctxPct === "number" ? renderBar(ctxPct, 5) : "?";
         let ctxColored = ctxStr;
         if (typeof ctxPct === "number") {
           if (ctxPct > 90) ctxColored = theme.fg("error", ctxStr);

--- a/pi-sandbox/.pi/extensions/agent-footer.ts
+++ b/pi-sandbox/.pi/extensions/agent-footer.ts
@@ -1,0 +1,144 @@
+// agent-footer — replaces pi's default footer with one that fits the
+// `npm run agent` rails:
+//   line 1, left:  `sandbox: <root>` (the AGENT_SANDBOX_ROOT, with home
+//                  replaced by ~), instead of pi's `cwd (branch)`. The
+//                  agent can't escape the sandbox so the host cwd /
+//                  branch are misleading noise.
+//   line 1, right: `tools: <name1, name2, ...>` from pi.getActiveTools(),
+//                  i.e. the recipe's `tools:` allowlist plus any tools
+//                  registered by extensions. Truncated with an ellipsis
+//                  on narrow terminals; dropped entirely if there is no
+//                  room for a 2-column gap after the sandbox label.
+//   line 2:        token stats + context % + model id (mirrors pi's
+//                  default).
+//   line 3 (opt):  extension status texts set via ctx.ui.setStatus().
+
+import os from "node:os";
+import path from "node:path";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+
+function formatTokens(count: number): string {
+  if (count < 1000) return String(count);
+  if (count < 10_000) return `${(count / 1000).toFixed(1)}k`;
+  if (count < 1_000_000) return `${Math.round(count / 1000)}k`;
+  if (count < 10_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  return `${Math.round(count / 1_000_000)}M`;
+}
+
+function homeReplace(p: string): string {
+  const home = os.homedir();
+  if (!home) return p;
+  if (p === home) return "~";
+  if (p.startsWith(home + path.sep)) return `~${p.slice(home.length)}`;
+  return p;
+}
+
+function sanitizeStatusText(text: string): string {
+  return text.replace(/[\r\n\t]/g, " ").replace(/ +/g, " ").trim();
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    const root = path.resolve(process.env.AGENT_SANDBOX_ROOT || ctx.cwd);
+    const displayRoot = homeReplace(root);
+
+    ctx.ui.setFooter((_tui, theme, footerData) => ({
+      invalidate() {},
+      render(width: number): string[] {
+        const sandboxLabel = `sandbox: ${displayRoot}`;
+        let activeTools: string[] = [];
+        try {
+          activeTools = pi.getActiveTools();
+        } catch {
+          // getActiveTools may not be ready in some session states.
+        }
+        const toolsLabel = activeTools.length > 0 ? `tools: ${activeTools.join(", ")}` : "";
+        const sbW = visibleWidth(sandboxLabel);
+        const tlW = visibleWidth(toolsLabel);
+        const minGap = 2;
+
+        let pwdContent: string;
+        if (toolsLabel.length > 0 && sbW + minGap + tlW <= width) {
+          pwdContent = sandboxLabel + " ".repeat(width - sbW - tlW) + toolsLabel;
+        } else if (toolsLabel.length > 0 && sbW + minGap < width) {
+          const truncT = truncateToWidth(toolsLabel, width - sbW - minGap, "…");
+          pwdContent = sandboxLabel + " ".repeat(Math.max(0, width - sbW - visibleWidth(truncT))) + truncT;
+        } else {
+          pwdContent = sandboxLabel;
+        }
+        const pwdLine = truncateToWidth(theme.fg("dim", pwdContent), width, theme.fg("dim", "..."));
+
+        let input = 0;
+        let output = 0;
+        let cacheRead = 0;
+        let cacheWrite = 0;
+        let cost = 0;
+        for (const entry of ctx.sessionManager.getEntries()) {
+          if (entry.type === "message" && entry.message.role === "assistant") {
+            const u = (entry.message as AssistantMessage).usage;
+            input += u.input;
+            output += u.output;
+            cacheRead += u.cacheRead;
+            cacheWrite += u.cacheWrite;
+            cost += u.cost.total;
+          }
+        }
+
+        const usage = ctx.getContextUsage();
+        const ctxWindow = usage?.contextWindow ?? ctx.model?.contextWindow ?? 0;
+        const ctxPct = usage?.percent;
+
+        const stats: string[] = [];
+        if (input) stats.push(`↑${formatTokens(input)}`);
+        if (output) stats.push(`↓${formatTokens(output)}`);
+        if (cacheRead) stats.push(`R${formatTokens(cacheRead)}`);
+        if (cacheWrite) stats.push(`W${formatTokens(cacheWrite)}`);
+        if (cost) stats.push(`$${cost.toFixed(3)}`);
+
+        const ctxStr =
+          typeof ctxPct === "number"
+            ? `${ctxPct.toFixed(1)}%/${formatTokens(ctxWindow)}`
+            : `?/${formatTokens(ctxWindow)}`;
+        let ctxColored = ctxStr;
+        if (typeof ctxPct === "number") {
+          if (ctxPct > 90) ctxColored = theme.fg("error", ctxStr);
+          else if (ctxPct > 70) ctxColored = theme.fg("warning", ctxStr);
+        }
+        stats.push(ctxColored);
+
+        const left = stats.join(" ");
+        const right = ctx.model?.id || "no-model";
+        const leftW = visibleWidth(left);
+        const rightW = visibleWidth(right);
+        const minPad = 2;
+
+        let statsLine: string;
+        if (leftW + minPad + rightW <= width) {
+          statsLine = left + " ".repeat(width - leftW - rightW) + right;
+        } else if (leftW + minPad < width) {
+          const truncR = truncateToWidth(right, width - leftW - minPad, "");
+          const padW = Math.max(0, width - leftW - visibleWidth(truncR));
+          statsLine = left + " ".repeat(padW) + truncR;
+        } else {
+          statsLine = truncateToWidth(left, width, "...");
+        }
+
+        const dimLeft = theme.fg("dim", left);
+        const dimRest = theme.fg("dim", statsLine.slice(left.length));
+        const lines = [pwdLine, dimLeft + dimRest];
+
+        const statuses = footerData.getExtensionStatuses();
+        if (statuses.size > 0) {
+          const sorted = Array.from(statuses.entries())
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([, t]) => sanitizeStatusText(t));
+          lines.push(truncateToWidth(sorted.join(" "), width, theme.fg("dim", "...")));
+        }
+
+        return lines;
+      },
+    }));
+  });
+}

--- a/pi-sandbox/.pi/extensions/agent-footer.ts
+++ b/pi-sandbox/.pi/extensions/agent-footer.ts
@@ -9,8 +9,12 @@
 //                  registered by extensions. Truncated with an ellipsis
 //                  on narrow terminals; dropped entirely if there is no
 //                  room for a 2-column gap after the sandbox label.
-//   line 2:        token stats + context % + model id (mirrors pi's
-//                  default).
+//   line 2, left:  `$cost  CTX%` — accumulated assistant cost from
+//                  session history plus the context-usage percent.
+//                  pi's default token-flow stats (↑input, ↓output,
+//                  cache R/W, /<window-size>) are intentionally
+//                  dropped.
+//   line 2, right: model id.
 //   line 3 (opt):  extension status texts set via ctx.ui.setStatus().
 
 import os from "node:os";
@@ -18,14 +22,6 @@ import path from "node:path";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-
-function formatTokens(count: number): string {
-  if (count < 1000) return String(count);
-  if (count < 10_000) return `${(count / 1000).toFixed(1)}k`;
-  if (count < 1_000_000) return `${Math.round(count / 1000)}k`;
-  if (count < 10_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
-  return `${Math.round(count / 1_000_000)}M`;
-}
 
 function homeReplace(p: string): string {
   const home = os.homedir();
@@ -70,37 +66,19 @@ export default function (pi: ExtensionAPI) {
         }
         const pwdLine = truncateToWidth(theme.fg("dim", pwdContent), width, theme.fg("dim", "..."));
 
-        let input = 0;
-        let output = 0;
-        let cacheRead = 0;
-        let cacheWrite = 0;
         let cost = 0;
         for (const entry of ctx.sessionManager.getEntries()) {
           if (entry.type === "message" && entry.message.role === "assistant") {
-            const u = (entry.message as AssistantMessage).usage;
-            input += u.input;
-            output += u.output;
-            cacheRead += u.cacheRead;
-            cacheWrite += u.cacheWrite;
-            cost += u.cost.total;
+            cost += (entry.message as AssistantMessage).usage.cost.total;
           }
         }
 
-        const usage = ctx.getContextUsage();
-        const ctxWindow = usage?.contextWindow ?? ctx.model?.contextWindow ?? 0;
-        const ctxPct = usage?.percent;
+        const ctxPct = ctx.getContextUsage()?.percent;
 
         const stats: string[] = [];
-        if (input) stats.push(`↑${formatTokens(input)}`);
-        if (output) stats.push(`↓${formatTokens(output)}`);
-        if (cacheRead) stats.push(`R${formatTokens(cacheRead)}`);
-        if (cacheWrite) stats.push(`W${formatTokens(cacheWrite)}`);
         if (cost) stats.push(`$${cost.toFixed(3)}`);
 
-        const ctxStr =
-          typeof ctxPct === "number"
-            ? `${ctxPct.toFixed(1)}%/${formatTokens(ctxWindow)}`
-            : `?/${formatTokens(ctxWindow)}`;
+        const ctxStr = typeof ctxPct === "number" ? `${ctxPct.toFixed(1)}%` : "?";
         let ctxColored = ctxStr;
         if (typeof ctxPct === "number") {
           if (ctxPct > 90) ctxColored = theme.fg("error", ctxStr);

--- a/pi-sandbox/.pi/extensions/agent-footer.ts
+++ b/pi-sandbox/.pi/extensions/agent-footer.ts
@@ -86,7 +86,7 @@ export default function (pi: ExtensionAPI) {
         }
         stats.push(ctxColored);
 
-        const left = stats.join(" ");
+        const left = stats.join(" / ");
         const right = ctx.model?.id || "no-model";
         const leftW = visibleWidth(left);
         const rightW = visibleWidth(right);

--- a/pi-sandbox/.pi/extensions/agent-footer.ts
+++ b/pi-sandbox/.pi/extensions/agent-footer.ts
@@ -1,7 +1,7 @@
 // agent-footer — replaces pi's default footer with one that fits the
 // `npm run agent` rails:
-//   line 1, left:  `sandbox: <root>` (the AGENT_SANDBOX_ROOT, with home
-//                  replaced by ~), instead of pi's `cwd (branch)`. The
+//   line 1, left:  `sandbox: <root>` (the `--sandbox-root` flag value,
+//                  with home replaced by ~), instead of pi's `cwd (branch)`. The
 //                  agent can't escape the sandbox so the host cwd /
 //                  branch are misleading noise.
 //   line 1, right: `tools: <name1, name2, ...>` from pi.getActiveTools(),
@@ -41,7 +41,7 @@ function sanitizeStatusText(text: string): string {
 
 export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
-    const root = path.resolve(process.env.AGENT_SANDBOX_ROOT || ctx.cwd);
+    const root = path.resolve((pi.getFlag("sandbox-root") as string | undefined) || ctx.cwd);
     const displayRoot = homeReplace(root);
 
     ctx.ui.setFooter((_tui, theme, footerData) => ({

--- a/pi-sandbox/.pi/extensions/agent-header.ts
+++ b/pi-sandbox/.pi/extensions/agent-header.ts
@@ -1,0 +1,32 @@
+// agent-header — replaces pi's default startup header with a two-line
+// banner: the agent name (bold accent) and the recipe description
+// (dim). Reads AGENT_NAME and AGENT_DESCRIPTION from the environment;
+// the runner sets both based on the recipe filename and the recipe's
+// `description:` field. If neither is set, the header stays empty
+// (no-startup-help's empty render keeps applying).
+//
+// Pi wraps the header component in two `Spacer(1)` lines that aren't
+// removable via the public API, so the banner sits with one blank line
+// above and below.
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Container, Text } from "@mariozechner/pi-tui";
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    const name = process.env.AGENT_NAME?.trim();
+    const description = process.env.AGENT_DESCRIPTION?.trim();
+    if (!name && !description) return;
+
+    ctx.ui.setHeader((_tui, theme) => {
+      const container = new Container();
+      if (name) {
+        container.addChild(new Text(theme.bold(theme.fg("accent", name)), 1, 0));
+      }
+      if (description) {
+        container.addChild(new Text(theme.fg("dim", description), 1, 0));
+      }
+      return container;
+    });
+  });
+}

--- a/pi-sandbox/.pi/extensions/agent-header.ts
+++ b/pi-sandbox/.pi/extensions/agent-header.ts
@@ -1,10 +1,12 @@
 // agent-header — replaces pi's default startup header with a two-line
-// banner: the agent name (bold accent) and the recipe description
-// (dim). Reads the `--agent-name` and `--agent-description` flags;
-// the runner sets both based on the recipe filename and the recipe's
-// `description:` field. If neither is set, the header stays empty
-// (no-startup-help's empty render keeps applying). The flags can also
-// be passed on the `npm run agent --` line to override the recipe.
+// banner: the agent name (bold accent), optionally suffixed dim with the
+// model tier (e.g. "deferred-writer · Task Rabbit"), and the recipe
+// description on the next line (dim). Reads `--agent-name`,
+// `--agent-description`, and `--agent-tier`; the runner sets all three
+// from the recipe filename, `description:`, and `model:` (when the
+// latter is a tier var name). If none are set, the header stays empty
+// (no-startup-help's empty render keeps applying). Each flag can be
+// passed on the `npm run agent --` line to override the recipe.
 //
 // Pi wraps the header component in two `Spacer(1)` lines that aren't
 // removable via the public API, so the banner sits with one blank line
@@ -12,6 +14,16 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Container, Text } from "@mariozechner/pi-tui";
+
+// TASK_RABBIT_MODEL → "Task Rabbit"; LEAD_HARE_MODEL → "Lead Hare"; etc.
+function formatTier(tier: string): string {
+  return tier
+    .replace(/_MODEL$/, "")
+    .split("_")
+    .filter((s) => s.length > 0)
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase())
+    .join(" ");
+}
 
 export default function (pi: ExtensionAPI) {
   pi.registerFlag("agent-name", {
@@ -22,16 +34,25 @@ export default function (pi: ExtensionAPI) {
     description: "One-line description shown dim under the agent name in the TUI header banner",
     type: "string",
   });
+  pi.registerFlag("agent-tier", {
+    description: "Model tier var name (e.g. TASK_RABBIT_MODEL) appended dim after the agent name",
+    type: "string",
+  });
 
   pi.on("session_start", async (_event, ctx) => {
     const name = (pi.getFlag("agent-name") as string | undefined)?.trim();
     const description = (pi.getFlag("agent-description") as string | undefined)?.trim();
+    const tier = (pi.getFlag("agent-tier") as string | undefined)?.trim();
     if (!name && !description) return;
+
+    const tierLabel = tier ? formatTier(tier) : "";
 
     ctx.ui.setHeader((_tui, theme) => {
       const container = new Container();
       if (name) {
-        container.addChild(new Text(theme.bold(theme.fg("accent", name)), 1, 0));
+        const head = theme.bold(theme.fg("accent", name));
+        const tail = tierLabel ? theme.fg("dim", ` · ${tierLabel}`) : "";
+        container.addChild(new Text(head + tail, 1, 0));
       }
       if (description) {
         container.addChild(new Text(theme.fg("dim", description), 1, 0));

--- a/pi-sandbox/.pi/extensions/agent-header.ts
+++ b/pi-sandbox/.pi/extensions/agent-header.ts
@@ -1,9 +1,10 @@
 // agent-header — replaces pi's default startup header with a two-line
 // banner: the agent name (bold accent) and the recipe description
-// (dim). Reads AGENT_NAME and AGENT_DESCRIPTION from the environment;
+// (dim). Reads the `--agent-name` and `--agent-description` flags;
 // the runner sets both based on the recipe filename and the recipe's
 // `description:` field. If neither is set, the header stays empty
-// (no-startup-help's empty render keeps applying).
+// (no-startup-help's empty render keeps applying). The flags can also
+// be passed on the `npm run agent --` line to override the recipe.
 //
 // Pi wraps the header component in two `Spacer(1)` lines that aren't
 // removable via the public API, so the banner sits with one blank line
@@ -13,9 +14,18 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Container, Text } from "@mariozechner/pi-tui";
 
 export default function (pi: ExtensionAPI) {
+  pi.registerFlag("agent-name", {
+    description: "Agent name shown bold/accent on the first line of the TUI header banner",
+    type: "string",
+  });
+  pi.registerFlag("agent-description", {
+    description: "One-line description shown dim under the agent name in the TUI header banner",
+    type: "string",
+  });
+
   pi.on("session_start", async (_event, ctx) => {
-    const name = process.env.AGENT_NAME?.trim();
-    const description = process.env.AGENT_DESCRIPTION?.trim();
+    const name = (pi.getFlag("agent-name") as string | undefined)?.trim();
+    const description = (pi.getFlag("agent-description") as string | undefined)?.trim();
     if (!name && !description) return;
 
     ctx.ui.setHeader((_tui, theme) => {

--- a/pi-sandbox/.pi/extensions/deferred-write.ts
+++ b/pi-sandbox/.pi/extensions/deferred-write.ts
@@ -9,7 +9,7 @@
 // targeting paths that already exist.
 //
 // Designed to compose with sandbox.ts: paths are validated against the
-// same root (AGENT_SANDBOX_ROOT, falling back to ctx.cwd).
+// same root (the `--sandbox-root` flag, falling back to ctx.cwd).
 
 import { createHash } from "node:crypto";
 import fs from "node:fs";
@@ -59,7 +59,7 @@ export default function (pi: ExtensionAPI) {
   pi.on("agent_end", async (_event, ctx) => {
     if (drafts.length === 0) return;
     const queued = drafts.splice(0, drafts.length);
-    const root = path.resolve(process.env.AGENT_SANDBOX_ROOT || ctx.cwd);
+    const root = path.resolve((pi.getFlag("sandbox-root") as string | undefined) || ctx.cwd);
 
     type Plan = { relPath: string; destAbs: string; content: string; sha: string; bytes: number };
     const plans: Plan[] = [];

--- a/pi-sandbox/.pi/extensions/hide-extensions-list.ts
+++ b/pi-sandbox/.pi/extensions/hide-extensions-list.ts
@@ -1,0 +1,81 @@
+// hide-extensions-list — strips pi's `[Extensions]` section from the
+// chat history at startup. Pi calls `showLoadedResources` immediately
+// after extension session_start handlers finish, with no per-section
+// suppression in the public extension API. So we use `setWidget` as a
+// side-channel to capture the TUI instance, schedule a setTimeout(0)
+// callback that runs after `showLoadedResources` has appended the
+// section, and splice the matching subtree (plus its trailing Spacer)
+// out of the chat container.
+//
+// This reaches into private TUI state shape and is fragile if pi's
+// internal layout changes. If a future pi exposes a quietStartup
+// setter via the extension API, prefer that and delete this rail.
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { Component } from "@mariozechner/pi-tui";
+
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+const SECTION_LABEL = "[Extensions]";
+const PROBE_WIDTH = 80;
+
+function isContainer(node: unknown): node is { children: Component[] } {
+  return (
+    node !== null &&
+    typeof node === "object" &&
+    "children" in (node as object) &&
+    Array.isArray((node as { children: unknown }).children)
+  );
+}
+
+function firstStrippedLine(node: Component): string {
+  try {
+    const lines = node.render(PROBE_WIDTH);
+    if (!lines || lines.length === 0) return "";
+    return (lines[0] ?? "").replace(ANSI_RE, "").trim();
+  } catch {
+    return "";
+  }
+}
+
+function findAndRemove(node: Component, label: string): boolean {
+  if (!isContainer(node)) return false;
+  const arr = node.children;
+  for (let i = 0; i < arr.length; i++) {
+    if (firstStrippedLine(arr[i]!) === label) {
+      // Drop the matched section and the trailing Spacer pi adds after it.
+      arr.splice(i, i + 1 < arr.length ? 2 : 1);
+      return true;
+    }
+    if (findAndRemove(arr[i]!, label)) return true;
+  }
+  return false;
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    const captureKey = "hide-extensions-list:capture";
+    let tui: Component | undefined;
+
+    ctx.ui.setWidget(
+      captureKey,
+      (t) => {
+        tui = t as unknown as Component;
+        return {
+          render: () => [],
+          invalidate: () => {},
+        };
+      },
+      { placement: "belowEditor" },
+    );
+
+    setTimeout(() => {
+      try {
+        if (tui && findAndRemove(tui, SECTION_LABEL)) {
+          (tui as { requestRender?: () => void }).requestRender?.();
+        }
+      } finally {
+        ctx.ui.setWidget(captureKey, undefined);
+      }
+    }, 0);
+  });
+}

--- a/pi-sandbox/.pi/extensions/hide-extensions-list.ts
+++ b/pi-sandbox/.pi/extensions/hide-extensions-list.ts
@@ -1,11 +1,14 @@
-// hide-extensions-list — strips pi's `[Extensions]` section from the
-// chat history at startup. Pi calls `showLoadedResources` immediately
-// after extension session_start handlers finish, with no per-section
-// suppression in the public extension API. So we use `setWidget` as a
-// side-channel to capture the TUI instance, schedule a setTimeout(0)
-// callback that runs after `showLoadedResources` has appended the
-// section, and splice the matching subtree (plus its trailing Spacer)
-// out of the chat container.
+// hide-extensions-list — baseline rail that strips pi's `[Extensions]`
+// section from the chat history at startup. The agent-footer already
+// shows the active tools, and the path listing pi appends is noise.
+//
+// Pi calls `showLoadedResources` immediately after extension
+// session_start handlers finish, with no per-section suppression in
+// the public extension API. So we use `setWidget` as a side-channel
+// to capture the TUI instance, schedule a setTimeout(0) callback that
+// runs after `showLoadedResources` has appended the section, and
+// splice the matching subtree (plus its trailing Spacer) out of the
+// chat container.
 //
 // This reaches into private TUI state shape and is fragile if pi's
 // internal layout changes. If a future pi exposes a quietStartup

--- a/pi-sandbox/.pi/extensions/hide-extensions-list.ts
+++ b/pi-sandbox/.pi/extensions/hide-extensions-list.ts
@@ -44,12 +44,16 @@ function findAndRemove(node: Component, label: string): boolean {
   if (!isContainer(node)) return false;
   const arr = node.children;
   for (let i = 0; i < arr.length; i++) {
+    // Recurse first so deeper matches splice from the closest container.
+    // Otherwise an ancestor (e.g. pi's chatContainer when [Extensions] is its
+    // first child) matches at the wrong level and we splice the whole
+    // ancestor out, taking all chat history with it.
+    if (findAndRemove(arr[i]!, label)) return true;
     if (firstStrippedLine(arr[i]!) === label) {
       // Drop the matched section and the trailing Spacer pi adds after it.
       arr.splice(i, i + 1 < arr.length ? 2 : 1);
       return true;
     }
-    if (findAndRemove(arr[i]!, label)) return true;
   }
   return false;
 }

--- a/pi-sandbox/.pi/extensions/no-edit.ts
+++ b/pi-sandbox/.pi/extensions/no-edit.ts
@@ -14,8 +14,10 @@
 //   `write` plus our `deferred_write`.
 //
 // Recipe overrides (forwarded by scripts/run-agent.mjs):
-//   noEditAdd:  [tool, ...]   →  AGENT_NO_EDIT_ADD   (force-include)
-//   noEditSkip: [tool, ...]   →  AGENT_NO_EDIT_SKIP  (force-exclude)
+//   noEditAdd:  [tool, ...]   →  --no-edit-add  <a,b,...>   (force-include)
+//   noEditSkip: [tool, ...]   →  --no-edit-skip <a,b,...>   (force-exclude)
+// The sandbox-root path used to compare resolved targets is read from
+// the `--sandbox-root` flag (registered by the sandbox extension).
 
 import fs from "node:fs";
 import path from "node:path";
@@ -34,13 +36,21 @@ function declaresWriteShape(parameters: unknown): boolean {
   }
 }
 
-function parseEnvList(name: string): string[] {
-  const raw = process.env[name];
+function parseFlagList(raw: string | undefined): string[] {
   if (!raw) return [];
   return raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
 }
 
 export default function (pi: ExtensionAPI) {
+  pi.registerFlag("no-edit-add", {
+    description: "Comma-separated extra tools to force-include in the no-edit (create-only) rail",
+    type: "string",
+  });
+  pi.registerFlag("no-edit-skip", {
+    description: "Comma-separated tools to exempt from the no-edit (create-only) rail",
+    type: "string",
+  });
+
   const createOnlyTools = new Set<string>(STATIC_CREATE_ONLY_TOOLS);
 
   pi.on("session_start", async (_event, ctx) => {
@@ -55,8 +65,8 @@ export default function (pi: ExtensionAPI) {
       );
     }
 
-    for (const t of parseEnvList("AGENT_NO_EDIT_ADD")) createOnlyTools.add(t);
-    for (const t of parseEnvList("AGENT_NO_EDIT_SKIP")) createOnlyTools.delete(t);
+    for (const t of parseFlagList(pi.getFlag("no-edit-add") as string | undefined)) createOnlyTools.add(t);
+    for (const t of parseFlagList(pi.getFlag("no-edit-skip") as string | undefined)) createOnlyTools.delete(t);
 
     if (process.env.AGENT_DEBUG === "1") {
       const dump = `no-edit createOnlyTools = [${[...createOnlyTools].sort().join(", ")}]`;
@@ -75,7 +85,7 @@ export default function (pi: ExtensionAPI) {
     const raw = (event.input as Record<string, unknown>).path;
     if (typeof raw !== "string" || raw.length === 0) return undefined;
 
-    const root = path.resolve(process.env.AGENT_SANDBOX_ROOT || process.cwd());
+    const root = path.resolve((pi.getFlag("sandbox-root") as string | undefined) || process.cwd());
     const abs = path.isAbsolute(raw) ? raw : path.resolve(root, raw);
 
     if (fs.existsSync(abs)) {

--- a/pi-sandbox/.pi/extensions/no-startup-help.ts
+++ b/pi-sandbox/.pi/extensions/no-startup-help.ts
@@ -1,0 +1,17 @@
+// no-startup-help — suppresses pi's default startup header (logo,
+// keybinding cheatsheet, "Press ^O for help", onboarding tips). Pi
+// surrounds the header with spacers, so this leaves a small gap at
+// the top of the chat area but removes the help text itself.
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    ctx.ui.setHeader(() => ({
+      invalidate() {},
+      render() {
+        return [];
+      },
+    }));
+  });
+}

--- a/pi-sandbox/.pi/extensions/sandbox.ts
+++ b/pi-sandbox/.pi/extensions/sandbox.ts
@@ -12,9 +12,18 @@
 // and falls back to ctx.cwd. The runner spawns pi with cwd = sandbox root,
 // so a missing/empty `path` (which the built-in tools resolve to ".") is
 // always inside the root.
+//
+// The extension also installs a custom footer that replaces pi's default
+// `cwd (branch)` line with `sandbox: <root>` so the user sees the
+// confined directory rather than the host cwd / git branch (which the
+// agent cannot escape anyway). The remaining footer lines (token stats,
+// model, extension statuses) mirror the default footer.
 
+import os from "node:os";
 import path from "node:path";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 
 const STATIC_PATH_TOOLS = ["read", "write", "edit", "ls", "grep", "find"];
 
@@ -25,6 +34,26 @@ function declaresPathString(parameters: unknown): boolean {
   } catch {
     return false;
   }
+}
+
+function formatTokens(count: number): string {
+  if (count < 1000) return String(count);
+  if (count < 10_000) return `${(count / 1000).toFixed(1)}k`;
+  if (count < 1_000_000) return `${Math.round(count / 1000)}k`;
+  if (count < 10_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  return `${Math.round(count / 1_000_000)}M`;
+}
+
+function homeReplace(p: string): string {
+  const home = os.homedir();
+  if (!home) return p;
+  if (p === home) return "~";
+  if (p.startsWith(home + path.sep)) return `~${p.slice(home.length)}`;
+  return p;
+}
+
+function sanitizeStatusText(text: string): string {
+  return text.replace(/[\r\n\t]/g, " ").replace(/ +/g, " ").trim();
 }
 
 export default function (pi: ExtensionAPI) {
@@ -42,13 +71,96 @@ export default function (pi: ExtensionAPI) {
       );
     }
 
-    const root = process.env.AGENT_SANDBOX_ROOT || ctx.cwd;
+    const root = path.resolve(process.env.AGENT_SANDBOX_ROOT || ctx.cwd);
+    const displayRoot = homeReplace(root);
     ctx.ui.notify(`sandbox active: fs limited to ${root}, bash disabled`, "info");
     if (process.env.AGENT_DEBUG === "1") {
       const dump = `sandbox pathTools = [${[...pathTools].sort().join(", ")}]`;
       ctx.ui.notify(dump, "info");
       process.stderr.write(`[AGENT_DEBUG] ${dump}\n`);
     }
+
+    ctx.ui.setFooter((_tui, theme, footerData) => ({
+      invalidate() {},
+      render(width: number): string[] {
+        const pwdLine = truncateToWidth(
+          theme.fg("dim", `sandbox: ${displayRoot}`),
+          width,
+          theme.fg("dim", "..."),
+        );
+
+        let input = 0;
+        let output = 0;
+        let cacheRead = 0;
+        let cacheWrite = 0;
+        let cost = 0;
+        for (const entry of ctx.sessionManager.getEntries()) {
+          if (entry.type === "message" && entry.message.role === "assistant") {
+            const u = (entry.message as AssistantMessage).usage;
+            input += u.input;
+            output += u.output;
+            cacheRead += u.cacheRead;
+            cacheWrite += u.cacheWrite;
+            cost += u.cost.total;
+          }
+        }
+
+        const usage = ctx.getContextUsage();
+        const ctxWindow = usage?.contextWindow ?? ctx.model?.contextWindow ?? 0;
+        const ctxPct = usage?.percent;
+
+        const stats: string[] = [];
+        if (input) stats.push(`↑${formatTokens(input)}`);
+        if (output) stats.push(`↓${formatTokens(output)}`);
+        if (cacheRead) stats.push(`R${formatTokens(cacheRead)}`);
+        if (cacheWrite) stats.push(`W${formatTokens(cacheWrite)}`);
+        if (cost) stats.push(`$${cost.toFixed(3)}`);
+
+        const ctxStr =
+          typeof ctxPct === "number"
+            ? `${ctxPct.toFixed(1)}%/${formatTokens(ctxWindow)}`
+            : `?/${formatTokens(ctxWindow)}`;
+        let ctxColored = ctxStr;
+        if (typeof ctxPct === "number") {
+          if (ctxPct > 90) ctxColored = theme.fg("error", ctxStr);
+          else if (ctxPct > 70) ctxColored = theme.fg("warning", ctxStr);
+        }
+        stats.push(ctxColored);
+
+        const left = stats.join(" ");
+        const right = ctx.model?.id || "no-model";
+        const leftW = visibleWidth(left);
+        const rightW = visibleWidth(right);
+        const minPad = 2;
+
+        let statsLine: string;
+        if (leftW + minPad + rightW <= width) {
+          statsLine = left + " ".repeat(width - leftW - rightW) + right;
+        } else if (leftW + minPad < width) {
+          const truncR = truncateToWidth(right, width - leftW - minPad, "");
+          const padW = Math.max(0, width - leftW - visibleWidth(truncR));
+          statsLine = left + " ".repeat(padW) + truncR;
+        } else {
+          statsLine = truncateToWidth(left, width, "...");
+        }
+
+        // The context-percent color emits a reset that would clear an outer
+        // dim wrapper, so dim the pre-color portion and the remainder separately.
+        const dimLeft = theme.fg("dim", left);
+        const dimRest = theme.fg("dim", statsLine.slice(left.length));
+        const lines = [pwdLine, dimLeft + dimRest];
+
+        const statuses = footerData.getExtensionStatuses();
+        if (statuses.size > 0) {
+          const sorted = Array.from(statuses.entries())
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([, t]) => sanitizeStatusText(t));
+          lines.push(truncateToWidth(sorted.join(" "), width, theme.fg("dim", "...")));
+        }
+
+        return lines;
+      },
+    }));
   });
 
   pi.on("tool_call", async (event, ctx) => {

--- a/pi-sandbox/.pi/extensions/sandbox.ts
+++ b/pi-sandbox/.pi/extensions/sandbox.ts
@@ -73,7 +73,6 @@ export default function (pi: ExtensionAPI) {
 
     const root = path.resolve(process.env.AGENT_SANDBOX_ROOT || ctx.cwd);
     const displayRoot = homeReplace(root);
-    ctx.ui.notify(`sandbox active: fs limited to ${root}, bash disabled`, "info");
     if (process.env.AGENT_DEBUG === "1") {
       const dump = `sandbox pathTools = [${[...pathTools].sort().join(", ")}]`;
       ctx.ui.notify(dump, "info");

--- a/pi-sandbox/.pi/extensions/sandbox.ts
+++ b/pi-sandbox/.pi/extensions/sandbox.ts
@@ -8,10 +8,12 @@
 // installed pi 0.69 built-ins; introspection automatically picks up
 // custom tools (including deferred_write) and any future built-ins.
 //
-// Sandbox root is read from AGENT_SANDBOX_ROOT (set by scripts/run-agent.mjs)
-// and falls back to ctx.cwd. The runner spawns pi with cwd = sandbox root,
-// so a missing/empty `path` (which the built-in tools resolve to ".") is
-// always inside the root.
+// Sandbox root is read from the `--sandbox-root` flag (set by
+// scripts/run-agent.mjs) and falls back to ctx.cwd. The runner spawns pi
+// with cwd = sandbox root, so a missing/empty `path` (which the built-in
+// tools resolve to ".") is always inside the root. This extension owns
+// the `--sandbox-root` flag; the agent-footer, deferred-write, and
+// no-edit extensions read it via pi.getFlag.
 //
 // Footer rendering (sandbox dir, tools list, stats) lives in the
 // `agent-footer` extension.
@@ -31,6 +33,11 @@ function declaresPathString(parameters: unknown): boolean {
 }
 
 export default function (pi: ExtensionAPI) {
+  pi.registerFlag("sandbox-root", {
+    description: "Root directory for the sandbox; tool calls outside it are blocked",
+    type: "string",
+  });
+
   const pathTools = new Set<string>(STATIC_PATH_TOOLS);
 
   pi.on("session_start", async (_event, ctx) => {
@@ -59,7 +66,7 @@ export default function (pi: ExtensionAPI) {
 
     if (!pathTools.has(event.toolName)) return undefined;
 
-    const root = path.resolve(process.env.AGENT_SANDBOX_ROOT || ctx.cwd);
+    const root = path.resolve((pi.getFlag("sandbox-root") as string | undefined) || ctx.cwd);
     const input = event.input as Record<string, unknown>;
     const raw = input.path;
     if (raw !== undefined && typeof raw !== "string") return undefined;

--- a/pi-sandbox/.pi/extensions/sandbox.ts
+++ b/pi-sandbox/.pi/extensions/sandbox.ts
@@ -13,17 +13,11 @@
 // so a missing/empty `path` (which the built-in tools resolve to ".") is
 // always inside the root.
 //
-// The extension also installs a custom footer that replaces pi's default
-// `cwd (branch)` line with `sandbox: <root>` so the user sees the
-// confined directory rather than the host cwd / git branch (which the
-// agent cannot escape anyway). The remaining footer lines (token stats,
-// model, extension statuses) mirror the default footer.
+// Footer rendering (sandbox dir, tools list, stats) lives in the
+// `agent-footer` extension.
 
-import os from "node:os";
 import path from "node:path";
-import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 
 const STATIC_PATH_TOOLS = ["read", "write", "edit", "ls", "grep", "find"];
 
@@ -34,26 +28,6 @@ function declaresPathString(parameters: unknown): boolean {
   } catch {
     return false;
   }
-}
-
-function formatTokens(count: number): string {
-  if (count < 1000) return String(count);
-  if (count < 10_000) return `${(count / 1000).toFixed(1)}k`;
-  if (count < 1_000_000) return `${Math.round(count / 1000)}k`;
-  if (count < 10_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
-  return `${Math.round(count / 1_000_000)}M`;
-}
-
-function homeReplace(p: string): string {
-  const home = os.homedir();
-  if (!home) return p;
-  if (p === home) return "~";
-  if (p.startsWith(home + path.sep)) return `~${p.slice(home.length)}`;
-  return p;
-}
-
-function sanitizeStatusText(text: string): string {
-  return text.replace(/[\r\n\t]/g, " ").replace(/ +/g, " ").trim();
 }
 
 export default function (pi: ExtensionAPI) {
@@ -71,95 +45,11 @@ export default function (pi: ExtensionAPI) {
       );
     }
 
-    const root = path.resolve(process.env.AGENT_SANDBOX_ROOT || ctx.cwd);
-    const displayRoot = homeReplace(root);
     if (process.env.AGENT_DEBUG === "1") {
       const dump = `sandbox pathTools = [${[...pathTools].sort().join(", ")}]`;
       ctx.ui.notify(dump, "info");
       process.stderr.write(`[AGENT_DEBUG] ${dump}\n`);
     }
-
-    ctx.ui.setFooter((_tui, theme, footerData) => ({
-      invalidate() {},
-      render(width: number): string[] {
-        const pwdLine = truncateToWidth(
-          theme.fg("dim", `sandbox: ${displayRoot}`),
-          width,
-          theme.fg("dim", "..."),
-        );
-
-        let input = 0;
-        let output = 0;
-        let cacheRead = 0;
-        let cacheWrite = 0;
-        let cost = 0;
-        for (const entry of ctx.sessionManager.getEntries()) {
-          if (entry.type === "message" && entry.message.role === "assistant") {
-            const u = (entry.message as AssistantMessage).usage;
-            input += u.input;
-            output += u.output;
-            cacheRead += u.cacheRead;
-            cacheWrite += u.cacheWrite;
-            cost += u.cost.total;
-          }
-        }
-
-        const usage = ctx.getContextUsage();
-        const ctxWindow = usage?.contextWindow ?? ctx.model?.contextWindow ?? 0;
-        const ctxPct = usage?.percent;
-
-        const stats: string[] = [];
-        if (input) stats.push(`↑${formatTokens(input)}`);
-        if (output) stats.push(`↓${formatTokens(output)}`);
-        if (cacheRead) stats.push(`R${formatTokens(cacheRead)}`);
-        if (cacheWrite) stats.push(`W${formatTokens(cacheWrite)}`);
-        if (cost) stats.push(`$${cost.toFixed(3)}`);
-
-        const ctxStr =
-          typeof ctxPct === "number"
-            ? `${ctxPct.toFixed(1)}%/${formatTokens(ctxWindow)}`
-            : `?/${formatTokens(ctxWindow)}`;
-        let ctxColored = ctxStr;
-        if (typeof ctxPct === "number") {
-          if (ctxPct > 90) ctxColored = theme.fg("error", ctxStr);
-          else if (ctxPct > 70) ctxColored = theme.fg("warning", ctxStr);
-        }
-        stats.push(ctxColored);
-
-        const left = stats.join(" ");
-        const right = ctx.model?.id || "no-model";
-        const leftW = visibleWidth(left);
-        const rightW = visibleWidth(right);
-        const minPad = 2;
-
-        let statsLine: string;
-        if (leftW + minPad + rightW <= width) {
-          statsLine = left + " ".repeat(width - leftW - rightW) + right;
-        } else if (leftW + minPad < width) {
-          const truncR = truncateToWidth(right, width - leftW - minPad, "");
-          const padW = Math.max(0, width - leftW - visibleWidth(truncR));
-          statsLine = left + " ".repeat(padW) + truncR;
-        } else {
-          statsLine = truncateToWidth(left, width, "...");
-        }
-
-        // The context-percent color emits a reset that would clear an outer
-        // dim wrapper, so dim the pre-color portion and the remainder separately.
-        const dimLeft = theme.fg("dim", left);
-        const dimRest = theme.fg("dim", statsLine.slice(left.length));
-        const lines = [pwdLine, dimLeft + dimRest];
-
-        const statuses = footerData.getExtensionStatuses();
-        if (statuses.size > 0) {
-          const sorted = Array.from(statuses.entries())
-            .sort(([a], [b]) => a.localeCompare(b))
-            .map(([, t]) => sanitizeStatusText(t));
-          lines.push(truncateToWidth(sorted.join(" "), width, theme.fg("dim", "...")));
-        }
-
-        return lines;
-      },
-    }));
   });
 
   pi.on("tool_call", async (event, ctx) => {

--- a/pi-sandbox/agents/deferred-writer.yaml
+++ b/pi-sandbox/agents/deferred-writer.yaml
@@ -4,6 +4,8 @@
 
 model: TASK_RABBIT_MODEL
 
+description: Drafts files in memory; the user reviews and approves at end of turn.
+
 prompt: |
   You are a careful drafter. Your job is to read the user's request, inspect
   the project enough to draft the right files, then call `deferred_write` for

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -135,7 +135,8 @@ const recipe = loadRecipe(args.name);
 const sandboxRoot = path.resolve(args.sandbox || process.env.INIT_CWD || process.cwd());
 if (!existsSync(sandboxRoot)) die(`sandbox dir does not exist: ${sandboxRoot}`);
 
-const model = resolveModel(recipe.model);
+const recipeModel = recipe.model || "TASK_RABBIT_MODEL";
+const model = resolveModel(recipeModel);
 const extensionPaths = resolveExtensionPaths(Array.isArray(recipe.extensions) ? recipe.extensions : []);
 const skillPaths = resolveSkillPaths(Array.isArray(recipe.skills) ? recipe.skills : []);
 
@@ -158,6 +159,9 @@ piArgs.push("--sandbox-root", sandboxRoot);
 piArgs.push("--agent-name", args.name);
 if (typeof recipe.description === "string" && recipe.description.trim()) {
   piArgs.push("--agent-description", recipe.description.trim());
+}
+if (TIER_VARS.has(recipeModel)) {
+  piArgs.push("--agent-tier", recipeModel);
 }
 if (Array.isArray(recipe.noEditAdd) && recipe.noEditAdd.length > 0) {
   piArgs.push("--no-edit-add", recipe.noEditAdd.join(","));

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -154,29 +154,25 @@ const piArgs = [
 ];
 for (const p of extensionPaths) piArgs.push("-e", p);
 for (const p of skillPaths) piArgs.push("--skill", p);
+piArgs.push("--sandbox-root", sandboxRoot);
+piArgs.push("--agent-name", args.name);
+if (typeof recipe.description === "string" && recipe.description.trim()) {
+  piArgs.push("--agent-description", recipe.description.trim());
+}
+if (Array.isArray(recipe.noEditAdd) && recipe.noEditAdd.length > 0) {
+  piArgs.push("--no-edit-add", recipe.noEditAdd.join(","));
+}
+if (Array.isArray(recipe.noEditSkip) && recipe.noEditSkip.length > 0) {
+  piArgs.push("--no-edit-skip", recipe.noEditSkip.join(","));
+}
 piArgs.push(...args.passthrough);
 
 if (!existsSync(PI_BIN)) die(`pi binary missing: ${PI_BIN} (run npm install)`);
 
-const childEnv = {
-  ...process.env,
-  AGENT_SANDBOX_ROOT: sandboxRoot,
-  AGENT_NAME: args.name,
-};
-if (typeof recipe.description === "string" && recipe.description.trim()) {
-  childEnv.AGENT_DESCRIPTION = recipe.description.trim();
-}
-if (Array.isArray(recipe.noEditAdd) && recipe.noEditAdd.length > 0) {
-  childEnv.AGENT_NO_EDIT_ADD = recipe.noEditAdd.join(",");
-}
-if (Array.isArray(recipe.noEditSkip) && recipe.noEditSkip.length > 0) {
-  childEnv.AGENT_NO_EDIT_SKIP = recipe.noEditSkip.join(",");
-}
-
 const child = spawn(PI_BIN, piArgs, {
   cwd: sandboxRoot,
   stdio: "inherit",
-  env: childEnv,
+  env: process.env,
 });
 
 child.on("exit", (code, signal) => {

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -12,7 +12,7 @@ const EXTENSIONS_DIR = path.join(SANDBOX_ROOT, ".pi", "extensions");
 const SKILLS_DIR = path.join(SANDBOX_ROOT, "skills");
 const PI_BIN = path.join(REPO_ROOT, "node_modules", ".bin", "pi");
 
-const BASELINE_EXTENSIONS = ["sandbox", "no-startup-help", "agent-footer"];
+const BASELINE_EXTENSIONS = ["sandbox", "no-startup-help", "agent-footer", "hide-extensions-list"];
 const TIER_VARS = new Set(["RABBIT_SAGE_MODEL", "LEAD_HARE_MODEL", "TASK_RABBIT_MODEL"]);
 
 function die(msg) {

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -12,7 +12,7 @@ const EXTENSIONS_DIR = path.join(SANDBOX_ROOT, ".pi", "extensions");
 const SKILLS_DIR = path.join(SANDBOX_ROOT, "skills");
 const PI_BIN = path.join(REPO_ROOT, "node_modules", ".bin", "pi");
 
-const BASELINE_EXTENSIONS = ["sandbox", "no-startup-help"];
+const BASELINE_EXTENSIONS = ["sandbox", "no-startup-help", "agent-footer"];
 const TIER_VARS = new Set(["RABBIT_SAGE_MODEL", "LEAD_HARE_MODEL", "TASK_RABBIT_MODEL"]);
 
 function die(msg) {

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -12,7 +12,7 @@ const EXTENSIONS_DIR = path.join(SANDBOX_ROOT, ".pi", "extensions");
 const SKILLS_DIR = path.join(SANDBOX_ROOT, "skills");
 const PI_BIN = path.join(REPO_ROOT, "node_modules", ".bin", "pi");
 
-const BASELINE_EXTENSIONS = ["sandbox"];
+const BASELINE_EXTENSIONS = ["sandbox", "no-startup-help"];
 const TIER_VARS = new Set(["RABBIT_SAGE_MODEL", "LEAD_HARE_MODEL", "TASK_RABBIT_MODEL"]);
 
 function die(msg) {

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -12,7 +12,13 @@ const EXTENSIONS_DIR = path.join(SANDBOX_ROOT, ".pi", "extensions");
 const SKILLS_DIR = path.join(SANDBOX_ROOT, "skills");
 const PI_BIN = path.join(REPO_ROOT, "node_modules", ".bin", "pi");
 
-const BASELINE_EXTENSIONS = ["sandbox", "no-startup-help", "agent-footer", "hide-extensions-list"];
+const BASELINE_EXTENSIONS = [
+  "sandbox",
+  "no-startup-help",
+  "agent-header",
+  "agent-footer",
+  "hide-extensions-list",
+];
 const TIER_VARS = new Set(["RABBIT_SAGE_MODEL", "LEAD_HARE_MODEL", "TASK_RABBIT_MODEL"]);
 
 function die(msg) {
@@ -157,6 +163,9 @@ const childEnv = {
   AGENT_SANDBOX_ROOT: sandboxRoot,
   AGENT_NAME: args.name,
 };
+if (typeof recipe.description === "string" && recipe.description.trim()) {
+  childEnv.AGENT_DESCRIPTION = recipe.description.trim();
+}
 if (Array.isArray(recipe.noEditAdd) && recipe.noEditAdd.length > 0) {
   childEnv.AGENT_NO_EDIT_ADD = recipe.noEditAdd.join(",");
 }


### PR DESCRIPTION
* feat: composable agents via npm run agent <name>

Recipes in pi-sandbox/agents/<name>.yaml declare prompt, model tier,
tool allowlist, extensions, and skills. scripts/run-agent.mjs resolves
the recipe and execs pi from the user's cwd (or --sandbox <dir>) so
filesystem activity is naturally rooted there.

Every agent gets the new sandbox.ts baseline extension, which blocks
bash entirely and rejects any path-bearing tool call that escapes the
sandbox root.

deferred-writer is the first migrated agent: the old child-process
slash command is replaced by a top-level deferred_write tool that
buffers drafts in memory and prompts for promotion at agent_end.

* docs: rename model tiers and refresh AGENTS.md for npm run agent

Tiers now read in the rabbit/hare/sage idiom we want to use throughout:
  PLAN_MODEL  -> RABBIT_SAGE_MODEL  (Rabbit Sage — planner)
  LEAD_MODEL  -> LEAD_HARE_MODEL    (Lead Hare — task overseer)
  TASK_MODEL  -> TASK_RABBIT_MODEL  (Task Rabbit — worker)

Updated every reference (models.env, AGENTS.md, defaults skill, runner,
deferred-writer recipe).

Also refreshed AGENTS.md to document the new npm run agent flow (recipe
shape, sandbox baseline, deferred-writer worked example) and dropped the
stale child-tools/slash-command sections.

* docs: split AGENTS.md into a docs/ folder

AGENTS.md was approaching 200 lines and mixing tier reference, runner
docs, scripted-pi gotchas, layout, and conventions. Split into:

  docs/agents.md       npm run agent recipe shape + sandbox baseline
  docs/model-tiers.md  tier table + how to switch
  docs/pi-direct.md    raw npm run pi, pi-agent-builder skill, -p gotchas
  docs/repo-layout.md  directory tour + build-by-pi workflow
  docs/conventions.md  branch/commit/secrets

AGENTS.md is now a 38-line index. The two load-bearing docs (agents,
model-tiers) are pulled into Claude Code's context via @-includes; the
rest stay as plain links and load on demand.

* fix: update deferred-writer agent documentation to remove invalid commands

* refactor: split deferred-write and no-edit into composable rails

deferred-write previously did two things: buffer-and-approve, and
refuse-to-overwrite. That conflated two policies that some agents will
want independently. Split them:

- deferred-write keeps only the buffer/preview/approve flow. If the
  user approves, the write proceeds even when the target exists; the
  preview marks overwrites with [OVERWRITE] so it is obvious.
- no-edit is a new extension that blocks edit outright and rejects
  write / deferred_write whose target already exists.

deferred-writer.yaml now lists both, preserving the previous behavior.
Recipes that want overwrite-on-approval can drop no-edit; recipes that
use plain write but still want create-only can drop deferred-write.

---------

Co-authored-by: Claude <noreply@anthropic.com>