### PR TITLE
Add deferred batch approval system for writes, edits, moves, deletes

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -4,7 +4,7 @@ Day-to-day, the way to launch a focused agent is `npm run agent -- <name>`.
 The runner (`scripts/run-agent.mjs`) reads a YAML recipe from
 `pi-sandbox/agents/<name>.yaml`, resolves the model tier, and execs `pi`
 from the directory you invoked it from (or `--sandbox <dir>`). Every
-agent gets five baseline extensions:
+agent gets six baseline extensions:
 
 - `sandbox` — blocks `bash` outright and rejects any path-bearing tool
   call whose `path` resolves outside the sandbox root. The set of
@@ -40,6 +40,19 @@ agent gets five baseline extensions:
   agent-footer already shows the active tools and the path listing is
   noise. Reaches into private TUI state via `setWidget`+`setTimeout(0)`
   because pi has no public API to suppress per-section.
+- `deferred-confirm` — end-of-turn coordinator for any `deferred-*`
+  extension. Exposes `registerDeferredHandler({ label, extension,
+  priority, prepare })` (named export) plus a single `agent_end` listener
+  that calls every registered handler's `prepare(ctx)`, aggregates the
+  results into one `ctx.ui.confirm` dialog (sections grouped by handler
+  label, summary line in the title), and on approval invokes each
+  handler's `apply()` in priority order (10 writes → 20 edits → 25
+  moves → 30 deletes). Any handler returning `status: "error"` aborts
+  the entire batch before the dialog renders. The handler array is
+  stashed on `globalThis` so it survives jiti's per-extension module
+  isolation (`loader.js` uses `moduleCache: false`). No-op for agents
+  that don't load any deferred-* extension — when no handlers register,
+  `agent_end` returns silently.
 
 ```sh
 set -a; source models.env; set +a
@@ -57,7 +70,7 @@ description: Drafts files...      # optional; shown by agent-header in the TUI
 prompt: |                         # replaces pi's default system prompt
   You are a careful drafter...
 tools: [read, ls, grep, deferred_write]
-extensions: [deferred-write]      # merged with the [sandbox, no-startup-help, agent-header, agent-footer, hide-extensions-list] baseline
+extensions: [deferred-write]      # merged with the [sandbox, no-startup-help, agent-header, agent-footer, hide-extensions-list, deferred-confirm] baseline
 skills: [pi-agent-builder]        # optional; resolved against pi-sandbox/skills/
 provider: openrouter              # optional; defaults to openrouter
 noEditAdd: [my_writer]            # optional; force-include in no-edit rail
@@ -89,9 +102,9 @@ non-empty). All six appear under "Extension CLI Flags" in `pi --help`.
 
 - `sandbox` (baseline) — disables `bash`, clamps fs activity to the root.
 - `deferred-write` — registers the `deferred_write` tool. Drafts are
-  buffered in extension memory; on `agent_end` the extension previews the
-  queued drafts via `ctx.ui.confirm` and writes approved ones to disk
-  (sha256-verified after write, ≤ 50 files / ≤ 2 MB each).
+  buffered in extension memory; the extension registers a handler with
+  the `deferred-confirm` baseline that previews queued drafts and writes
+  approved ones (sha256-verified after write, ≤ 50 files / ≤ 2 MB each).
 - `no-edit` — blocks `edit` outright and rejects any create-only tool
   whose target already exists. The create-only set is discovered at
   session start from `pi.getAllTools()`: any tool whose schema declares
@@ -108,6 +121,44 @@ overwrite-on-approval keeps `deferred-write` and omits `no-edit`; an
 agent using plain `write` but still wanting create-only semantics keeps
 `no-edit` and omits `deferred-write`.
 
+## Worked example: deferred-author (composing all four kinds)
+
+`pi-sandbox/agents/deferred-author.yaml` composes the full set of
+deferred-* tool extensions and relies on `deferred-confirm` (baseline)
+to show one approval dialog at end-of-turn:
+
+- `deferred-write` — `deferred_write({path, content})`. Creates new
+  files. Same shape and limits as the worked example above.
+- `deferred-edit` — `deferred_edit({path, old_string, new_string})`.
+  Modifies existing files. Validates `old_string` is unique against the
+  buffered file state at queue time, so multi-edit ordering works. Re-
+  validates against disk at apply time; any drift aborts the batch.
+- `deferred-move` — `deferred_move({src, dst})`. Verbatim relocation:
+  bit-identical content at the new path. Refuses to overwrite (`dst`
+  must not exist). Parent directories of `dst` are auto-created at
+  apply time. Cross-device EXDEV falls back to copy + unlink.
+- `deferred-delete` — `deferred_delete({path})`. Removes existing files
+  (rejects directories and missing paths at queue time so the model
+  gets immediate feedback).
+
+End-of-turn approval is **all-or-nothing across all four kinds**: the
+`deferred-confirm` coordinator collects every handler's `prepare`
+result, aborts the whole batch if any returns `status: "error"`,
+otherwise renders one `ctx.ui.confirm` with sections per handler. On
+approve, the apply phase runs in fixed priority order (writes → edits
+→ moves → deletes) so compositions like "edit `foo.ts`, then move it
+to `lib/foo.ts`" land deterministically — the edit hits the original
+path, then the rename moves the now-edited file. The reverse ("move
+then edit at the new path") fails at the edit's re-validation because
+`dst` doesn't exist when the edit's `prepare` reads from disk.
+
+Authoring agents should compose the four deferred-* extensions and let
+`deferred-confirm` drive the dialog rather than each running its own.
+`no-edit` is redundant under this composition: the recipe's `tools:`
+allowlist already omits the built-in `edit`/`write`, and each
+deferred-* tool enforces its own existence/non-existence preconditions
+at queue time.
+
 ### Debugging the rails
 
 Set `AGENT_DEBUG=1` in the environment when launching an agent and the
@@ -115,7 +166,7 @@ Set `AGENT_DEBUG=1` in the environment when launching an agent and the
 via `ctx.ui.notify` on `session_start`. Useful when you've added a new
 write tool and want to confirm it was picked up by introspection.
 
-The rails — `agent-header`, `agent-footer`, and `deferred-write`'s
+The rails — `agent-header`, `agent-footer`, and `deferred-confirm`'s
 end-of-turn `ctx.ui.confirm` dialog — only render under a real PTY,
 so `pi -p` print mode can't exercise them. For integration testing,
 drive a full TUI session under tmux:

--- a/pi-sandbox/.pi/extensions/deferred-confirm.ts
+++ b/pi-sandbox/.pi/extensions/deferred-confirm.ts
@@ -1,0 +1,127 @@
+// deferred-confirm extension. Auto-loaded as a baseline extension.
+//
+// Doubles as:
+//   1. A shared registry (the named exports below) that other "deferred-*"
+//      extensions import to register end-of-turn handlers.
+//   2. The coordinator that, on agent_end, drives every registered handler
+//      through prepare -> unified ctx.ui.confirm -> atomic apply.
+//
+// The handler array is stashed on globalThis so it's shared across
+// extensions even though jiti loads each extension's import graph in
+// isolation (loader.js uses `moduleCache: false` and a fresh createJiti
+// per extension).
+
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+export interface DeferredHandler {
+  /** Section header in the unified confirm preview ("Writes", "Edits", "Moves", "Deletes"). */
+  label: string;
+  /** Owning extension name, surfaced in error messages for diagnostics. */
+  extension: string;
+  /** Apply order: 10 writes -> 20 edits -> 25 moves -> 30 deletes. */
+  priority: number;
+  prepare: (ctx: ExtensionContext) => Promise<PrepareResult>;
+}
+
+export type PrepareResult =
+  | { status: "empty" }
+  | { status: "error"; messages: string[] }
+  | {
+      status: "ok";
+      /** One-line summary used in the dialog title (e.g. "3 edits across 2 files"). */
+      summary: string;
+      /** Detailed preview body, rendered under the section header. */
+      preview: string;
+      apply: () => Promise<{ wrote: string[]; failed: string[] }>;
+    };
+
+function getHandlers(): DeferredHandler[] {
+  const g = globalThis as { __pi_deferred_handlers__?: DeferredHandler[] };
+  return (g.__pi_deferred_handlers__ ??= []);
+}
+const handlers = getHandlers();
+
+export function registerDeferredHandler(h: DeferredHandler): void {
+  handlers.push(h);
+}
+
+export function listDeferredHandlers(): readonly DeferredHandler[] {
+  return handlers;
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("agent_end", async (_event, ctx) => {
+    if (handlers.length === 0) return;
+
+    type Prepared = { handler: DeferredHandler; result: PrepareResult };
+    const prepared: Prepared[] = [];
+    for (const h of handlers) {
+      try {
+        prepared.push({ handler: h, result: await h.prepare(ctx) });
+      } catch (e) {
+        prepared.push({
+          handler: h,
+          result: { status: "error", messages: [(e as Error).message] },
+        });
+      }
+    }
+
+    const errors = prepared.flatMap((p) =>
+      p.result.status === "error"
+        ? p.result.messages.map((m) => `${p.handler.label}: ${m}`)
+        : [],
+    );
+    if (errors.length > 0) {
+      if (ctx.hasUI) {
+        ctx.ui.notify(
+          `deferred batch aborted (re-validation failed):\n${errors.join("\n")}`,
+          "error",
+        );
+      }
+      return;
+    }
+
+    type OkEntry = { handler: DeferredHandler; result: Extract<PrepareResult, { status: "ok" }> };
+    const oks: OkEntry[] = prepared.flatMap((p) =>
+      p.result.status === "ok" ? [{ handler: p.handler, result: p.result }] : [],
+    );
+    if (oks.length === 0) return;
+
+    if (!ctx.hasUI) {
+      // Non-interactive: refuse to apply without confirmation.
+      return;
+    }
+
+    oks.sort((a, b) => a.handler.priority - b.handler.priority);
+
+    const summaryLine = oks
+      .map((p) => `${p.handler.label.toLowerCase()}: ${p.result.summary}`)
+      .join(" · ");
+    const previewBody = oks
+      .map((p) => `${p.handler.label} (${p.result.summary})\n\n${p.result.preview}`)
+      .join("\n\n---\n\n");
+
+    const ok = await ctx.ui.confirm(
+      `Apply pending changes?  (${summaryLine})`,
+      previewBody,
+    );
+    if (!ok) {
+      ctx.ui.notify("deferred batch cancelled, nothing applied", "info");
+      return;
+    }
+
+    for (const p of oks) {
+      try {
+        const r = await p.result.apply();
+        if (r.failed.length > 0) {
+          ctx.ui.notify(`${p.handler.label} failures:\n${r.failed.join("\n")}`, "error");
+        }
+        if (r.wrote.length > 0) {
+          ctx.ui.notify(`${p.handler.label} applied:\n${r.wrote.join("\n")}`, "info");
+        }
+      } catch (e) {
+        ctx.ui.notify(`${p.handler.label} crashed: ${(e as Error).message}`, "error");
+      }
+    }
+  });
+}

--- a/pi-sandbox/.pi/extensions/deferred-delete.ts
+++ b/pi-sandbox/.pi/extensions/deferred-delete.ts
@@ -1,0 +1,140 @@
+// Deferred-delete extension. File deletions queued via the
+// `deferred_delete` tool are buffered in extension memory and surfaced to
+// the user (via the shared deferred-confirm dialog) once the agent loop
+// completes. Approved batches unlink the listed files; rejected batches
+// leave them untouched.
+//
+// Designed to compose with sandbox.ts: paths are validated against the
+// same root (the `--sandbox-root` flag, falling back to ctx.cwd /
+// process.cwd). End-of-turn approval is handled centrally by
+// deferred-confirm.ts.
+//
+// File-only: deferred_delete refuses to remove directories and refuses to
+// no-op on missing paths (the model gets an immediate error so it can
+// correct the path).
+
+import fs from "node:fs";
+import path from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+import { registerDeferredHandler, type PrepareResult } from "./deferred-confirm";
+
+type Deletion = { relPath: string; absPath: string };
+
+function resolveSandboxRoot(pi: ExtensionAPI, fallback: string): string {
+  const flag = pi.getFlag("sandbox-root") as string | undefined;
+  return path.resolve(flag || fallback);
+}
+
+function validatePath(relPath: unknown, root: string): { ok: true; abs: string } | { ok: false; err: string } {
+  if (typeof relPath !== "string" || relPath.length === 0) return { ok: false, err: "empty path" };
+  if (path.isAbsolute(relPath) || relPath.split(/[/\\]/).includes("..")) {
+    return { ok: false, err: `${relPath}: absolute or contains '..'` };
+  }
+  const abs = path.resolve(root, relPath);
+  if (abs !== root && !abs.startsWith(root + path.sep)) {
+    return { ok: false, err: `${relPath}: escapes sandbox` };
+  }
+  return { ok: true, abs };
+}
+
+export default function (pi: ExtensionAPI) {
+  const deletions: Deletion[] = [];
+
+  pi.registerTool({
+    name: "deferred_delete",
+    label: "Deferred Delete",
+    description:
+      "Queue deletion of an existing file. The deletion is buffered in memory " +
+      "and presented to the user for approval at the end of the agent loop; " +
+      "nothing is removed from disk until then. `path` must be relative to the " +
+      "sandbox root (no absolute paths, no `..`), must already exist, and must " +
+      "be a regular file (directories are not supported). Each queued path must " +
+      "be unique. The user approves all queued deletions as part of one atomic " +
+      "batch — accept all or none.",
+    parameters: Type.Object({
+      path: Type.String({ description: "Relative path to an existing file inside the sandbox root." }),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const root = resolveSandboxRoot(pi, ctx.cwd);
+      const v = validatePath(params.path, root);
+      if (!v.ok) throw new Error(`deferred_delete: ${v.err}`);
+      if (!fs.existsSync(v.abs)) {
+        throw new Error(`deferred_delete: ${params.path} does not exist`);
+      }
+      const stat = fs.statSync(v.abs);
+      if (!stat.isFile()) {
+        throw new Error(`deferred_delete: ${params.path} is not a regular file (directories are not supported)`);
+      }
+      if (deletions.some((d) => d.absPath === v.abs)) {
+        throw new Error(`deferred_delete: ${params.path} is already queued for deletion`);
+      }
+
+      deletions.push({ relPath: params.path, absPath: v.abs });
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Queued deletion of ${params.path} (${deletions.length} pending). Will be reviewed at end of turn.`,
+          },
+        ],
+        details: { path: params.path, queued: deletions.length },
+      };
+    },
+  });
+
+  registerDeferredHandler({
+    label: "Deletes",
+    extension: "deferred-delete",
+    priority: 30,
+    async prepare(ctx): Promise<PrepareResult> {
+      if (deletions.length === 0) return { status: "empty" };
+      const queued = deletions.splice(0, deletions.length);
+      const root = resolveSandboxRoot(pi, ctx.cwd);
+
+      const errors: string[] = [];
+      const plans: Deletion[] = [];
+
+      for (const d of queued) {
+        const v = validatePath(d.relPath, root);
+        if (!v.ok) { errors.push(v.err); continue; }
+        if (!fs.existsSync(v.abs)) {
+          errors.push(`${d.relPath}: file no longer exists`);
+          continue;
+        }
+        const stat = fs.statSync(v.abs);
+        if (!stat.isFile()) {
+          errors.push(`${d.relPath}: no longer a regular file`);
+          continue;
+        }
+        plans.push({ relPath: d.relPath, absPath: v.abs });
+      }
+
+      if (errors.length > 0) return { status: "error", messages: errors };
+      if (plans.length === 0) return { status: "empty" };
+
+      const preview = plans.map((p) => p.absPath).join("\n");
+
+      const apply = async (): Promise<{ wrote: string[]; failed: string[] }> => {
+        const wrote: string[] = [];
+        const failed: string[] = [];
+        for (const p of plans) {
+          try {
+            fs.unlinkSync(p.absPath);
+            wrote.push(p.absPath);
+          } catch (e) {
+            failed.push(`${p.relPath}: ${(e as Error).message}`);
+          }
+        }
+        return { wrote, failed };
+      };
+
+      return {
+        status: "ok",
+        summary: `${plans.length} file(s)`,
+        preview,
+        apply,
+      };
+    },
+  });
+}

