### PR TITLE
Add multi-agent extensions: agent-bus (async peer messaging) and agent-spawn (blocking delegation)

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -200,3 +200,101 @@ When an extension delegates to a child `pi` process:
   `$LEAD_HARE_MODEL` for reviewers, `$RABBIT_SAGE_MODEL` for orchestration.
 
 See `pi-sandbox/skills/pi-agent-builder/references/` for recipe-level detail.
+
+## Multi-agent: spawn vs. talk
+
+Two orthogonal extensions cover the two distinct relationships a recipe
+might want with another agent. Neither requires a YAML schema change —
+both opt in via `extensions:` + `tools:`. A recipe can load either, both,
+or neither.
+
+### `agent-spawn` — blocking delegation (ephemeral, anonymous)
+
+Registers the `delegate({recipe, task, sandbox?, timeout_ms?})` tool. The
+parent calls `delegate`, the runner shells out
+`node scripts/run-agent.mjs <recipe> --sandbox <dir> -p <task>` as a
+child process, captures stdout (truncated to 20 KB), forwards the
+parent's `AbortSignal`, and returns when the child exits. The child runs
+through the same runner as a normal `npm run agent`, so it inherits the
+full baseline rails (sandbox, no-edit if its recipe loads it). Default
+timeout is 5 minutes.
+
+Use this for focused subtasks where you want a structured result. The
+child has no name on the bus and dies after the call. Worked example:
+`pi-sandbox/agents/delegator.yaml`.
+
+### `agent-bus` — async peer messaging (long-lived, named)
+
+Registers three tools and one CLI flag:
+
+- `agent_send({to, body, in_reply_to?})` — fire-and-forget. Connects to
+  `${BUS_ROOT}/${to}.sock`, writes one JSON envelope, returns
+  `{msg_id, delivered}`. `peer offline` / `timeout` are normal failure
+  modes (no retry, no offline queue).
+- `agent_inbox({since_ts?, peek?})` — pull buffered envelopes. By
+  default returned messages are cleared from the inbox; `peek=true`
+  keeps them.
+- `agent_list()` — probe `${BUS_ROOT}/*.sock` for live peers; clean up
+  stale socks left by crashed peers.
+- `--agent-bus-root <dir>` — the rendezvous directory. Resolution
+  order: this flag → `$PI_AGENT_BUS_ROOT` → `~/.pi-agent-bus/<basename
+  of sandbox-root>`. The runner sets the flag automatically and accepts
+  `--agent-bus <dir>` (parallel to `--sandbox <dir>`) to override.
+
+Each agent listens on `${BUS_ROOT}/${name}.sock` (name comes from
+`--agent-name`, which the runner sets from the recipe filename or a
+passthrough override). Incoming messages buffer in an in-memory inbox
+and, between turns, are pushed into the agent's next turn via
+`pi.sendUserMessage("[from <peer>] <body>")`. Mid-turn arrivals are
+held in a `pendingDuringTurn` queue and drained at `turn_end` so the
+live LLM call is never interrupted.
+
+The bus root deliberately lives **outside** `--sandbox-root` so the
+`sandbox` extension's path-rejection doesn't trip on socket paths. The
+bus extension never invokes path-bearing built-in tools, so the sandbox
+allowlist is unaffected.
+
+Stale-sock handling: on bind, `EADDRINUSE` triggers a probe-connect; if
+the previous owner refuses, the sock is unlinked and bind retried once.
+A live peer at the same name fails loudly. On send, `ECONNREFUSED` /
+`ENOENT` opportunistically unlinks the dead sock and returns
+`{delivered:false, reason:"peer offline"}`.
+
+v1 defaults intentionally deferred to later: no auth (filesystem perms
+only), no offline queue, no synthesised request/response correlation
+beyond the optional `in_reply_to` field, hard-fail on name collision.
+
+Worked example: `pi-sandbox/agents/peer-chatter.yaml`.
+
+### Why two systems and not one
+
+Spawn is a blocking function call (ephemeral, anonymous handle,
+structured return); peer-talk is async messaging (long-lived, stable
+name, `pi.sendUserMessage` delivery). Forcing delegation through the bus
+would make every subtask allocate a name and burn turns polling an
+inbox; forcing peers through `createAgentSession` doesn't work at all
+since peers are independent processes. Keeping them as two independent
+extensions lets recipes mix exactly the relationship they need.
+
+### Verifying the multi-agent rails under tmux
+
+Same pattern as the rails-debug section above. Two panes:
+
+```sh
+set -a; source models.env; set +a
+tmux new-session -d -s bus-test -x 200 -y 50 \
+  'PI_AGENT_BUS_ROOT=/tmp/bus npm run agent -- peer-chatter --sandbox /tmp/p1 -- --agent-name planner'
+tmux split-window -t bus-test \
+  'PI_AGENT_BUS_ROOT=/tmp/bus npm run agent -- peer-chatter --sandbox /tmp/p2 -- --agent-name worker-a'
+sleep 5
+tmux send-keys -t bus-test:0.0 'call agent_list, then agent_send to worker-a with body "ping"' Enter
+sleep 30
+tmux capture-pane -t bus-test:0.1 -p   # expect "[from planner] ping" on next user turn
+tmux send-keys -t bus-test:0.0 '/quit' Enter
+tmux send-keys -t bus-test:0.1 '/quit' Enter
+```
+
+For `delegate`, run `npm run agent -- delegator --sandbox /tmp/p` and
+prompt *"delegate to recipe peer-chatter with task 'list /tmp'"* — the
+child spawns, runs in print mode, exits, and the captured stdout comes
+back as the tool result.

