### PR TITLE
Refactor agent system to recipe-driven runner with sandbox isolation (#30)

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -115,9 +115,28 @@ Set `AGENT_DEBUG=1` in the environment when launching an agent and the
 via `ctx.ui.notify` on `session_start`. Useful when you've added a new
 write tool and want to confirm it was picked up by introspection.
 
+The rails — `agent-header`, `agent-footer`, and `deferred-write`'s
+end-of-turn `ctx.ui.confirm` dialog — only render under a real PTY,
+so `pi -p` print mode can't exercise them. For integration testing,
+drive a full TUI session under tmux:
+
 ```sh
-AGENT_DEBUG=1 npm run agent -- deferred-writer -p "ping"
+set -a; source models.env; set +a
+tmux new-session -d -s pi-test -x 200 -y 50 \
+  'AGENT_DEBUG=1 npm run agent -- deferred-writer'
+sleep 5                                              # let pi boot + print debug
+tmux send-keys -t pi-test 'draft hello.txt saying hi' Enter
+sleep 30                                             # wait for the model
+tmux capture-pane -t pi-test -p                       # snapshot the screen
+tmux send-keys -t pi-test 'y' Enter                   # approve deferred_write dialog
+sleep 5
+tmux capture-pane -t pi-test -p
+tmux send-keys -t pi-test '/quit' Enter
 ```
+
+Caveats: this hits the real model so each run costs a fraction of a
+cent, and `capture-pane -p` returns plain text — colors and bold from
+`agent-header` won't show up in the snapshot.
 
 ## Mandatory safety rails for sub-agents
 


### PR DESCRIPTION
* feat: composable agents via npm run agent <name>

Recipes in pi-sandbox/agents/<name>.yaml declare prompt, model tier,
tool allowlist, extensions, and skills. scripts/run-agent.mjs resolves
the recipe and execs pi from the user's cwd (or --sandbox <dir>) so
filesystem activity is naturally rooted there.

Every agent gets the new sandbox.ts baseline extension, which blocks
bash entirely and rejects any path-bearing tool call that escapes the
sandbox root.

deferred-writer is the first migrated agent: the old child-process
slash command is replaced by a top-level deferred_write tool that
buffers drafts in memory and prompts for promotion at agent_end.

* docs: rename model tiers and refresh AGENTS.md for npm run agent

Tiers now read in the rabbit/hare/sage idiom we want to use throughout:
  PLAN_MODEL  -> RABBIT_SAGE_MODEL  (Rabbit Sage — planner)
  LEAD_MODEL  -> LEAD_HARE_MODEL    (Lead Hare — task overseer)
  TASK_MODEL  -> TASK_RABBIT_MODEL  (Task Rabbit — worker)

Updated every reference (models.env, AGENTS.md, defaults skill, runner,
deferred-writer recipe).

Also refreshed AGENTS.md to document the new npm run agent flow (recipe
shape, sandbox baseline, deferred-writer worked example) and dropped the
stale child-tools/slash-command sections.

* docs: split AGENTS.md into a docs/ folder

AGENTS.md was approaching 200 lines and mixing tier reference, runner
docs, scripted-pi gotchas, layout, and conventions. Split into:

  docs/agents.md       npm run agent recipe shape + sandbox baseline
  docs/model-tiers.md  tier table + how to switch
  docs/pi-direct.md    raw npm run pi, pi-agent-builder skill, -p gotchas
  docs/repo-layout.md  directory tour + build-by-pi workflow
  docs/conventions.md  branch/commit/secrets

AGENTS.md is now a 38-line index. The two load-bearing docs (agents,
model-tiers) are pulled into Claude Code's context via @-includes; the
rest stay as plain links and load on demand.

* fix: update deferred-writer agent documentation to remove invalid commands

* refactor: split deferred-write and no-edit into composable rails

deferred-write previously did two things: buffer-and-approve, and
refuse-to-overwrite. That conflated two policies that some agents will
want independently. Split them:

- deferred-write keeps only the buffer/preview/approve flow. If the
  user approves, the write proceeds even when the target exists; the
  preview marks overwrites with [OVERWRITE] so it is obvious.
- no-edit is a new extension that blocks edit outright and rejects
  write / deferred_write whose target already exists.

deferred-writer.yaml now lists both, preserving the previous behavior.
Recipes that want overwrite-on-approval can drop no-edit; recipes that
use plain write but still want create-only can drop deferred-write.

---------

Co-authored-by: Claude <noreply@anthropic.com>