--- a/pi-sandbox/.pi/extensions/deferred-edit.ts
+++ b/pi-sandbox/.pi/extensions/deferred-edit.ts
@@ -1,0 +1,198 @@
+// Deferred-edit extension. Edits queued via the `deferred_edit` tool are
+// buffered in extension memory and surfaced to the user (via ctx.ui.confirm)
+// once the agent loop completes. Approved batches are applied atomically:
+// either every queued edit lands or none does.
+//
+// Designed to compose with sandbox.ts: paths are validated against the same
+// root (the `--sandbox-root` flag, falling back to ctx.cwd / process.cwd).
+//
+// Orthogonal to deferred-write: `deferred_edit` only modifies existing files;
+// it never creates new ones. Recipes that want both create-on-approval and
+// edit-on-approval should compose the two extensions.
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+
+const PREVIEW_LINES_PER_BLOCK = 20;
+
+type Edit = { relPath: string; oldString: string; newString: string };
+
+const sha256 = (s: string) => createHash("sha256").update(s, "utf8").digest("hex");
+
+function resolveSandboxRoot(pi: ExtensionAPI, fallback: string): string {
+  const flag = pi.getFlag("sandbox-root") as string | undefined;
+  return path.resolve(flag || fallback);
+}
+
+function validatePath(relPath: unknown, root: string): { ok: true; abs: string } | { ok: false; err: string } {
+  if (typeof relPath !== "string" || relPath.length === 0) return { ok: false, err: "empty path" };
+  if (path.isAbsolute(relPath) || relPath.split(/[/\\]/).includes("..")) {
+    return { ok: false, err: `${relPath}: absolute or contains '..'` };
+  }
+  const abs = path.resolve(root, relPath);
+  if (abs !== root && !abs.startsWith(root + path.sep)) {
+    return { ok: false, err: `${relPath}: escapes sandbox` };
+  }
+  return { ok: true, abs };
+}
+
+function applyUnique(content: string, oldStr: string, newStr: string): { ok: true; out: string } | { ok: false; err: string } {
+  if (oldStr.length === 0) return { ok: false, err: "old_string is empty" };
+  const idx = content.indexOf(oldStr);
+  if (idx < 0) return { ok: false, err: "old_string not found in current content" };
+  if (content.indexOf(oldStr, idx + 1) >= 0) return { ok: false, err: "old_string matches multiple times; add surrounding context to make it unique" };
+  return { ok: true, out: content.slice(0, idx) + newStr + content.slice(idx + oldStr.length) };
+}
+
+function clipPreview(s: string): string {
+  const lines = s.split("\n");
+  if (lines.length <= PREVIEW_LINES_PER_BLOCK) return s;
+  return lines.slice(0, PREVIEW_LINES_PER_BLOCK).join("\n") + `\n… (+${lines.length - PREVIEW_LINES_PER_BLOCK} more lines)`;
+}
+
+export default function (pi: ExtensionAPI) {
+  const edits: Edit[] = [];
+
+  pi.registerTool({
+    name: "deferred_edit",
+    label: "Deferred Edit",
+    description:
+      "Queue an edit on an existing file. The edit is buffered in memory and " +
+      "presented to the user for approval at the end of the agent loop; nothing " +
+      "is written to disk until then. Use this in place of `edit`. " +
+      "`path` must be relative to the sandbox root (no absolute paths, no `..`) " +
+      "and must already exist. `old_string` must appear exactly once in the " +
+      "file's current buffered state (after any earlier queued edits to the " +
+      "same file); add surrounding context until it matches uniquely. The user " +
+      "approves all queued edits as one atomic batch — accept all or none.",
+    parameters: Type.Object({
+      path: Type.String({ description: "Relative path to an existing file inside the sandbox root." }),
+      old_string: Type.String({ description: "Exact text to replace. Must match the current buffered content uniquely." }),
+      new_string: Type.String({ description: "Replacement text." }),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const root = resolveSandboxRoot(pi, ctx.cwd);
+      const v = validatePath(params.path, root);
+      if (!v.ok) throw new Error(`deferred_edit: ${v.err}`);
+      if (!fs.existsSync(v.abs)) {
+        throw new Error(`deferred_edit: ${params.path} does not exist; deferred_edit only modifies existing files`);
+      }
+
+      let content = fs.readFileSync(v.abs, "utf8");
+      for (const e of edits) {
+        if (e.relPath !== params.path) continue;
+        const r = applyUnique(content, e.oldString, e.newString);
+        if (!r.ok) {
+          throw new Error(`deferred_edit: replaying earlier queued edits on ${params.path} failed: ${r.err}`);
+        }
+        content = r.out;
+      }
+      const r = applyUnique(content, params.old_string, params.new_string);
+      if (!r.ok) {
+        throw new Error(`deferred_edit on ${params.path}: ${r.err}`);
+      }
+
+      edits.push({ relPath: params.path, oldString: params.old_string, newString: params.new_string });
+      const newBytes = Buffer.byteLength(params.new_string, "utf8");
+      const oldBytes = Buffer.byteLength(params.old_string, "utf8");
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Queued edit on ${params.path} (-${oldBytes}+${newBytes} bytes; ${edits.length} pending). Will be reviewed at end of turn.`,
+          },
+        ],
+        details: { path: params.path, queued: edits.length, oldBytes, newBytes },
+      };
+    },
+  });
+
+  pi.on("agent_end", async (_event, ctx) => {
+    if (edits.length === 0) return;
+    const queued = edits.splice(0, edits.length);
+    const root = resolveSandboxRoot(pi, ctx.cwd);
+
+    type FilePlan = { relPath: string; destAbs: string; original: string; final: string; edits: Edit[] };
+    const fileMap = new Map<string, FilePlan>();
+    const errors: string[] = [];
+
+    for (const e of queued) {
+      const v = validatePath(e.relPath, root);
+      if (!v.ok) { errors.push(v.err); continue; }
+      let plan = fileMap.get(v.abs);
+      if (!plan) {
+        if (!fs.existsSync(v.abs)) {
+          errors.push(`${e.relPath}: file no longer exists`);
+          continue;
+        }
+        const original = fs.readFileSync(v.abs, "utf8");
+        plan = { relPath: e.relPath, destAbs: v.abs, original, final: original, edits: [] };
+        fileMap.set(v.abs, plan);
+      }
+      const r = applyUnique(plan.final, e.oldString, e.newString);
+      if (!r.ok) { errors.push(`${e.relPath}: ${r.err}`); continue; }
+      plan.final = r.out;
+      plan.edits.push(e);
+    }
+
+    if (errors.length > 0) {
+      if (ctx.hasUI) {
+        ctx.ui.notify(
+          `deferred_edit aborted (re-validation failed for ${errors.length} edit(s)):\n${errors.join("\n")}`,
+          "error",
+        );
+      }
+      return;
+    }
+
+    const plans = [...fileMap.values()].filter((p) => p.final !== p.original);
+    if (plans.length === 0) {
+      if (ctx.hasUI) ctx.ui.notify("deferred_edit: no net changes to apply", "warning");
+      return;
+    }
+
+    if (!ctx.hasUI) {
+      // Non-interactive: refuse to write without confirmation.
+      return;
+    }
+
+    const totalEdits = plans.reduce((n, p) => n + p.edits.length, 0);
+    const preview = plans
+      .map((p) => {
+        const header = `${p.destAbs} (${p.edits.length} edit${p.edits.length === 1 ? "" : "s"})`;
+        const blocks = p.edits.map((e, i) => {
+          return `Edit ${i + 1}:\n--- old\n${clipPreview(e.oldString)}\n+++ new\n${clipPreview(e.newString)}`;
+        });
+        return [header, ...blocks].join("\n\n");
+      })
+      .join("\n\n---\n\n");
+
+    const ok = await ctx.ui.confirm(`Apply ${totalEdits} edit(s) across ${plans.length} file(s)?`, preview);
+    if (!ok) {
+      ctx.ui.notify("deferred_edit: cancelled, nothing written", "info");
+      return;
+    }
+
+    const wrote: string[] = [];
+    const failed: string[] = [];
+    for (const p of plans) {
+      try {
+        const expected = sha256(p.final);
+        fs.writeFileSync(p.destAbs, p.final, "utf8");
+        const back = sha256(fs.readFileSync(p.destAbs, "utf8"));
+        if (back !== expected) {
+          failed.push(`${p.relPath}: sha mismatch after write`);
+          continue;
+        }
+        wrote.push(p.destAbs);
+      } catch (e) {
+        failed.push(`${p.relPath}: ${(e as Error).message}`);
+      }
+    }
+    if (failed.length > 0) ctx.ui.notify(`deferred_edit failures:\n${failed.join("\n")}`, "error");
+    if (wrote.length > 0) ctx.ui.notify(`deferred_edit wrote:\n${wrote.join("\n")}`, "info");
+  });
+}

--- a/pi-sandbox/.pi/extensions/deferred-edit.ts
+++ b/pi-sandbox/.pi/extensions/deferred-edit.ts
@@ -1,20 +1,21 @@
 // Deferred-edit extension. Edits queued via the `deferred_edit` tool are
-// buffered in extension memory and surfaced to the user (via ctx.ui.confirm)
-// once the agent loop completes. Approved batches are applied atomically:
-// either every queued edit lands or none does.
+// buffered in extension memory and surfaced to the user (via the shared
+// deferred-confirm dialog) once the agent loop completes. Approved
+// batches are applied atomically.
 //
 // Designed to compose with sandbox.ts: paths are validated against the same
 // root (the `--sandbox-root` flag, falling back to ctx.cwd / process.cwd).
 //
 // Orthogonal to deferred-write: `deferred_edit` only modifies existing files;
-// it never creates new ones. Recipes that want both create-on-approval and
-// edit-on-approval should compose the two extensions.
+// it never creates new ones. End-of-turn approval is handled centrally by
+// deferred-confirm.ts.
 
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
+import { registerDeferredHandler, type PrepareResult } from "./deferred-confirm";
 
 const PREVIEW_LINES_PER_BLOCK = 20;
 
@@ -110,89 +111,80 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
-  pi.on("agent_end", async (_event, ctx) => {
-    if (edits.length === 0) return;
-    const queued = edits.splice(0, edits.length);
-    const root = resolveSandboxRoot(pi, ctx.cwd);
+  registerDeferredHandler({
+    label: "Edits",
+    extension: "deferred-edit",
+    priority: 20,
+    async prepare(ctx): Promise<PrepareResult> {
+      if (edits.length === 0) return { status: "empty" };
+      const queued = edits.splice(0, edits.length);
+      const root = resolveSandboxRoot(pi, ctx.cwd);
 
-    type FilePlan = { relPath: string; destAbs: string; original: string; final: string; edits: Edit[] };
-    const fileMap = new Map<string, FilePlan>();
-    const errors: string[] = [];
+      type FilePlan = { relPath: string; destAbs: string; original: string; final: string; edits: Edit[] };
+      const fileMap = new Map<string, FilePlan>();
+      const errors: string[] = [];
 
-    for (const e of queued) {
-      const v = validatePath(e.relPath, root);
-      if (!v.ok) { errors.push(v.err); continue; }
-      let plan = fileMap.get(v.abs);
-      if (!plan) {
-        if (!fs.existsSync(v.abs)) {
-          errors.push(`${e.relPath}: file no longer exists`);
-          continue;
+      for (const e of queued) {
+        const v = validatePath(e.relPath, root);
+        if (!v.ok) { errors.push(v.err); continue; }
+        let plan = fileMap.get(v.abs);
+        if (!plan) {
+          if (!fs.existsSync(v.abs)) {
+            errors.push(`${e.relPath}: file no longer exists`);
+            continue;
+          }
+          const original = fs.readFileSync(v.abs, "utf8");
+          plan = { relPath: e.relPath, destAbs: v.abs, original, final: original, edits: [] };
+          fileMap.set(v.abs, plan);
         }
-        const original = fs.readFileSync(v.abs, "utf8");
-        plan = { relPath: e.relPath, destAbs: v.abs, original, final: original, edits: [] };
-        fileMap.set(v.abs, plan);
+        const r = applyUnique(plan.final, e.oldString, e.newString);
+        if (!r.ok) { errors.push(`${e.relPath}: ${r.err}`); continue; }
+        plan.final = r.out;
+        plan.edits.push(e);
       }
-      const r = applyUnique(plan.final, e.oldString, e.newString);
-      if (!r.ok) { errors.push(`${e.relPath}: ${r.err}`); continue; }
-      plan.final = r.out;
-      plan.edits.push(e);
-    }
 
-    if (errors.length > 0) {
-      if (ctx.hasUI) {
-        ctx.ui.notify(
-          `deferred_edit aborted (re-validation failed for ${errors.length} edit(s)):\n${errors.join("\n")}`,
-          "error",
-        );
-      }
-      return;
-    }
+      if (errors.length > 0) return { status: "error", messages: errors };
 
-    const plans = [...fileMap.values()].filter((p) => p.final !== p.original);
-    if (plans.length === 0) {
-      if (ctx.hasUI) ctx.ui.notify("deferred_edit: no net changes to apply", "warning");
-      return;
-    }
+      const plans = [...fileMap.values()].filter((p) => p.final !== p.original);
+      if (plans.length === 0) return { status: "empty" };
 
-    if (!ctx.hasUI) {
-      // Non-interactive: refuse to write without confirmation.
-      return;
-    }
+      const totalEdits = plans.reduce((n, p) => n + p.edits.length, 0);
+      const preview = plans
+        .map((p) => {
+          const header = `${p.destAbs} (${p.edits.length} edit${p.edits.length === 1 ? "" : "s"})`;
+          const blocks = p.edits.map((e, i) => {
+            return `Edit ${i + 1}:\n--- old\n${clipPreview(e.oldString)}\n+++ new\n${clipPreview(e.newString)}`;
+          });
+          return [header, ...blocks].join("\n\n");
+        })
+        .join("\n\n---\n\n");
 
-    const totalEdits = plans.reduce((n, p) => n + p.edits.length, 0);
-    const preview = plans
-      .map((p) => {
-        const header = `${p.destAbs} (${p.edits.length} edit${p.edits.length === 1 ? "" : "s"})`;
-        const blocks = p.edits.map((e, i) => {
-          return `Edit ${i + 1}:\n--- old\n${clipPreview(e.oldString)}\n+++ new\n${clipPreview(e.newString)}`;
-        });
-        return [header, ...blocks].join("\n\n");
-      })
-      .join("\n\n---\n\n");
-
-    const ok = await ctx.ui.confirm(`Apply ${totalEdits} edit(s) across ${plans.length} file(s)?`, preview);
-    if (!ok) {
-      ctx.ui.notify("deferred_edit: cancelled, nothing written", "info");
-      return;
-    }
-
-    const wrote: string[] = [];
-    const failed: string[] = [];
-    for (const p of plans) {
-      try {
-        const expected = sha256(p.final);
-        fs.writeFileSync(p.destAbs, p.final, "utf8");
-        const back = sha256(fs.readFileSync(p.destAbs, "utf8"));
-        if (back !== expected) {
-          failed.push(`${p.relPath}: sha mismatch after write`);
-          continue;
+      const apply = async (): Promise<{ wrote: string[]; failed: string[] }> => {
+        const wrote: string[] = [];
+        const failed: string[] = [];
+        for (const p of plans) {
+          try {
+            const expected = sha256(p.final);
+            fs.writeFileSync(p.destAbs, p.final, "utf8");
+            const back = sha256(fs.readFileSync(p.destAbs, "utf8"));
+            if (back !== expected) {
+              failed.push(`${p.relPath}: sha mismatch after write`);
+              continue;
+            }
+            wrote.push(p.destAbs);
+          } catch (e) {
+            failed.push(`${p.relPath}: ${(e as Error).message}`);
+          }
         }
-        wrote.push(p.destAbs);
-      } catch (e) {
-        failed.push(`${p.relPath}: ${(e as Error).message}`);
-      }
-    }
-    if (failed.length > 0) ctx.ui.notify(`deferred_edit failures:\n${failed.join("\n")}`, "error");
-    if (wrote.length > 0) ctx.ui.notify(`deferred_edit wrote:\n${wrote.join("\n")}`, "info");
+        return { wrote, failed };
+      };
+
+      return {
+        status: "ok",
+        summary: `${totalEdits} edit(s) across ${plans.length} file(s)`,
+        preview,
+        apply,
+      };
+    },
   });
 }

--- a/pi-sandbox/.pi/extensions/deferred-move.ts
+++ b/pi-sandbox/.pi/extensions/deferred-move.ts
@@ -1,0 +1,169 @@
+// Deferred-move extension. File relocations queued via the
+// `deferred_move` tool are buffered in extension memory and surfaced to
+// the user (via the shared deferred-confirm dialog) once the agent loop
+// completes. Approved batches rename each src to its dst; rejected
+// batches leave them untouched.
+//
+// "Verbatim" relocation: file content is bit-identical at the destination,
+// only the path changes. No implicit overwrite — dst must not exist at
+// queue time. To overwrite, queue a deferred_delete on the destination
+// first; to change content at the new path, pair with deferred_edit (or
+// deferred_write for new files). The deferred-confirm coordinator runs
+// writes, edits, moves, then deletes in that order, so those compositions
+// are deterministic.
+
+import fs from "node:fs";
+import path from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+import { registerDeferredHandler, type PrepareResult } from "./deferred-confirm";
+
+type Move = { srcRel: string; srcAbs: string; dstRel: string; dstAbs: string };
+
+function resolveSandboxRoot(pi: ExtensionAPI, fallback: string): string {
+  const flag = pi.getFlag("sandbox-root") as string | undefined;
+  return path.resolve(flag || fallback);
+}
+
+function validatePath(relPath: unknown, root: string): { ok: true; abs: string } | { ok: false; err: string } {
+  if (typeof relPath !== "string" || relPath.length === 0) return { ok: false, err: "empty path" };
+  if (path.isAbsolute(relPath) || relPath.split(/[/\\]/).includes("..")) {
+    return { ok: false, err: `${relPath}: absolute or contains '..'` };
+  }
+  const abs = path.resolve(root, relPath);
+  if (abs !== root && !abs.startsWith(root + path.sep)) {
+    return { ok: false, err: `${relPath}: escapes sandbox` };
+  }
+  return { ok: true, abs };
+}
+
+export default function (pi: ExtensionAPI) {
+  const moves: Move[] = [];
+
+  pi.registerTool({
+    name: "deferred_move",
+    label: "Deferred Move",
+    description:
+      "Queue a verbatim file relocation. The file at `src` is renamed to `dst` " +
+      "with bit-identical content; only the path changes. Both paths must be " +
+      "relative to the sandbox root (no absolute paths, no `..`). `src` must " +
+      "exist and be a regular file; `dst` must NOT already exist (no implicit " +
+      "overwrite) but its parent directories are CREATED AUTOMATICALLY at apply " +
+      "time — you do not need to pre-create destination directories. Use " +
+      "deferred_delete on the destination first if you want to replace it. The " +
+      "user approves all queued moves as part of one atomic batch — accept all " +
+      "or none.",
+    parameters: Type.Object({
+      src: Type.String({ description: "Relative path to the existing source file." }),
+      dst: Type.String({ description: "Relative path to the destination (must not already exist)." }),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const root = resolveSandboxRoot(pi, ctx.cwd);
+      const vs = validatePath(params.src, root);
+      if (!vs.ok) throw new Error(`deferred_move (src): ${vs.err}`);
+      const vd = validatePath(params.dst, root);
+      if (!vd.ok) throw new Error(`deferred_move (dst): ${vd.err}`);
+      if (vs.abs === vd.abs) {
+        throw new Error(`deferred_move: src and dst resolve to the same path (${params.src})`);
+      }
+      if (!fs.existsSync(vs.abs)) {
+        throw new Error(`deferred_move: src ${params.src} does not exist`);
+      }
+      const stat = fs.statSync(vs.abs);
+      if (!stat.isFile()) {
+        throw new Error(`deferred_move: src ${params.src} is not a regular file (directories are not supported)`);
+      }
+      if (fs.existsSync(vd.abs)) {
+        throw new Error(`deferred_move: dst ${params.dst} already exists; deferred_move does not overwrite`);
+      }
+      if (moves.some((m) => m.srcAbs === vs.abs)) {
+        throw new Error(`deferred_move: src ${params.src} is already queued as the source of another move`);
+      }
+      if (moves.some((m) => m.dstAbs === vd.abs)) {
+        throw new Error(`deferred_move: dst ${params.dst} is already queued as the destination of another move`);
+      }
+
+      moves.push({ srcRel: params.src, srcAbs: vs.abs, dstRel: params.dst, dstAbs: vd.abs });
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Queued move ${params.src} → ${params.dst} (${moves.length} pending). Will be reviewed at end of turn.`,
+          },
+        ],
+        details: { src: params.src, dst: params.dst, queued: moves.length },
+      };
+    },
+  });
+
+  registerDeferredHandler({
+    label: "Moves",
+    extension: "deferred-move",
+    priority: 25,
+    async prepare(ctx): Promise<PrepareResult> {
+      if (moves.length === 0) return { status: "empty" };
+      const queued = moves.splice(0, moves.length);
+      const root = resolveSandboxRoot(pi, ctx.cwd);
+
+      const errors: string[] = [];
+      const plans: Move[] = [];
+
+      for (const m of queued) {
+        const vs = validatePath(m.srcRel, root);
+        if (!vs.ok) { errors.push(`src: ${vs.err}`); continue; }
+        const vd = validatePath(m.dstRel, root);
+        if (!vd.ok) { errors.push(`dst: ${vd.err}`); continue; }
+        if (!fs.existsSync(vs.abs)) {
+          errors.push(`${m.srcRel} → ${m.dstRel}: src no longer exists`);
+          continue;
+        }
+        const stat = fs.statSync(vs.abs);
+        if (!stat.isFile()) {
+          errors.push(`${m.srcRel} → ${m.dstRel}: src is no longer a regular file`);
+          continue;
+        }
+        if (fs.existsSync(vd.abs)) {
+          errors.push(`${m.srcRel} → ${m.dstRel}: dst now exists`);
+          continue;
+        }
+        plans.push({ srcRel: m.srcRel, srcAbs: vs.abs, dstRel: m.dstRel, dstAbs: vd.abs });
+      }
+
+      if (errors.length > 0) return { status: "error", messages: errors };
+      if (plans.length === 0) return { status: "empty" };
+
+      const preview = plans.map((p) => `${p.srcAbs} → ${p.dstAbs}`).join("\n");
+
+      const apply = async (): Promise<{ wrote: string[]; failed: string[] }> => {
+        const wrote: string[] = [];
+        const failed: string[] = [];
+        for (const p of plans) {
+          try {
+            fs.mkdirSync(path.dirname(p.dstAbs), { recursive: true });
+            try {
+              fs.renameSync(p.srcAbs, p.dstAbs);
+            } catch (e) {
+              if ((e as NodeJS.ErrnoException).code === "EXDEV") {
+                fs.copyFileSync(p.srcAbs, p.dstAbs);
+                fs.unlinkSync(p.srcAbs);
+              } else {
+                throw e;
+              }
+            }
+            wrote.push(p.dstAbs);
+          } catch (e) {
+            failed.push(`${p.srcRel} → ${p.dstRel}: ${(e as Error).message}`);
+          }
+        }
+        return { wrote, failed };
+      };
+
+      return {
+        status: "ok",
+        summary: `${plans.length} file(s)`,
+        preview,
+        apply,
+      };
+    },
+  });
+}