--- a/pi-sandbox/.pi/extensions/agent-bus.ts
+++ b/pi-sandbox/.pi/extensions/agent-bus.ts
@@ -1,0 +1,376 @@
+// agent-bus extension — peer-to-peer messaging between independently
+// launched pi agents. Each agent listens on a Unix domain socket at
+// `${BUS_ROOT}/${name}.sock`. Messages are async fire-and-forget: a
+// successful send returns immediately and the recipient surfaces the
+// message on its next turn via pi.sendUserMessage. The same buffer is
+// also pull-readable via the agent_inbox tool.
+//
+// Bus root resolution: --agent-bus-root flag → $PI_AGENT_BUS_ROOT →
+// ~/.pi-agent-bus/<basename(sandbox-root)>. Deliberately lives outside
+// --sandbox-root so the sandbox extension's path rejection doesn't trip.
+// The bus extension only opens sockets, never invokes path-bearing
+// built-in tools, so the sandbox allowlist is unaffected.
+//
+// Companion to agent-spawn (blocking delegation). The two are
+// orthogonal: a recipe loads either, both, or neither.
+
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+
+interface Envelope {
+  v: 1;
+  msg_id: string;
+  from: string;
+  to: string;
+  ts: number;
+  body: string;
+  in_reply_to?: string;
+}
+
+interface BusState {
+  server?: net.Server;
+  sockPath?: string;
+  name: string;
+  busRoot: string;
+  inbox: Envelope[];
+  pendingDuringTurn: Envelope[];
+  inTurn: boolean;
+  pi?: ExtensionAPI;
+}
+
+// Stash on globalThis so any second import of this module (jiti loads
+// extensions in isolated module graphs) sees the same state — same
+// pattern as deferred-confirm.
+function getState(): BusState {
+  const g = globalThis as { __pi_agent_bus__?: BusState };
+  return (g.__pi_agent_bus__ ??= {
+    name: "",
+    busRoot: "",
+    inbox: [],
+    pendingDuringTurn: [],
+    inTurn: false,
+  });
+}
+
+function resolveBusRoot(pi: ExtensionAPI, sandboxRoot: string): string {
+  const flag = pi.getFlag("agent-bus-root") as string | undefined;
+  if (flag) return path.resolve(flag);
+  // PI_AGENT_BUS_ROOT is also honored by the runner; reading it here
+  // covers the case where pi was launched directly without the runner.
+  if (process.env.PI_AGENT_BUS_ROOT) return path.resolve(process.env.PI_AGENT_BUS_ROOT);
+  return path.join(os.homedir(), ".pi-agent-bus", path.basename(sandboxRoot));
+}
+
+function probeSocketLive(sockPath: string, timeoutMs = 200): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = net.connect(sockPath);
+    const done = (live: boolean) => {
+      sock.removeAllListeners();
+      sock.destroy();
+      resolve(live);
+    };
+    const timer = setTimeout(() => done(false), timeoutMs);
+    sock.once("connect", () => {
+      clearTimeout(timer);
+      done(true);
+    });
+    sock.once("error", () => {
+      clearTimeout(timer);
+      done(false);
+    });
+  });
+}
+
+async function bindServer(state: BusState, ctx: { ui: { notify: (m: string, l?: string) => void } }) {
+  const sockPath = path.join(state.busRoot, `${state.name}.sock`);
+  state.sockPath = sockPath;
+  fs.mkdirSync(state.busRoot, { recursive: true });
+
+  const server = net.createServer((conn) => {
+    let buf = "";
+    conn.setEncoding("utf8");
+    conn.on("data", (chunk: string) => {
+      buf += chunk;
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.trim()) continue;
+        try {
+          const env = JSON.parse(line) as Envelope;
+          if (env.v !== 1 || typeof env.from !== "string" || typeof env.body !== "string") continue;
+          handleIncoming(state, env);
+        } catch {
+          // ignore malformed lines
+        }
+      }
+    });
+    conn.on("error", () => conn.destroy());
+  });
+
+  const tryListen = (): Promise<void> =>
+    new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(sockPath, () => {
+        server.removeAllListeners("error");
+        resolve();
+      });
+    });
+
+  try {
+    await tryListen();
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code !== "EADDRINUSE") throw e;
+    const live = await probeSocketLive(sockPath);
+    if (live) {
+      ctx.ui.notify(
+        `agent-bus: name "${state.name}" already held by a live peer at ${sockPath} — refusing to bind`,
+        "error",
+      );
+      throw new Error(`agent-bus name collision: ${state.name}`);
+    }
+    fs.unlinkSync(sockPath);
+    await tryListen();
+  }
+
+  state.server = server;
+}
+
+function handleIncoming(state: BusState, env: Envelope) {
+  state.inbox.push(env);
+  if (state.inTurn) {
+    state.pendingDuringTurn.push(env);
+    return;
+  }
+  pushToModel(state, [env]);
+}
+
+function pushToModel(state: BusState, envs: Envelope[]) {
+  if (!state.pi) return;
+  for (const env of envs) {
+    const text = `[from ${env.from}${env.in_reply_to ? ` re:${env.in_reply_to.slice(0, 8)}` : ""}] ${env.body}`;
+    try {
+      state.pi.sendUserMessage(text);
+    } catch {
+      // best-effort; the message is still in inbox for pull
+    }
+  }
+}
+
+async function sendEnvelope(state: BusState, env: Envelope): Promise<{ delivered: boolean; reason?: string }> {
+  const dest = path.join(state.busRoot, `${env.to}.sock`);
+  return new Promise((resolve) => {
+    const sock = net.connect(dest);
+    const done = (r: { delivered: boolean; reason?: string }) => {
+      sock.removeAllListeners();
+      sock.destroy();
+      resolve(r);
+    };
+    const timer = setTimeout(() => done({ delivered: false, reason: "timeout" }), 1000);
+    sock.once("connect", () => {
+      sock.write(`${JSON.stringify(env)}\n`, "utf8", () => {
+        clearTimeout(timer);
+        done({ delivered: true });
+      });
+    });
+    sock.once("error", (e: NodeJS.ErrnoException) => {
+      clearTimeout(timer);
+      const reason =
+        e.code === "ENOENT" || e.code === "ECONNREFUSED" ? "peer offline" : `socket error: ${e.message}`;
+      if (e.code === "ECONNREFUSED") {
+        // dead sock left by a crashed peer; opportunistic cleanup
+        try {
+          fs.unlinkSync(dest);
+        } catch {
+          /* noop */
+        }
+      }
+      done({ delivered: false, reason });
+    });
+  });
+}
+
+async function listLivePeers(state: BusState): Promise<{ name: string; addr: string }[]> {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(state.busRoot);
+  } catch {
+    return [];
+  }
+  const candidates = entries.filter((f) => f.endsWith(".sock")).map((f) => f.slice(0, -".sock".length));
+  const results: { name: string; addr: string }[] = [];
+  for (const peerName of candidates) {
+    const addr = path.join(state.busRoot, `${peerName}.sock`);
+    if (peerName === state.name) {
+      results.push({ name: peerName, addr });
+      continue;
+    }
+    if (await probeSocketLive(addr)) {
+      results.push({ name: peerName, addr });
+    } else {
+      try {
+        fs.unlinkSync(addr);
+      } catch {
+        /* noop */
+      }
+    }
+  }
+  return results;
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.registerFlag("agent-bus-root", {
+    description: "Rendezvous directory for inter-agent Unix sockets (one .sock per agent name)",
+    type: "string",
+  });
+
+  const state = getState();
+  state.pi = pi;
+
+  pi.on("session_start", async (_event, ctx) => {
+    // pi.getFlag is scoped to the calling extension, so reading flags
+    // owned by sandbox/agent-header doesn't work cross-extension. The
+    // runner mirrors agent-name into PI_AGENT_NAME for us; sandbox-root
+    // equals ctx.cwd because the runner spawns pi with cwd=sandboxRoot.
+    const name = (process.env.PI_AGENT_NAME || "anonymous").trim() || "anonymous";
+    const sandboxRoot = path.resolve(ctx.cwd);
+    state.name = name;
+    state.busRoot = resolveBusRoot(pi, sandboxRoot);
+
+    try {
+      await bindServer(state, ctx);
+    } catch (e) {
+      ctx.ui.notify(`agent-bus: failed to bind ${state.sockPath}: ${(e as Error).message}`, "error");
+      return;
+    }
+
+    if (process.env.AGENT_DEBUG === "1") {
+      const dump = `agent-bus: name=${state.name} sock=${state.sockPath}`;
+      ctx.ui.notify(dump, "info");
+      process.stderr.write(`[AGENT_DEBUG] ${dump}\n`);
+    }
+  });
+
+  pi.on("turn_start", async () => {
+    state.inTurn = true;
+  });
+
+  pi.on("turn_end", async () => {
+    state.inTurn = false;
+    if (state.pendingDuringTurn.length === 0) return;
+    const drained = state.pendingDuringTurn.splice(0, state.pendingDuringTurn.length);
+    pushToModel(state, drained);
+  });
+
+  const cleanup = () => {
+    if (state.server) {
+      try {
+        state.server.close();
+      } catch {
+        /* noop */
+      }
+      state.server = undefined;
+    }
+    if (state.sockPath) {
+      try {
+        fs.unlinkSync(state.sockPath);
+      } catch {
+        /* noop */
+      }
+    }
+  };
+  pi.on("session_shutdown", async () => cleanup());
+  process.once("exit", cleanup);
+
+  pi.registerTool({
+    name: "agent_send",
+    label: "Agent Send",
+    description:
+      "Send an async message to another agent on the bus. Fire-and-forget: " +
+      "returns once the byte hits the wire (or fails). The recipient receives " +
+      "the message as a synthetic user prompt on its next turn (and via " +
+      "agent_inbox). Use agent_list to discover live peers.",
+    parameters: Type.Object({
+      to: Type.String({ description: "Name of the recipient agent (matches its --agent-name)." }),
+      body: Type.String({ description: "Message body. Plain text; no envelope wrapping required." }),
+      in_reply_to: Type.Optional(
+        Type.String({ description: "Optional msg_id of the message you are replying to." }),
+      ),
+    }),
+    async execute(_id, params) {
+      if (!state.server) {
+        return {
+          content: [{ type: "text", text: "agent-bus not initialized; cannot send." }],
+          details: { delivered: false, reason: "bus not initialized" },
+        };
+      }
+      const env: Envelope = {
+        v: 1,
+        msg_id: randomUUID(),
+        from: state.name,
+        to: params.to,
+        ts: Date.now(),
+        body: params.body,
+        ...(params.in_reply_to ? { in_reply_to: params.in_reply_to } : {}),
+      };
+      const result = await sendEnvelope(state, env);
+      const text = result.delivered
+        ? `Sent to ${params.to} (msg_id ${env.msg_id.slice(0, 8)}).`
+        : `Send to ${params.to} failed: ${result.reason}.`;
+      return {
+        content: [{ type: "text", text }],
+        details: { msg_id: env.msg_id, delivered: result.delivered, reason: result.reason },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "agent_inbox",
+    label: "Agent Inbox",
+    description:
+      "Read messages buffered by the bus. By default returned messages are " +
+      "cleared from the inbox; pass peek=true to keep them. Use since_ts to " +
+      "filter to messages newer than a given epoch ms.",
+    parameters: Type.Object({
+      since_ts: Type.Optional(Type.Number({ description: "Only return messages with ts >= this value." })),
+      peek: Type.Optional(Type.Boolean({ description: "If true, do not clear returned messages from the inbox." })),
+    }),
+    async execute(_id, params) {
+      const since = typeof params.since_ts === "number" ? params.since_ts : 0;
+      const matched = state.inbox.filter((e) => e.ts >= since);
+      if (!params.peek) {
+        const remaining = state.inbox.filter((e) => e.ts < since);
+        state.inbox.length = 0;
+        state.inbox.push(...remaining);
+      }
+      const lines = matched.map(
+        (e) => `[${new Date(e.ts).toISOString()}] ${e.from} → ${e.to} (${e.msg_id.slice(0, 8)}): ${e.body}`,
+      );
+      return {
+        content: [{ type: "text", text: lines.length === 0 ? "(inbox empty)" : lines.join("\n") }],
+        details: { count: matched.length, messages: matched },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "agent_list",
+    label: "Agent List",
+    description: "List currently-live peers on the bus (probes each socket; cleans stale entries).",
+    parameters: Type.Object({}),
+    async execute() {
+      const peers = await listLivePeers(state);
+      const lines = peers.map((p) => `${p.name}${p.name === state.name ? " (self)" : ""} — ${p.addr}`);
+      return {
+        content: [{ type: "text", text: lines.length === 0 ? "(no peers)" : lines.join("\n") }],
+        details: { peers },
+      };
+    },
+  });
+}

--- a/pi-sandbox/.pi/extensions/agent-spawn.ts
+++ b/pi-sandbox/.pi/extensions/agent-spawn.ts
@@ -1,0 +1,146 @@
+// agent-spawn extension — blocking delegation to a focused child agent.
+// Registers the `delegate` tool, which spawns `node scripts/run-agent.mjs
+// <recipe> -p <task>` as a subprocess, captures stdout, and returns when
+// the child exits. The child runs through the same runner as a normal
+// `npm run agent` invocation, so it gets the full baseline rails
+// (sandbox, no-edit if the recipe loads it, etc).
+//
+// Companion to agent-bus (async peer messaging). Delegation is
+// ephemeral, anonymous, and structured-return; it does NOT use the bus.
+// A recipe that wants both delegation and peer messaging loads both
+// extensions independently.
+//
+// Why subprocess and not in-process createAgentSession: the parent's
+// extension surface (including agent-bus's socket binding) would re-fire
+// session_start for the child, causing name collisions and shared
+// globalThis state. Subprocess gives clean isolation at the cost of
+// startup latency.
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
+const RUNNER_PATH = path.join(REPO_ROOT, "scripts", "run-agent.mjs");
+const AGENTS_DIR = path.join(REPO_ROOT, "pi-sandbox", "agents");
+
+const MAX_OUTPUT_BYTES = 20_000;
+const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+
+export default function (pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "delegate",
+    label: "Delegate",
+    description:
+      "Spawn a child agent from a recipe in pi-sandbox/agents/, hand it a " +
+      "task, and block until it exits. Returns the child's captured stdout " +
+      "(truncated to 20KB). Ephemeral and anonymous: the child has no name " +
+      "on the bus and dies after the call. Use this for focused subtasks " +
+      "where you want a structured result; use agent_send for long-lived " +
+      "peer coordination.",
+    parameters: Type.Object({
+      recipe: Type.String({
+        description: "Name of a recipe in pi-sandbox/agents/ (without .yaml suffix).",
+      }),
+      task: Type.String({
+        description: "The task prompt handed to the child as its first user message.",
+      }),
+      sandbox: Type.Optional(
+        Type.String({
+          description: "Optional sandbox root for the child. Defaults to the parent's sandbox root.",
+        }),
+      ),
+      timeout_ms: Type.Optional(
+        Type.Number({
+          description: `Max child runtime in ms before SIGTERM. Defaults to ${DEFAULT_TIMEOUT_MS}.`,
+        }),
+      ),
+    }),
+    async execute(_id, params, signal, _onUpdate, ctx) {
+      const recipeFile = path.join(AGENTS_DIR, `${params.recipe}.yaml`);
+      if (!existsSync(recipeFile)) {
+        return {
+          content: [{ type: "text", text: `delegate: recipe not found: ${recipeFile}` }],
+          details: { error: "recipe_not_found", recipe: params.recipe },
+        };
+      }
+      if (!existsSync(RUNNER_PATH)) {
+        return {
+          content: [{ type: "text", text: `delegate: runner missing: ${RUNNER_PATH}` }],
+          details: { error: "runner_missing" },
+        };
+      }
+
+      // pi.getFlag is scoped to the calling extension, so we can't read
+      // sandbox-root cross-extension. ctx.cwd works because the runner
+      // spawns pi with cwd=sandboxRoot.
+      const sandboxRoot = path.resolve(params.sandbox || ctx?.cwd || process.cwd());
+      const timeoutMs = typeof params.timeout_ms === "number" ? params.timeout_ms : DEFAULT_TIMEOUT_MS;
+
+      const args = [RUNNER_PATH, params.recipe, "--sandbox", sandboxRoot, "-p", params.task];
+
+      const child = spawn(process.execPath, args, {
+        cwd: REPO_ROOT,
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+      let truncated = false;
+
+      const append = (target: "stdout" | "stderr", chunk: Buffer) => {
+        const s = chunk.toString("utf8");
+        if (target === "stdout") {
+          if (stdout.length + s.length > MAX_OUTPUT_BYTES) {
+            stdout += s.slice(0, MAX_OUTPUT_BYTES - stdout.length);
+            truncated = true;
+          } else {
+            stdout += s;
+          }
+        } else {
+          if (stderr.length < MAX_OUTPUT_BYTES) {
+            stderr += s.slice(0, MAX_OUTPUT_BYTES - stderr.length);
+          }
+        }
+      };
+      child.stdout?.on("data", (c: Buffer) => append("stdout", c));
+      child.stderr?.on("data", (c: Buffer) => append("stderr", c));
+
+      const onAbort = () => {
+        if (!child.killed) child.kill("SIGTERM");
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+
+      const timer = setTimeout(() => {
+        if (!child.killed) child.kill("SIGTERM");
+      }, timeoutMs);
+
+      const exit: { code: number | null; signal: NodeJS.Signals | null } = await new Promise((resolve) => {
+        child.once("exit", (code, sig) => resolve({ code, signal: sig }));
+      });
+
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+
+      const tail = truncated ? "\n…(output truncated)" : "";
+      const text = stdout.length > 0 ? `${stdout}${tail}` : stderr || "(no output)";
+
+      return {
+        content: [{ type: "text", text }],
+        details: {
+          recipe: params.recipe,
+          exit_code: exit.code,
+          exit_signal: exit.signal,
+          stdout_bytes: stdout.length,
+          stderr_bytes: stderr.length,
+          truncated,
+        },
+      };
+    },
+  });
+}

--- a/pi-sandbox/agents/delegator.yaml
+++ b/pi-sandbox/agents/delegator.yaml
@@ -1,0 +1,40 @@
+# Delegator — demo agent for the agent-spawn extension. Spawns a child
+# agent from another recipe via `delegate(recipe, task)` and blocks
+# until the child exits, returning its captured stdout.
+#
+# Compose with peer-chatter (or any other recipe) as the worker target:
+#   npm run agent -- delegator --sandbox /tmp/p
+#   > "delegate to recipe peer-chatter with task 'list files in cwd'"
+
+model: LEAD_HARE_MODEL
+
+description: Planner that delegates focused subtasks to a child agent recipe.
+
+prompt: |
+  You are a planner. Your job is to decompose the user's request into
+  focused subtasks and hand each to the right recipe via `delegate`.
+
+  Tools:
+  - `delegate({recipe, task, sandbox?, timeout_ms?})` — spawns a child
+    agent from pi-sandbox/agents/<recipe>.yaml in print mode (`-p`),
+    blocks until it exits, returns its stdout. The child runs through
+    the same runner as `npm run agent`, so it gets the full baseline
+    rails (sandbox, no-edit if its recipe loads it).
+  - `read`, `ls`, `grep` — local fs (sandboxed) for picking the right
+    recipe and crafting the task prompt.
+
+  Rules:
+  - Pick the smallest recipe that fits the subtask. Read
+    pi-sandbox/agents/ to see what's available.
+  - Each `delegate` call is blocking and adds startup latency (a fresh
+    pi process). Don't delegate trivial work you could do inline.
+  - Summarise child output in your reply; don't dump raw stdout.
+
+tools:
+  - read
+  - ls
+  - grep
+  - delegate
+
+extensions:
+  - agent-spawn

--- a/pi-sandbox/agents/peer-chatter.yaml
+++ b/pi-sandbox/agents/peer-chatter.yaml
@@ -1,0 +1,47 @@
+# Peer-chatter — demo agent for the agent-bus extension. Two (or more)
+# instances launched in separate terminals can find each other by name
+# and exchange async messages.
+#
+# Launch two panes, each with `set -a; source models.env; set +a`, then:
+#   tmux split-window
+#   # pane A
+#   PI_AGENT_BUS_ROOT=/tmp/bus npm run agent -- peer-chatter --sandbox /tmp/p1 -- --agent-name planner
+#   # pane B
+#   PI_AGENT_BUS_ROOT=/tmp/bus npm run agent -- peer-chatter --sandbox /tmp/p2 -- --agent-name worker-a
+#
+# Then prompt pane A: "call agent_list, then agent_send to worker-a with body 'ping'"
+
+model: TASK_RABBIT_MODEL
+
+description: Demo peer that talks to other agents over the agent-bus.
+
+prompt: |
+  You are a peer agent on a multi-agent bus. Your name is whatever was
+  passed via --agent-name (default "anonymous"). Other agents launched
+  with the same PI_AGENT_BUS_ROOT can send you messages and you can send
+  them messages back.
+
+  Tools:
+  - `agent_list` — list live peers on the bus (probes each socket).
+  - `agent_send({to, body, in_reply_to?})` — async send. Returns once
+    the byte hits the wire. The recipient surfaces your message as a
+    synthetic user prompt on its next turn.
+  - `agent_inbox({since_ts?, peek?})` — pull inbox. Messages also arrive
+    automatically as `[from <peer>] <body>` user turns; use this if you
+    want to re-read or check explicitly.
+  - `read`, `ls`, `grep`, `find` — local fs (sandboxed).
+
+  When you receive a message that asks for a reply, send one back via
+  `agent_send` with `in_reply_to` set to the incoming msg_id.
+
+tools:
+  - read
+  - ls
+  - grep
+  - find
+  - agent_send
+  - agent_inbox
+  - agent_list
+
+extensions:
+  - agent-bus

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -187,7 +187,11 @@ const busRoot =
   args.agentBus ||
   process.env.PI_AGENT_BUS_ROOT ||
   path.join(os.homedir(), ".pi-agent-bus", path.basename(sandboxRoot));
-piArgs.push("--agent-bus-root", busRoot);
+// Only push --agent-bus-root when agent-bus is loaded; otherwise pi
+// rejects the flag as unknown.
+const recipeExtensions = Array.isArray(recipe.extensions) ? recipe.extensions : [];
+const usesBus = recipeExtensions.includes("agent-bus");
+if (usesBus) piArgs.push("--agent-bus-root", busRoot);
 if (typeof recipe.description === "string" && recipe.description.trim()) {
   piArgs.push("--agent-description", recipe.description.trim());
 }

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
@@ -28,11 +29,20 @@ function die(msg) {
 }
 
 function parseArgs(argv) {
-  const out = { name: null, sandbox: null, passthrough: [] };
+  const out = { name: null, sandbox: null, agentBus: null, passthrough: [] };
+  let passthroughOnly = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (a === "--sandbox") {
+    if (passthroughOnly) {
+      out.passthrough.push(a);
+      continue;
+    }
+    if (a === "--") {
+      passthroughOnly = true;
+    } else if (a === "--sandbox") {
       out.sandbox = argv[++i] ?? die("--sandbox requires a directory");
+    } else if (a === "--agent-bus") {
+      out.agentBus = argv[++i] ?? die("--agent-bus requires a directory");
     } else if (a === "--help" || a === "-h") {
       printHelp();
       process.exit(0);
@@ -157,7 +167,27 @@ const piArgs = [
 for (const p of extensionPaths) piArgs.push("-e", p);
 for (const p of skillPaths) piArgs.push("--skill", p);
 piArgs.push("--sandbox-root", sandboxRoot);
-piArgs.push("--agent-name", args.name);
+
+// Pull --agent-name out of passthrough so we can apply the override to
+// both the CLI flag (read by agent-header) and the env var (read by
+// agent-bus, since pi.getFlag is scoped per-extension).
+let agentName = args.name;
+const passthrough = [];
+for (let i = 0; i < args.passthrough.length; i++) {
+  if (args.passthrough[i] === "--agent-name" && i + 1 < args.passthrough.length) {
+    agentName = args.passthrough[++i];
+  } else {
+    passthrough.push(args.passthrough[i]);
+  }
+}
+args.passthrough = passthrough;
+piArgs.push("--agent-name", agentName);
+
+const busRoot =
+  args.agentBus ||
+  process.env.PI_AGENT_BUS_ROOT ||
+  path.join(os.homedir(), ".pi-agent-bus", path.basename(sandboxRoot));
+piArgs.push("--agent-bus-root", busRoot);
 if (typeof recipe.description === "string" && recipe.description.trim()) {
   piArgs.push("--agent-description", recipe.description.trim());
 }
@@ -177,7 +207,10 @@ if (!existsSync(PI_BIN)) die(`pi binary missing: ${PI_BIN} (run npm install)`);
 const child = spawn(PI_BIN, piArgs, {
   cwd: sandboxRoot,
   stdio: "inherit",
-  env: process.env,
+  // Mirror the agent name + bus root into env vars so extensions that
+  // can't read the CLI flags via pi.getFlag (which is scoped per
+  // extension) still see them.
+  env: { ...process.env, PI_AGENT_NAME: agentName, PI_AGENT_BUS_ROOT: busRoot },
 });
 
 child.on("exit", (code, signal) => {


### PR DESCRIPTION
## Summary

Introduces two orthogonal multi-agent extensions that enable agents to coordinate with each other: `agent-bus` for long-lived peer messaging and `agent-spawn` for ephemeral blocking delegation to child agents.

## Key Changes

### New Extensions

- **`agent-bus.ts`** — Peer-to-peer async messaging system
  - Each agent listens on a Unix domain socket at `${BUS_ROOT}/${name}.sock`
  - Registers three tools: `agent_send()` (fire-and-forget), `agent_inbox()` (pull buffered messages), `agent_list()` (discover live peers)
  - Messages arrive as synthetic user prompts between turns via `pi.sendUserMessage()`
  - Handles stale socket cleanup, name collision detection, and mid-turn message buffering
  - Bus root resolution: `--agent-bus-root` flag → `$PI_AGENT_BUS_ROOT` → `~/.pi-agent-bus/<sandbox-basename>`
  - Deliberately lives outside `--sandbox-root` to avoid sandbox path rejection

- **`agent-spawn.ts`** — Blocking delegation to child agents
  - Registers `delegate({recipe, task, sandbox?, timeout_ms?})` tool
  - Spawns `node scripts/run-agent.mjs <recipe> --sandbox <dir> -p <task>` as a subprocess
  - Captures stdout (truncated to 20 KB), forwards `AbortSignal`, returns on child exit
  - Default 5-minute timeout; child inherits full baseline rails (sandbox, no-edit, etc.)

### Demo Recipes

- **`peer-chatter.yaml`** — Example agent that discovers peers and exchanges messages via agent-bus
- **`delegator.yaml`** — Example planner that decomposes tasks and delegates to child agents via agent-spawn

### Runner Updates (`scripts/run-agent.mjs`)

- Added `--agent-bus` flag support (parallel to `--sandbox`)
- Extracts `--agent-name` from passthrough args to apply consistently across CLI and env vars
- Mirrors `PI_AGENT_NAME` and `PI_AGENT_BUS_ROOT` into child process environment (needed because `pi.getFlag()` is scoped per-extension)
- Only pushes `--agent-bus-root` to pi when recipe loads `agent-bus` extension

### Documentation (`docs/agents.md`)

- Added "Multi-agent: spawn vs. talk" section explaining both systems
- Rationale for two separate extensions vs. unified approach
- Verification instructions for testing multi-agent rails under tmux
- Worked examples and tool reference

## Implementation Details

- **State isolation**: Both extensions use `globalThis` stashing to survive jiti's isolated module graphs (same pattern as `deferred-confirm`)
- **Message buffering**: `agent-bus` holds mid-turn arrivals in `pendingDuringTurn` queue and drains at `turn_end` to avoid interrupting live LLM calls
- **Stale socket handling**: On bind collision, probes the existing socket; if dead, unlinks and retries. On send failure, opportunistically cleans up dead sockets.
- **Subprocess isolation**: `agent-spawn` uses subprocess (not in-process `createAgentSession`) to avoid extension re-firing and globalThis state sharing
- **Envelope format**: v1 JSON with `msg_id`, `from`, `to`, `ts`, `body`, optional `in_reply_to`

https://claude.ai/code/session_01YQvfsAYNndCqwZuNx71KDd