--- a/pi-sandbox/.pi/extensions/deferred-write.ts
+++ b/pi-sandbox/.pi/extensions/deferred-write.ts
@@ -35,11 +35,17 @@ export default function (pi: ExtensionAPI) {
       "Draft a file. Content is buffered in memory and presented to the user " +
       "for approval at the end of the agent loop; nothing hits disk until then. " +
       "Use this in place of `write`. `path` must be relative to the sandbox root " +
-      "(no absolute paths, no `..`). Approved drafts are written; rejected drafts " +
-      "are discarded.",
+      "(no absolute paths, no `..`). `content` MUST be the complete, final file " +
+      "contents — every line you want on disk, verbatim. Do not abbreviate or " +
+      "use placeholders like `...`, `// rest unchanged`, or `TODO: fill in`. " +
+      "Approved drafts are written; rejected drafts are discarded.",
     parameters: Type.Object({
       path: Type.String({ description: "Relative destination path inside the sandbox root." }),
-      content: Type.String({ description: "Full text content of the file." }),
+      content: Type.String({
+        description:
+          "Complete final text of the file. Every line you want on disk, " +
+          "verbatim — no placeholders, no abbreviations, no `...`.",
+      }),
     }),
     async execute(_id, params) {
       const bytes = Buffer.byteLength(params.content, "utf8");

--- a/pi-sandbox/.pi/extensions/deferred-write.ts
+++ b/pi-sandbox/.pi/extensions/deferred-write.ts
@@ -120,12 +120,12 @@ export default function (pi: ExtensionAPI) {
         const overwrite = fs.existsSync(p.destAbs) ? " [OVERWRITE]" : "";
         const header = `${p.destAbs} (${p.bytes} bytes, sha ${p.sha.slice(0, 10)}…)${overwrite}`;
         const lines = p.content.split("\n");
-        const shown = lines.slice(0, PREVIEW_LINES_PER_FILE).join("\n\n\n");
+        const shown = lines.slice(0, PREVIEW_LINES_PER_FILE).join("\n");
         const tail =
           lines.length > PREVIEW_LINES_PER_FILE
-            ? `\n\n\n… (+${lines.length - PREVIEW_LINES_PER_FILE} more lines)`
+            ? `\n… (+${lines.length - PREVIEW_LINES_PER_FILE} more lines)`
             : "";
-        return `${header}\n\n\n${shown}${tail}`;
+        return `${header}\n\n${shown}${tail}`;
       })
       .join("\n\n---\n\n");
 

--- a/pi-sandbox/.pi/extensions/deferred-write.ts
+++ b/pi-sandbox/.pi/extensions/deferred-write.ts
@@ -1,21 +1,24 @@
 // Deferred-write extension. Drafts written via the `deferred_write` tool
-// are buffered in extension memory and surfaced to the user (via
-// ctx.ui.confirm) once the agent loop completes. Approved drafts are
-// written to disk under the sandbox root; rejected drafts are discarded.
+// are buffered in extension memory and surfaced to the user (via the
+// shared deferred-confirm dialog) once the agent loop completes. Approved
+// drafts are written to disk under the sandbox root; rejected drafts are
+// discarded.
 //
 // This extension does not enforce no-overwrite. If a recipe wants to
 // forbid modifying existing files, pair it with the `no-edit` extension,
 // which blocks `edit` outright and rejects `write`/`deferred_write`
 // targeting paths that already exist.
 //
-// Designed to compose with sandbox.ts: paths are validated against the
-// same root (the `--sandbox-root` flag, falling back to ctx.cwd).
+// End-of-turn approval is handled centrally by deferred-confirm.ts; this
+// extension registers a handler with the shared bus rather than driving
+// its own ctx.ui.confirm dialog.
 
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
+import { registerDeferredHandler, type PrepareResult } from "./deferred-confirm";
 
 const MAX_FILES_PER_TURN = 50;
 const MAX_BYTES_PER_FILE = 2_000_000;
@@ -62,96 +65,87 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
-  pi.on("agent_end", async (_event, ctx) => {
-    if (drafts.length === 0) return;
-    const queued = drafts.splice(0, drafts.length);
-    const root = path.resolve((pi.getFlag("sandbox-root") as string | undefined) || ctx.cwd);
+  registerDeferredHandler({
+    label: "Writes",
+    extension: "deferred-write",
+    priority: 10,
+    async prepare(ctx): Promise<PrepareResult> {
+      if (drafts.length === 0) return { status: "empty" };
+      const queued = drafts.splice(0, drafts.length);
+      const root = path.resolve((pi.getFlag("sandbox-root") as string | undefined) || ctx.cwd);
 
-    type Plan = { relPath: string; destAbs: string; content: string; sha: string; bytes: number };
-    const plans: Plan[] = [];
-    const skips: string[] = [];
+      type Plan = { relPath: string; destAbs: string; content: string; sha: string; bytes: number };
+      const plans: Plan[] = [];
+      const errors: string[] = [];
 
-    for (const d of queued) {
-      if (typeof d.relPath !== "string" || d.relPath.length === 0) {
-        skips.push(`<empty path>`);
-        continue;
-      }
-      if (path.isAbsolute(d.relPath) || d.relPath.split(/[/\\]/).includes("..")) {
-        skips.push(`${d.relPath}: absolute or contains '..'`);
-        continue;
-      }
-      const destAbs = path.resolve(root, d.relPath);
-      if (destAbs !== root && !destAbs.startsWith(root + path.sep)) {
-        skips.push(`${d.relPath}: escapes sandbox`);
-        continue;
-      }
-      const bytes = Buffer.byteLength(d.content, "utf8");
-      if (bytes > MAX_BYTES_PER_FILE) {
-        skips.push(`${d.relPath}: ${bytes} bytes > ${MAX_BYTES_PER_FILE}`);
-        continue;
-      }
-      plans.push({ relPath: d.relPath, destAbs, content: d.content, sha: sha256(d.content), bytes });
-    }
-
-    for (const s of skips) {
-      if (ctx.hasUI) ctx.ui.notify(`deferred_write skip: ${s}`, "warning");
-    }
-    if (plans.length === 0) {
-      if (ctx.hasUI) ctx.ui.notify("deferred_write: no promotable drafts", "warning");
-      return;
-    }
-    if (plans.length > MAX_FILES_PER_TURN) {
-      if (ctx.hasUI) {
-        ctx.ui.notify(
-          `deferred_write: ${plans.length} drafts exceeds limit of ${MAX_FILES_PER_TURN}; aborting`,
-          "error",
-        );
-      }
-      return;
-    }
-
-    if (!ctx.hasUI) {
-      // Non-interactive: refuse to write without confirmation.
-      return;
-    }
-
-    const preview = plans
-      .map((p) => {
-        const overwrite = fs.existsSync(p.destAbs) ? " [OVERWRITE]" : "";
-        const header = `${p.destAbs} (${p.bytes} bytes, sha ${p.sha.slice(0, 10)}…)${overwrite}`;
-        const lines = p.content.split("\n");
-        const shown = lines.slice(0, PREVIEW_LINES_PER_FILE).join("\n");
-        const tail =
-          lines.length > PREVIEW_LINES_PER_FILE
-            ? `\n… (+${lines.length - PREVIEW_LINES_PER_FILE} more lines)`
-            : "";
-        return `${header}\n\n${shown}${tail}`;
-      })
-      .join("\n\n---\n\n");
-
-    const ok = await ctx.ui.confirm(`Promote ${plans.length} file(s)?`, preview);
-    if (!ok) {
-      ctx.ui.notify("deferred_write: cancelled, nothing written", "info");
-      return;
-    }
-
-    const wrote: string[] = [];
-    const failed: string[] = [];
-    for (const p of plans) {
-      try {
-        fs.mkdirSync(path.dirname(p.destAbs), { recursive: true });
-        fs.writeFileSync(p.destAbs, p.content, "utf8");
-        const back = sha256(fs.readFileSync(p.destAbs, "utf8"));
-        if (back !== p.sha) {
-          failed.push(`${p.relPath}: sha mismatch after write`);
+      for (const d of queued) {
+        if (typeof d.relPath !== "string" || d.relPath.length === 0) {
+          errors.push("<empty path>");
           continue;
         }
-        wrote.push(p.destAbs);
-      } catch (e) {
-        failed.push(`${p.relPath}: ${(e as Error).message}`);
+        if (path.isAbsolute(d.relPath) || d.relPath.split(/[/\\]/).includes("..")) {
+          errors.push(`${d.relPath}: absolute or contains '..'`);
+          continue;
+        }
+        const destAbs = path.resolve(root, d.relPath);
+        if (destAbs !== root && !destAbs.startsWith(root + path.sep)) {
+          errors.push(`${d.relPath}: escapes sandbox`);
+          continue;
+        }
+        const bytes = Buffer.byteLength(d.content, "utf8");
+        if (bytes > MAX_BYTES_PER_FILE) {
+          errors.push(`${d.relPath}: ${bytes} bytes > ${MAX_BYTES_PER_FILE}`);
+          continue;
+        }
+        plans.push({ relPath: d.relPath, destAbs, content: d.content, sha: sha256(d.content), bytes });
       }
-    }
-    if (failed.length > 0) ctx.ui.notify(`deferred_write failures:\n${failed.join("\n")}`, "error");
-    if (wrote.length > 0) ctx.ui.notify(`deferred_write wrote:\n${wrote.join("\n")}`, "info");
+
+      if (plans.length > MAX_FILES_PER_TURN) {
+        errors.push(`${plans.length} drafts exceeds limit of ${MAX_FILES_PER_TURN}`);
+      }
+      if (errors.length > 0) return { status: "error", messages: errors };
+      if (plans.length === 0) return { status: "empty" };
+
+      const preview = plans
+        .map((p) => {
+          const overwrite = fs.existsSync(p.destAbs) ? " [OVERWRITE]" : "";
+          const header = `${p.destAbs} (${p.bytes} bytes, sha ${p.sha.slice(0, 10)}…)${overwrite}`;
+          const lines = p.content.split("\n");
+          const shown = lines.slice(0, PREVIEW_LINES_PER_FILE).join("\n");
+          const tail =
+            lines.length > PREVIEW_LINES_PER_FILE
+              ? `\n… (+${lines.length - PREVIEW_LINES_PER_FILE} more lines)`
+              : "";
+          return `${header}\n\n${shown}${tail}`;
+        })
+        .join("\n\n---\n\n");
+
+      const apply = async (): Promise<{ wrote: string[]; failed: string[] }> => {
+        const wrote: string[] = [];
+        const failed: string[] = [];
+        for (const p of plans) {
+          try {
+            fs.mkdirSync(path.dirname(p.destAbs), { recursive: true });
+            fs.writeFileSync(p.destAbs, p.content, "utf8");
+            const back = sha256(fs.readFileSync(p.destAbs, "utf8"));
+            if (back !== p.sha) {
+              failed.push(`${p.relPath}: sha mismatch after write`);
+              continue;
+            }
+            wrote.push(p.destAbs);
+          } catch (e) {
+            failed.push(`${p.relPath}: ${(e as Error).message}`);
+          }
+        }
+        return { wrote, failed };
+      };
+
+      return {
+        status: "ok",
+        summary: `${plans.length} file(s)`,
+        preview,
+        apply,
+      };
+    },
   });
 }

--- a/pi-sandbox/.pi/extensions/deferred-write.ts
+++ b/pi-sandbox/.pi/extensions/deferred-write.ts
@@ -120,12 +120,12 @@ export default function (pi: ExtensionAPI) {
         const overwrite = fs.existsSync(p.destAbs) ? " [OVERWRITE]" : "";
         const header = `${p.destAbs} (${p.bytes} bytes, sha ${p.sha.slice(0, 10)}…)${overwrite}`;
         const lines = p.content.split("\n");
-        const shown = lines.slice(0, PREVIEW_LINES_PER_FILE).join("\n");
+        const shown = lines.slice(0, PREVIEW_LINES_PER_FILE).join("\n\n");
         const tail =
           lines.length > PREVIEW_LINES_PER_FILE
-            ? `\n… (+${lines.length - PREVIEW_LINES_PER_FILE} more lines)`
+            ? `\n\n… (+${lines.length - PREVIEW_LINES_PER_FILE} more lines)`
             : "";
-        return `${header}\n${shown}${tail}`;
+        return `${header}\n\n${shown}${tail}`;
       })
       .join("\n\n---\n\n");
 

--- a/pi-sandbox/.pi/extensions/deferred-write.ts
+++ b/pi-sandbox/.pi/extensions/deferred-write.ts
@@ -120,12 +120,12 @@ export default function (pi: ExtensionAPI) {
         const overwrite = fs.existsSync(p.destAbs) ? " [OVERWRITE]" : "";
         const header = `${p.destAbs} (${p.bytes} bytes, sha ${p.sha.slice(0, 10)}…)${overwrite}`;
         const lines = p.content.split("\n");
-        const shown = lines.slice(0, PREVIEW_LINES_PER_FILE).join("\n\n");
+        const shown = lines.slice(0, PREVIEW_LINES_PER_FILE).join("\n\n\n");
         const tail =
           lines.length > PREVIEW_LINES_PER_FILE
-            ? `\n\n… (+${lines.length - PREVIEW_LINES_PER_FILE} more lines)`
+            ? `\n\n\n… (+${lines.length - PREVIEW_LINES_PER_FILE} more lines)`
             : "";
-        return `${header}\n\n${shown}${tail}`;
+        return `${header}\n\n\n${shown}${tail}`;
       })
       .join("\n\n---\n\n");
 

--- a/pi-sandbox/agents/change-reviewer.yaml
+++ b/pi-sandbox/agents/change-reviewer.yaml
@@ -1,0 +1,58 @@
+# Change-reviewer agent — reviews proposed edits and writes pasted into the
+# prompt, instead of being pointed at files to review.
+# Read-only via the tools allowlist (no write/edit/bash). All filesystem
+# activity is sandboxed to the directory you launched `npm run agent` from
+# (or --sandbox <dir>).
+
+model: LEAD_HARE_MODEL
+
+description: Reviews proposed edits and writes pasted into the prompt.
+
+prompt: |
+  You are a careful code reviewer. The user will paste one or more proposed
+  changes inline — either edit intents (modify an existing file) or write
+  intents (create a new file). Your job is to review those proposals before
+  the user applies them.
+
+  Expect the user's prompt to contain things like:
+  - A unified diff or "change file X from A to B".
+  - A full "write file Y with this content: ..." block.
+  - A natural-language intent ("rename function foo to bar across src/").
+
+  Workflow:
+  1. For every file the proposal touches, if the file already exists, use
+     `read` to see its current state before judging the change. Use `grep`
+     and `find` to spot other call sites that the proposal might break.
+  2. Evaluate the proposal: correctness, regressions, missed call sites,
+     security, style. Compare against the current code, not just the
+     diff in isolation.
+  3. Emit findings in the format below.
+
+  Output format: end your reply with a markdown section titled "## Review",
+  grouped by the file the proposal targets. Under each file, list findings
+  as one of:
+
+      - L<line> [error|warning|info] <one-line message>     # anchored to current file
+      - new   [error|warning|info] <one-line message>       # anchored to a new file's content
+      - diff  [error|warning|info] <one-line message>       # anchored to the proposed change itself
+
+  Severity:
+  - error   — bugs, security issues, broken invariants, regressions
+  - warning — likely problems, smells, risky patterns, missed call sites
+  - info    — style, readability, suggestions
+
+  Rules:
+  - Use `read`, `ls`, `grep`, and `find` to inspect the existing code. Paths
+    must stay inside the sandbox root.
+  - Keep findings concrete. Quote the offending snippet only when it
+    clarifies the comment.
+  - If you have nothing to flag, say so in plain text and emit no
+    "## Review" section. Do not invent issues to fill space.
+  - You do not have `write`, `edit`, or `bash`. Do not try to use them. You
+    are not applying the proposal — you are reviewing it.
+
+tools:
+  - read
+  - ls
+  - grep
+  - find

--- a/pi-sandbox/agents/change-reviewer.yaml
+++ b/pi-sandbox/agents/change-reviewer.yaml
@@ -6,7 +6,7 @@
 
 model: LEAD_HARE_MODEL
 
-description: Reviews proposed edits and writes pasted into the prompt.
+description: Reviews verbatim edit and write proposals pasted into the prompt.
 
 prompt: |
   You are a careful code reviewer. The user will paste one or more proposed
@@ -14,15 +14,26 @@ prompt: |
   intents (create a new file). Your job is to review those proposals before
   the user applies them.
 
-  Expect the user's prompt to contain things like:
-  - A unified diff or "change file X from A to B".
-  - A full "write file Y with this content: ..." block.
-  - A natural-language intent ("rename function foo to bar across src/").
+  The user must be verbatim about what will happen. Accept only:
+  - Write intents that include the FULL file contents of every new file,
+    not a summary. ("Write file Y with this content: <complete file>")
+  - Edit intents specified as either a unified diff or matched
+    before/after blocks ("Replace exactly: <X>  with: <Y>") with enough
+    surrounding context to locate the change unambiguously.
 
-  Workflow:
+  Reject anything underspecified. If the proposal is vague (e.g. "rename
+  foo to bar", "clean up imports", "extract a helper", a partial diff with
+  "...", or a write intent with "// rest unchanged"), do NOT attempt to
+  review it. Reply explaining exactly what is missing — name the files,
+  name the regions — and ask the user to resend with full contents and
+  exact edits. Emit no "## Review" section in that case.
+
+  Workflow (only when the proposal is fully verbatim):
   1. For every file the proposal touches, if the file already exists, use
-     `read` to see its current state before judging the change. Use `grep`
-     and `find` to spot other call sites that the proposal might break.
+     `read` to see its current state before judging the change. For edit
+     intents, confirm the "before" block matches the file exactly; flag
+     a mismatch as an `error`. Use `grep` and `find` to spot other call
+     sites that the proposal might break.
   2. Evaluate the proposal: correctness, regressions, missed call sites,
      security, style. Compare against the current code, not just the
      diff in isolation.

--- a/pi-sandbox/agents/code-reviewer.yaml
+++ b/pi-sandbox/agents/code-reviewer.yaml
@@ -1,0 +1,38 @@
+# Code-reviewer agent — reads code and emits a structured review.
+# Read-only via the tools allowlist (no write/edit/bash). All filesystem
+# activity is sandboxed to the directory you launched `npm run agent` from
+# (or --sandbox <dir>).
+
+model: LEAD_HARE_MODEL
+
+description: Reads code and emits a structured review.
+
+prompt: |
+  You are a careful code reviewer. Read the code the user points you at and
+  produce a review.
+
+  Output format: end your reply with a markdown section titled "## Review",
+  grouped by file path. Under each file, list findings as:
+
+      - L<line> [error|warning|info] <one-line message>
+
+  Severity:
+  - error   — bugs, security issues, broken invariants
+  - warning — likely problems, smells, risky patterns
+  - info    — style, readability, suggestions
+
+  Rules:
+  - Use `read`, `ls`, `grep`, and `find` to inspect the code. Paths must stay
+    inside the sandbox root.
+  - Keep findings concrete and line-anchored. Quote the offending snippet
+    only when it clarifies the comment.
+  - If you have nothing to flag, say so in plain text and emit no
+    "## Review" section.
+  - You do not have `write`, `edit`, or `bash`. Do not try to use them. Do
+    not modify files.
+
+tools:
+  - read
+  - ls
+  - grep
+  - find

--- a/pi-sandbox/agents/deferred-author.yaml
+++ b/pi-sandbox/agents/deferred-author.yaml
@@ -9,44 +9,53 @@ model: TASK_RABBIT_MODEL
 description: Drafts writes, edits, moves, and deletes; user approves the whole batch at end of turn.
 
 prompt: |
-  You are a careful author. Your job is to read the user's request, inspect
-  the project enough to plan the right changes, then queue each change
-  through one of the deferred tools below.
+  You are a careful author. The user describes changes they want made to
+  the project; you queue each change through `deferred_write`,
+  `deferred_edit`, `deferred_move`, or `deferred_delete`. The user
+  approves the entire batch in one dialog at end of turn — all or none.
 
-  Tools and their semantics:
-  - `deferred_write` — create a new file. `path` is relative to the sandbox
-    root; `content` MUST be the COMPLETE final file contents — every line
-    you want on disk, verbatim. No placeholders, no `...`, no
-    `// rest unchanged`.
-  - `deferred_edit` — modify an existing file. Pass `path`, `old_string`,
-    `new_string`. `old_string` must match the file's current buffered state
-    exactly once — add surrounding context until it's unique.
-  - `deferred_move` — verbatim file relocation. Pass `src` and `dst`. The
-    file content is bit-identical at the destination; only the path
-    changes. `dst` must NOT already exist; if you need to overwrite, queue
-    a `deferred_delete` on the destination first. Parent directories of
-    `dst` are created automatically at apply time — do NOT pre-create them
-    with placeholder files.
-  - `deferred_delete` — remove an existing file. Pass `path`. Directories
-    are not supported.
+  Workflow:
+  1. Inspect with `read`, `ls`, `grep`, `find` before you queue anything.
+     Read every file you intend to edit, move, or delete so the path is
+     real and the planned change is grounded.
+  2. Queue each change with the appropriate deferred tool. Each tool's
+     reply tells you whether it was accepted; if it was rejected, the
+     message says why — fix and retry. A rejected call leaves nothing
+     buffered.
+  3. Reply with a short summary of what you queued, grouped by kind. Do
+     not narrate the upcoming approval dialog; the coordinator will
+     render it.
 
-  Rules:
-  - All four queues are flushed under ONE consolidated approval at the end
-    of the turn. The user accepts the whole batch or none of it; plan
-    accordingly.
-  - Multiple edits to the same file stack in order: each later edit sees
-    the buffered state after earlier edits to that file have been applied.
-  - Apply order at end of turn is fixed: writes, then edits, then moves,
-    then deletes. So "edit foo.ts then move it to lib/foo.ts" works as
-    expected — the edit lands on the original path, then the file is
-    renamed (now-edited content moves with it). "Move foo.ts to bar.ts then
-    edit bar.ts" does NOT work in one turn — re-validation will fail
-    because bar.ts doesn't exist when the edit is checked.
-  - Use `read`, `ls`, `grep`, and `find` to inspect the project before
-    queuing changes. Paths must stay inside the sandbox root.
-  - You do not have `bash`, `write`, or `edit`. Do not try to use them.
-  - Stop once you have queued every change the task needs. Reply with a
-    short summary of what you queued, grouped by kind.
+  Things the tool descriptions already cover but are worth re-stating
+  because they're easy to get wrong:
+  - `deferred_write.content` must be the COMPLETE finished file —
+    every line, verbatim. No `...`, no `// rest unchanged`, no summaries
+    of "what would change". The string you pass IS the file.
+  - `deferred_edit.old_string` must occur EXACTLY ONCE in the file's
+    current buffered state. Include surrounding context until it does.
+    Multiple edits to the same file stack in queue order, so a later
+    edit sees the buffered state after earlier edits to that file.
+  - `deferred_move` creates `dst`'s parent directories automatically.
+    Do NOT queue a placeholder `deferred_write` to "force" the
+    directory to exist; it isn't needed and adds noise to the dialog.
+  - `deferred_delete` is files only; it errors at queue time on missing
+    paths and on directories.
+
+  Apply order at end of turn is fixed: writes → edits → moves → deletes.
+  This means:
+  - "Edit foo.ts then move it to lib/foo.ts" works in one turn — the
+    edit lands on foo.ts, then the rename moves the now-edited file.
+  - "Move foo.ts to bar.ts then edit bar.ts" does NOT work in one turn:
+    the edit's re-validation reads bar.ts before the move runs and
+    fails because bar.ts doesn't exist yet. Split it across turns.
+  - Anything that needs `dst` to be free at apply time but exists at
+    queue time (e.g. "replace bar.ts with foo.ts") also has to split:
+    `deferred_move` rejects at queue time if `dst` is already on disk,
+    even when a `deferred_delete` for that same `dst` is also queued.
+
+  You do not have `bash`, `write`, or `edit`. Stop as soon as every
+  change is queued — no further inspection, no anticipating the user's
+  decision.
 
 tools:
   - read

--- a/pi-sandbox/agents/deferred-author.yaml
+++ b/pi-sandbox/agents/deferred-author.yaml
@@ -1,0 +1,65 @@
+# Deferred-author agent — drafts writes, edits, moves, and deletes; the
+# user approves the whole batch (across all four kinds) at the end of the
+# turn. All filesystem activity is sandboxed to the directory you launched
+# `npm run agent` from (or --sandbox <dir>). bash, write, and edit are not
+# in the allowlist.
+
+model: TASK_RABBIT_MODEL
+
+description: Drafts writes, edits, moves, and deletes; user approves the whole batch at end of turn.
+
+prompt: |
+  You are a careful author. Your job is to read the user's request, inspect
+  the project enough to plan the right changes, then queue each change
+  through one of the deferred tools below.
+
+  Tools and their semantics:
+  - `deferred_write` — create a new file. `path` is relative to the sandbox
+    root; `content` MUST be the COMPLETE final file contents — every line
+    you want on disk, verbatim. No placeholders, no `...`, no
+    `// rest unchanged`.
+  - `deferred_edit` — modify an existing file. Pass `path`, `old_string`,
+    `new_string`. `old_string` must match the file's current buffered state
+    exactly once — add surrounding context until it's unique.
+  - `deferred_move` — verbatim file relocation. Pass `src` and `dst`. The
+    file content is bit-identical at the destination; only the path
+    changes. `dst` must NOT already exist; if you need to overwrite, queue
+    a `deferred_delete` on the destination first. Parent directories of
+    `dst` are created automatically at apply time — do NOT pre-create them
+    with placeholder files.
+  - `deferred_delete` — remove an existing file. Pass `path`. Directories
+    are not supported.
+
+  Rules:
+  - All four queues are flushed under ONE consolidated approval at the end
+    of the turn. The user accepts the whole batch or none of it; plan
+    accordingly.
+  - Multiple edits to the same file stack in order: each later edit sees
+    the buffered state after earlier edits to that file have been applied.
+  - Apply order at end of turn is fixed: writes, then edits, then moves,
+    then deletes. So "edit foo.ts then move it to lib/foo.ts" works as
+    expected — the edit lands on the original path, then the file is
+    renamed (now-edited content moves with it). "Move foo.ts to bar.ts then
+    edit bar.ts" does NOT work in one turn — re-validation will fail
+    because bar.ts doesn't exist when the edit is checked.
+  - Use `read`, `ls`, `grep`, and `find` to inspect the project before
+    queuing changes. Paths must stay inside the sandbox root.
+  - You do not have `bash`, `write`, or `edit`. Do not try to use them.
+  - Stop once you have queued every change the task needs. Reply with a
+    short summary of what you queued, grouped by kind.
+
+tools:
+  - read
+  - ls
+  - grep
+  - find
+  - deferred_write
+  - deferred_edit
+  - deferred_move
+  - deferred_delete
+
+extensions:
+  - deferred-write
+  - deferred-edit
+  - deferred-move
+  - deferred-delete

--- a/pi-sandbox/agents/deferred-editor.yaml
+++ b/pi-sandbox/agents/deferred-editor.yaml
@@ -1,0 +1,43 @@
+# Deferred-editor agent — modifies existing files via buffered edits, user
+# approves the whole batch at end of turn (atomic across all files).
+# Edit-only: cannot create new files. All filesystem activity is sandboxed
+# to the directory you launched `npm run agent` from (or --sandbox <dir>).
+# bash, write, and edit are not in the allowlist.
+
+model: TASK_RABBIT_MODEL
+
+description: Drafts edits to existing files in memory; user approves the whole batch at end of turn.
+
+prompt: |
+  You are a careful editor. Your job is to read the user's request, inspect
+  the project enough to plan the right changes, then call `deferred_edit`
+  for each modification you want to make.
+
+  Rules:
+  - To modify an existing file, call `deferred_edit` with `path` (relative
+    to the sandbox root, no `..`, no absolute paths), `old_string` (exact
+    text to replace), and `new_string` (replacement text). The `old_string`
+    must appear exactly once in the file's current buffered state — add
+    surrounding context until it matches uniquely.
+  - Edits are buffered in memory and reviewed at end of turn as one atomic
+    batch. The user approves all queued edits or none — there is no
+    per-file or per-edit approval. Plan accordingly.
+  - Multiple edits to the same file stack in order: each later edit sees
+    the buffered state after earlier edits to that file have been applied.
+  - You can only modify existing files. You cannot create new files. If a
+    task requires a new file, stop and tell the user.
+  - Use `read`, `ls`, `grep`, and `find` to inspect the project before
+    editing. Paths must stay inside the sandbox root.
+  - You do not have `bash`, `write`, or `edit`. Do not try to use them.
+  - Stop once you have queued every edit the task needs. Reply with a
+    short summary of what you queued.
+
+tools:
+  - read
+  - ls
+  - grep
+  - find
+  - deferred_edit
+
+extensions:
+  - deferred-edit

--- a/pi-sandbox/agents/deferred-writer.yaml
+++ b/pi-sandbox/agents/deferred-writer.yaml
@@ -13,10 +13,17 @@ prompt: |
 
   Rules:
   - To create a file, call `deferred_write` with a `path` (relative to the
-    sandbox root, no `..`, no absolute paths) and the full `content`. Drafts
-    are buffered in memory; the user reviews and approves them at the end.
-  - Use `ls` to explore the existing project before
-    drafting. Paths must stay inside the sandbox root.
+    sandbox root, no `..`, no absolute paths) and the COMPLETE `content` of
+    the file you want on disk. The string you pass IS the file — every
+    line, verbatim. Do not abbreviate. Do not use placeholders like
+    `...`, `// rest unchanged`, `<existing imports>`, or `TODO: fill in`.
+    If the finished file has 200 lines, your `content` must contain all
+    200 lines.
+  - One `deferred_write` call per file you want to create.
+  - Drafts are buffered in memory; the user reviews and approves them at
+    the end.
+  - Use `ls` to explore the existing project before drafting. Paths must
+    stay inside the sandbox root.
   - You do not have `bash`, `write`, or `grep`. Do not try to use them.
   - Stop once you have staged everything the task needs. Reply with a short
     summary of what you drafted.

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -18,6 +18,7 @@ const BASELINE_EXTENSIONS = [
   "agent-header",
   "agent-footer",
   "hide-extensions-list",
+  "deferred-confirm",
 ];
 const TIER_VARS = new Set(["RABBIT_SAGE_MODEL", "LEAD_HARE_MODEL", "TASK_RABBIT_MODEL"]);
 


### PR DESCRIPTION
## Summary

Introduces a unified end-of-turn approval workflow for filesystem operations. Instead of individual confirmations, agents can now queue writes, edits, moves, and deletes through deferred tools, which are presented to the user as a single atomic batch for approval.

## Key Changes

- **New `deferred-confirm` extension** — Central coordinator that registers handlers from other deferred-* extensions, aggregates their results into one `ctx.ui.confirm` dialog, and applies changes atomically in priority order (writes → edits → moves → deletes). Uses `globalThis` to share handler registry across jiti's module isolation.

- **New `deferred-edit` extension** — Queues edits to existing files via `deferred_edit` tool. Validates `old_string` matches exactly once in the current buffered state (accounting for earlier queued edits to the same file). Errors immediately on validation failure so the model can correct and retry.

- **New `deferred-move` extension** — Queues file relocations via `deferred_move` tool. Validates source exists and destination doesn't, creates destination parent directories automatically at apply time, and handles cross-filesystem moves via copy+unlink fallback.

- **New `deferred-delete` extension** — Queues file deletions via `deferred_delete` tool. File-only (rejects directories), errors on missing paths so the model gets immediate feedback.

- **Updated `deferred-write` extension** — Refactored to register with the shared `deferred-confirm` handler bus instead of driving its own `ctx.ui.confirm` dialog. Enhanced prompt guidance to emphasize that `content` must be the complete, final file (no placeholders, no abbreviations).

- **New agent recipes**:
  - `deferred-author.yaml` — Queues writes, edits, moves, and deletes; user approves the whole batch.
  - `deferred-editor.yaml` — Edit-only agent; cannot create new files.
  - `deferred-writer.yaml` — Updated with clearer guidance on complete file contents.
  - `code-reviewer.yaml` — Read-only code review agent.
  - `change-reviewer.yaml` — Reviews verbatim edit and write proposals pasted inline.

- **Updated baseline extensions** — Added `deferred-confirm` to the six baseline extensions loaded by all agents (via `scripts/run-agent.mjs`).

- **Documentation** — Updated `docs/agents.md` to describe the new deferred-confirm coordinator and its handler registration API.

## Implementation Details

- **Path validation** — Shared `validatePath()` helper across all deferred-* extensions ensures consistent sandbox enforcement (no absolute paths, no `..`, must stay within sandbox root).

- **Atomic application** — All queued operations are validated before the confirmation dialog renders. If any re-validation fails (e.g., file deleted between queue and apply), the entire batch is aborted with error messages.

- **Deterministic ordering** — Fixed apply order (writes → edits → moves → deletes) ensures compositions like "edit foo.ts then move it to lib/foo.ts" work in a single turn.

- **Buffered edit stacking** — Multiple edits to the same file are replayed in queue order during validation, so later edits see the buffered state after earlier edits to that file.

- **SHA256 verification** — Write and edit operations verify file content via SHA256 hash after disk write to catch corruption.

https://claude.ai/code/session_0156iNv3gJeXs1hrNivXatQf