### PR TITLE
Non-blocking delegation with parent-driven approval over RPC

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -44,15 +44,45 @@ agent gets six baseline extensions:
   extension. Exposes `registerDeferredHandler({ label, extension,
   priority, prepare })` (named export) plus a single `agent_end` listener
   that calls every registered handler's `prepare(ctx)`, aggregates the
-  results into one `ctx.ui.confirm` dialog (sections grouped by handler
-  label, summary line in the title), and on approval invokes each
-  handler's `apply()` in priority order (10 writes → 20 edits → 25
-  moves → 30 deletes). Any handler returning `status: "error"` aborts
-  the entire batch before the dialog renders. The handler array is
-  stashed on `globalThis` so it survives jiti's per-extension module
-  isolation (`loader.js` uses `moduleCache: false`). No-op for agents
-  that don't load any deferred-* extension — when no handlers register,
+  results into one approval prompt (sections grouped by handler label,
+  summary line in the title), and on approval invokes each handler's
+  `apply()` in priority order (10 writes → 20 edits → 25 moves → 30
+  deletes). Any handler returning `status: "error"` aborts the entire
+  batch before the prompt renders. The handler array is stashed on
+  `globalThis` so it survives jiti's per-extension module isolation
+  (`loader.js` uses `moduleCache: false`). No-op for agents that don't
+  load any deferred-* extension — when no handlers register,
   `agent_end` returns silently.
+
+  **Approval routing** is handled by an exported helper,
+  `requestHumanApproval(ctx, pi, {title, summary, preview}) →
+  Promise<boolean>`, that picks the right channel:
+  - `ctx.hasUI` → renders `ctx.ui.confirm` locally (this terminal is
+    the human's).
+  - else `--rpc-sock` flag set → forwards over a unix socket to the
+    parent agent's RPC server (parent itself recurses if it's also
+    headless, so escalations walk up the chain to whoever can answer).
+  - else loud-fails to stderr (`[deferred] dropped: no UI and no
+    --rpc-sock`) and returns `false` — replacing today's silent drop
+    of queued drafts under `pi -p`.
+
+  The same primitive is reused by `agent-spawn`'s
+  `approve_delegation({escalate: true})`, so any agent works whether
+  it's running standalone or as a child.
+
+  RPC protocol (newline-delimited JSON, single round-trip):
+  ```
+  client → server : {type: "request-approval", title, summary, preview}
+  server → client : {type: "approval-result", approved: boolean}
+  ```
+  IPC failures (parent died, EPIPE, malformed reply, server closed
+  without replying) settle as `approved: false`. No retries, no
+  offline queueing.
+
+  When no UI is present, the apply-loop's status notifications
+  (`writes applied: …`, `edits applied: …`, etc.) are routed to
+  stdout as `[deferred] …` lines so the parent's `delegate` /
+  `approve_delegation` tool result captures them.
 
 ```sh
 set -a; source models.env; set +a
@@ -75,6 +105,7 @@ skills: [pi-agent-builder]        # optional; resolved against pi-sandbox/skills
 provider: openrouter              # optional; defaults to openrouter
 noEditAdd: [my_writer]            # optional; force-include in no-edit rail
 noEditSkip: [deferred_write]      # optional; exempt from no-edit rail
+agents: [deferred-writer]         # optional; recipes this agent may delegate to
 ```
 
 The runner always passes `--no-extensions --no-skills --no-context-files`
@@ -83,9 +114,21 @@ pi's `--tools` allowlist (built-in + extension-registered tools both
 qualify). Recipe-derived values reach the extensions as registered CLI
 flags: `--sandbox-root <path>` (always set), `--agent-name <name>`
 (always set), `--agent-description <text>` (when `description:` is set),
-`--agent-tier <TIER_VAR>` (when `model:` is a tier var name), and
+`--agent-tier <TIER_VAR>` (when `model:` is a tier var name),
 `--no-edit-add` / `--no-edit-skip` (when the matching list is
-non-empty). All six appear under "Extension CLI Flags" in `pi --help`.
+non-empty), and `--allowed-agents <a,b,c>` (when `agents:` is set).
+All seven appear under "Extension CLI Flags" in `pi --help`.
+
+When `agents:` is non-empty the runner also implicitly:
+
+- adds `agent-spawn` to `extensions:`, and
+- adds `delegate` and `approve_delegation` to `tools:`.
+
+Explicit duplicates in the recipe are fine. The inverse is rejected
+loudly: declaring `extensions: [agent-spawn]` or
+`tools: [delegate | approve_delegation]` without `agents:` causes the
+runner to `die()` so the allowlist is never accidentally empty. To
+disable delegation, drop the `agents:` field entirely.
 
 ## Where agent code lives
 
@@ -159,6 +202,49 @@ allowlist already omits the built-in `edit`/`write`, and each
 deferred-* tool enforces its own existence/non-existence preconditions
 at queue time.
 
+## Worked example: writer-foreman (parent-driven approval over RPC)
+
+`pi-sandbox/agents/writer-foreman.yaml` is a Lead-tier foreman that
+decomposes a drafting request and dispatches focused batches to a
+`deferred-writer` child. The recipe declares only:
+
+```yaml
+agents: [deferred-writer]
+tools: [read, ls, grep, find]
+```
+
+The runner implicitly loads `agent-spawn` and adds `delegate` +
+`approve_delegation` to the tool allowlist, and pushes
+`--allowed-agents deferred-writer` so the child recipe is locked.
+
+Flow per batch:
+
+1. Foreman calls `delegate({recipe: "deferred-writer", task: "…"})`.
+2. The runner spawns a child `pi -p` with `--rpc-sock <path>`.
+3. Child drafts in memory, hits `agent_end`. Its `deferred-confirm`
+   has no `ctx.hasUI` (print mode) but does have `--rpc-sock`, so
+   `requestHumanApproval` opens the socket and sends
+   `request-approval` with the preview.
+4. Foreman's per-call RPC server stashes the request in the
+   pending-delegations registry; `delegate` returns the preview +
+   `delegation_id` to the foreman LLM.
+5. Foreman LLM reads the preview, decides:
+   - `approve_delegation({id, approved: true})` — auto-approve.
+   - `approve_delegation({id, approved: false})` — discard.
+   - `approve_delegation({id, escalate: true})` — ask the human via
+     `requestHumanApproval`, which renders `ctx.ui.confirm` in the
+     foreman's terminal (or recursively forwards if the foreman is
+     itself a child).
+6. The decision is sent over the open RPC connection. Child resumes,
+   applies (or discards) the drafts, prints `[deferred] writes
+   applied: …` to stdout, exits.
+7. `approve_delegation` returns the captured stdout to the foreman.
+
+A foreman that is itself launched as a child — e.g.
+`delegator → writer-foreman → deferred-writer` — works the same way:
+its own `requestHumanApproval` reads its own `--rpc-sock` and forwards
+escalations one more hop up. The chain bottoms out at the human.
+
 ### Debugging the rails
 
 Set `AGENT_DEBUG=1` in the environment when launching an agent and the
@@ -204,24 +290,67 @@ See `pi-sandbox/skills/pi-agent-builder/references/` for recipe-level detail.
 ## Multi-agent: spawn vs. talk
 
 Two orthogonal extensions cover the two distinct relationships a recipe
-might want with another agent. Neither requires a YAML schema change —
-both opt in via `extensions:` + `tools:`. A recipe can load either, both,
-or neither.
+might want with another agent. `agent-spawn` is implicitly wired by the
+`agents:` recipe field; `agent-bus` is opt-in via `extensions:` +
+`tools:`. A recipe can use either, both, or neither.
 
-### `agent-spawn` — blocking delegation (ephemeral, anonymous)
+### `agent-spawn` — blocking delegation with parent-driven approval
 
-Registers the `delegate({recipe, task, sandbox?, timeout_ms?})` tool. The
-parent calls `delegate`, the runner shells out
-`node scripts/run-agent.mjs <recipe> --sandbox <dir> -p <task>` as a
-child process, captures stdout (truncated to 20 KB), forwards the
-parent's `AbortSignal`, and returns when the child exits. The child runs
-through the same runner as a normal `npm run agent`, so it inherits the
-full baseline rails (sandbox, no-edit if its recipe loads it). Default
-timeout is 5 minutes.
+Wired implicitly when the recipe declares `agents: [a, b, …]`. Registers
+two tools:
 
-Use this for focused subtasks where you want a structured result. The
-child has no name on the bus and dies after the call. Worked example:
-`pi-sandbox/agents/delegator.yaml`.
+- `delegate({recipe, task, sandbox?, timeout_ms?})` — spawns
+  `node scripts/run-agent.mjs <recipe> --sandbox <dir> -p <task>
+  -- --rpc-sock <path>` as a subprocess, captures stdout (truncated to
+  20 KB), and races two outcomes: child exits without queuing drafts
+  (returns captured stdout, today's behavior) OR child sends a
+  `request-approval` over the per-call RPC socket (returns the preview
+  + a `delegation_id` to the parent LLM with the child paused).
+  Forwards the parent's `AbortSignal`. Default timeout is 5 minutes.
+- `approve_delegation({id, approved, escalate?, comment?})` — resumes
+  a paused delegation. Pass `approved: true|false` for the parent LLM
+  to decide directly; pass `escalate: true` to ask the human via
+  `requestHumanApproval` (which recurses up the parent chain if the
+  parent itself is a child via `--rpc-sock`). Returns the child's
+  final captured stdout, including the `[deferred] writes applied: …`
+  lines from the apply phase.
+
+Why two tools: putting the parent LLM in the approval loop requires
+returning the preview to the LLM mid-delegation; a single blocking
+`delegate` can't do that. Splitting the flow gives the LLM full
+control without inventing new pi primitives.
+
+**Pre-flight checks** in `delegate.execute` (in order):
+
+1. **Recipe allowlist** — `params.recipe` must be in
+   `--allowed-agents` (set by the runner from `agents:`). Error:
+   `delegate: recipe 'X' not in this agent's allowed list […]`.
+2. **Sandbox containment** — `params.sandbox || ctx.cwd` must equal
+   or be inside the parent's sandbox root (parent root = `ctx.cwd`
+   because the runner spawns pi with `cwd = sandboxRoot`). Children
+   may run in subdirectories of the parent's sandbox but never
+   anywhere outside it. Error: `delegate: sandbox '…' escapes parent
+   root '…'`.
+
+**Pending delegations** are tracked in a globalThis registry
+(`__pi_delegate_pending__`) keyed by `delegation_id`. Each entry
+holds the child process handle, the open RPC connection, the
+preview, and the timeout budget. A watchdog enforces `timeout_ms`
+across the whole life of the delegation (delegate + LLM thinking +
+approve_delegation); exceeding it sends `approved: false` to the
+child and kills the process. `process.once("exit")` cleanup walks
+the registry, denies all pending requests, kills surviving children,
+and unlinks sockets.
+
+**Sockets** are per-call at
+`${os.tmpdir()}/pi-rpc-${pid}-${randomUUID()}.sock`, deliberately
+outside any sandbox root so neither `sandbox` nor `no-edit` flag
+them as escapes.
+
+Worked examples: `pi-sandbox/agents/writer-foreman.yaml` (single-
+recipe foreman driving `deferred-writer`) and
+`pi-sandbox/agents/delegator.yaml` (general-purpose planner with a
+broad allowlist).
 
 ### `agent-bus` — async peer messaging (long-lived, named)
 
@@ -294,7 +423,46 @@ tmux send-keys -t bus-test:0.0 '/quit' Enter
 tmux send-keys -t bus-test:0.1 '/quit' Enter
 ```
 
-For `delegate`, run `npm run agent -- delegator --sandbox /tmp/p` and
-prompt *"delegate to recipe peer-chatter with task 'list /tmp'"* — the
-child spawns, runs in print mode, exits, and the captured stdout comes
-back as the tool result.
+For non-paused `delegate`, run `npm run agent -- delegator --sandbox
+/tmp/p` and prompt *"delegate to recipe peer-chatter with task 'list
+/tmp'"* — the child spawns, runs in print mode, exits, and the
+captured stdout comes back as the tool result.
+
+For the **parent-driven approval** flow, drive `writer-foreman` end-
+to-end:
+
+```sh
+set -a; source models.env; set +a
+mkdir -p /tmp/foreman-test
+tmux new-session -d -s foreman -x 200 -y 50 \
+  'AGENT_DEBUG=1 npm run agent -- writer-foreman --sandbox /tmp/foreman-test'
+sleep 5
+tmux send-keys -t foreman \
+  'delegate to deferred-writer with task "draft hello.txt with text Hi"' Enter
+sleep 90                              # foreman delegates, child pauses,
+                                      # foreman reads preview, calls
+                                      # approve_delegation({approved: true})
+tmux capture-pane -t foreman -p       # expect "[deferred] writes applied: hello.txt"
+ls /tmp/foreman-test/hello.txt        # file present with "Hi"
+tmux send-keys -t foreman '/quit' Enter
+```
+
+Negative cases worth probing manually:
+
+- **Foreman escalates**: ambiguous task → expect
+  `approve_delegation({escalate: true})` and a `ctx.ui.confirm`
+  dialog in the foreman's terminal.
+- **Recursive escalation**: wrap with `delegator` (`delegator →
+  writer-foreman → deferred-writer`) and force the foreman to
+  escalate; the prompt surfaces in the *delegator's* terminal.
+- **Loud fail**: run `npm run agent -- deferred-writer -p "draft
+  x.txt"` directly. With no UI and no `--rpc-sock`, the child exits
+  but stderr contains `[deferred] dropped: no UI and no --rpc-sock`.
+- **Sandbox escape**: prompt foreman with `sandbox: "/tmp/elsewhere"`
+  → `delegate: sandbox '…' escapes parent root '…'`.
+- **Recipe not allowed**: prompt foreman with `recipe:
+  "deferred-editor"` → `delegate: recipe 'deferred-editor' not in
+  this agent's allowed list [deferred-writer]`.
+- **Schema rejection**: scratch recipe with `extensions: [agent-spawn]`
+  and no `agents:` → runner exits with `loads extension 'agent-spawn'
+  but has no 'agents:' list`.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -217,28 +217,37 @@ The runner implicitly loads `agent-spawn` and adds `delegate` +
 `approve_delegation` to the tool allowlist, and pushes
 `--allowed-agents deferred-writer` so the child recipe is locked.
 
-Flow per batch:
+Flow per batch (or per parallel set of batches):
 
 1. Foreman calls `delegate({recipe: "deferred-writer", task: "…"})`.
+   Returns immediately with a `delegation_id`; the child is spawning
+   in the background. Repeat for each independent batch before
+   collecting any results — all children run in parallel.
 2. The runner spawns a child `pi -p` with `--rpc-sock <path>`.
 3. Child drafts in memory, hits `agent_end`. Its `deferred-confirm`
    has no `ctx.hasUI` (print mode) but does have `--rpc-sock`, so
    `requestHumanApproval` opens the socket and sends
    `request-approval` with the preview.
-4. Foreman's per-call RPC server stashes the request in the
-   pending-delegations registry; `delegate` returns the preview +
-   `delegation_id` to the foreman LLM.
-5. Foreman LLM reads the preview, decides:
+4. The foreman's per-call RPC server receives the request. The child
+   remains paused on the open socket.
+5. Foreman calls `approve_delegation({id})` (no decision yet). Blocks
+   until the child settles, then returns the preview.
+6. Foreman LLM reads the preview, decides:
    - `approve_delegation({id, approved: true})` — auto-approve.
    - `approve_delegation({id, approved: false})` — discard.
    - `approve_delegation({id, escalate: true})` — ask the human via
      `requestHumanApproval`, which renders `ctx.ui.confirm` in the
      foreman's terminal (or recursively forwards if the foreman is
      itself a child).
-6. The decision is sent over the open RPC connection. Child resumes,
+7. The decision is sent over the open RPC connection. Child resumes,
    applies (or discards) the drafts, prints `[deferred] writes
    applied: …` to stdout, exits.
-7. `approve_delegation` returns the captured stdout to the foreman.
+8. `approve_delegation` returns the captured stdout (plus the preview
+   as an audit trail) to the foreman.
+
+Shortcut: `approve_delegation({id, approved: true})` combines steps 5–6
+into one call — it blocks until the child settles, sends the decision
+immediately, and includes the preview in the tool result for audit.
 
 A foreman that is itself launched as a child — e.g.
 `delegator → writer-foreman → deferred-writer` — works the same way:
@@ -294,31 +303,31 @@ might want with another agent. `agent-spawn` is implicitly wired by the
 `agents:` recipe field; `agent-bus` is opt-in via `extensions:` +
 `tools:`. A recipe can use either, both, or neither.
 
-### `agent-spawn` — blocking delegation with parent-driven approval
+### `agent-spawn` — non-blocking delegation with parent-driven approval
 
 Wired implicitly when the recipe declares `agents: [a, b, …]`. Registers
 two tools:
 
 - `delegate({recipe, task, sandbox?, timeout_ms?})` — spawns
   `node scripts/run-agent.mjs <recipe> --sandbox <dir> -p <task>
-  -- --rpc-sock <path>` as a subprocess, captures stdout (truncated to
-  20 KB), and races two outcomes: child exits without queuing drafts
-  (returns captured stdout, today's behavior) OR child sends a
-  `request-approval` over the per-call RPC socket (returns the preview
-  + a `delegation_id` to the parent LLM with the child paused).
-  Forwards the parent's `AbortSignal`. Default timeout is 5 minutes.
-- `approve_delegation({id, approved, escalate?, comment?})` — resumes
-  a paused delegation. Pass `approved: true|false` for the parent LLM
-  to decide directly; pass `escalate: true` to ask the human via
-  `requestHumanApproval` (which recurses up the parent chain if the
-  parent itself is a child via `--rpc-sock`). Returns the child's
-  final captured stdout, including the `[deferred] writes applied: …`
-  lines from the apply phase.
-
-Why two tools: putting the parent LLM in the approval loop requires
-returning the preview to the LLM mid-delegation; a single blocking
-`delegate` can't do that. Splitting the flow gives the LLM full
-control without inventing new pi primitives.
+  -- --rpc-sock <path>` as a subprocess and returns immediately with
+  a `delegation_id`. The child runs in the background. The parent LLM
+  can call `delegate` multiple times before calling `approve_delegation`
+  for any of them — all children spawn in parallel. Default timeout is
+  5 minutes (measured from the `delegate` call).
+- `approve_delegation({id, approved?, escalate?, comment?})` — the join
+  point. Blocks until the child settles, then:
+  - **Child exited without drafts**: returns captured stdout; no
+    decision needed.
+  - **Child paused, no decision given**: returns the preview so the
+    parent LLM can review it. Call again with `approved: true|false`
+    to send the decision.
+  - **Child paused, decision given**: sends the decision, waits for
+    the child to finish, returns captured stdout plus the preview as
+    an audit trail.
+  - **`escalate: true`**: asks the human via `requestHumanApproval`
+    (recurses up the parent chain if the parent itself is a child via
+    `--rpc-sock`).
 
 **Pre-flight checks** in `delegate.execute` (in order):
 
@@ -333,14 +342,14 @@ control without inventing new pi primitives.
    root '…'`.
 
 **Pending delegations** are tracked in a globalThis registry
-(`__pi_delegate_pending__`) keyed by `delegation_id`. Each entry
-holds the child process handle, the open RPC connection, the
-preview, and the timeout budget. A watchdog enforces `timeout_ms`
-across the whole life of the delegation (delegate + LLM thinking +
-approve_delegation); exceeding it sends `approved: false` to the
-child and kills the process. `process.once("exit")` cleanup walks
-the registry, denies all pending requests, kills surviving children,
-and unlinks sockets.
+(`__pi_delegate_pending__`) keyed by `delegation_id`. Each entry holds
+the child process handle, a `settled` promise (resolves when the child
+exits or sends a `request-approval`), and a `resolvedConn` field set
+once the child pauses. A watchdog enforces `timeout_ms` across the whole
+life of the delegation (delegate + LLM thinking + approve_delegation);
+exceeding it sends `approved: false` to the child (if paused) and kills
+the process. `process.once("exit")` cleanup walks the registry, denies
+all pending requests, kills surviving children, and unlinks sockets.
 
 **Sockets** are per-call at
 `${os.tmpdir()}/pi-rpc-${pid}-${randomUUID()}.sock`, deliberately
@@ -429,7 +438,7 @@ For non-paused `delegate`, run `npm run agent -- delegator --sandbox
 captured stdout comes back as the tool result.
 
 For the **parent-driven approval** flow, drive `writer-foreman` end-
-to-end:
+to-end (single file):
 
 ```sh
 set -a; source models.env; set +a
@@ -438,13 +447,23 @@ tmux new-session -d -s foreman -x 200 -y 50 \
   'AGENT_DEBUG=1 npm run agent -- writer-foreman --sandbox /tmp/foreman-test'
 sleep 5
 tmux send-keys -t foreman \
-  'delegate to deferred-writer with task "draft hello.txt with text Hi"' Enter
-sleep 90                              # foreman delegates, child pauses,
-                                      # foreman reads preview, calls
-                                      # approve_delegation({approved: true})
+  'draft hello.txt with text "Hi"' Enter
+sleep 90                              # delegate returns immediately (non-blocking),
+                                      # child runs in background, foreman calls
+                                      # approve_delegation({id, approved: true})
 tmux capture-pane -t foreman -p       # expect "[deferred] writes applied: hello.txt"
 ls /tmp/foreman-test/hello.txt        # file present with "Hi"
 tmux send-keys -t foreman '/quit' Enter
+```
+
+For **parallel dispatch** (multiple files at once):
+
+```sh
+tmux send-keys -t foreman \
+  'draft two files in parallel: hello.txt saying "Hi" and world.txt saying "World"' Enter
+sleep 120   # foreman calls delegate twice (both children spawn in parallel),
+            # then approve_delegation for each
+ls /tmp/foreman-test/   # hello.txt and world.txt both present
 ```
 
 Negative cases worth probing manually:

--- a/pi-sandbox/.pi/extensions/agent-spawn.ts
+++ b/pi-sandbox/.pi/extensions/agent-spawn.ts
@@ -1,27 +1,48 @@
-// agent-spawn extension — blocking delegation to a focused child agent.
-// Registers the `delegate` tool, which spawns `node scripts/run-agent.mjs
-// <recipe> -p <task>` as a subprocess, captures stdout, and returns when
-// the child exits. The child runs through the same runner as a normal
-// `npm run agent` invocation, so it gets the full baseline rails
-// (sandbox, no-edit if the recipe loads it, etc).
+// agent-spawn extension — blocking delegation to a focused child agent
+// with parent-driven approval.
 //
-// Companion to agent-bus (async peer messaging). Delegation is
-// ephemeral, anonymous, and structured-return; it does NOT use the bus.
-// A recipe that wants both delegation and peer messaging loads both
-// extensions independently.
+// Two tools:
+//   - `delegate({recipe, task, sandbox?, timeout_ms?})` spawns
+//     `node scripts/run-agent.mjs <recipe> -p <task>` as a subprocess.
+//     If the child exits without queuing any deferred-* drafts, returns
+//     the captured stdout (today's behavior). If the child queues drafts,
+//     the child pauses on the per-call RPC socket, the parent records
+//     the pending delegation in a globalThis registry, and `delegate`
+//     returns the preview + delegation_id so the parent LLM can review
+//     and decide.
+//   - `approve_delegation({id, approved, escalate?, comment?})` resumes
+//     a paused child. If escalate=true, the parent's own
+//     requestHumanApproval primitive is used (which routes to
+//     ctx.ui.confirm locally OR forwards up the parent's --rpc-sock if
+//     the parent itself is a child).
+//
+// Why two tools: putting the parent LLM in the approval loop requires
+// returning the preview to the LLM mid-delegation. A single blocking
+// `delegate` can't do that.
 //
 // Why subprocess and not in-process createAgentSession: the parent's
 // extension surface (including agent-bus's socket binding) would re-fire
 // session_start for the child, causing name collisions and shared
 // globalThis state. Subprocess gives clean isolation at the cost of
 // startup latency.
+//
+// Companion to agent-bus (async peer messaging). Delegation is
+// ephemeral, anonymous, and structured-return; it does NOT use the bus.
+// A recipe that wants both delegation and peer messaging loads both
+// extensions independently — though typically `agents:` in the recipe
+// implicitly wires agent-spawn for you.
 
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
+import { requestHumanApproval, type ApprovalRequest } from "./deferred-confirm";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
@@ -31,17 +52,133 @@ const AGENTS_DIR = path.join(REPO_ROOT, "pi-sandbox", "agents");
 const MAX_OUTPUT_BYTES = 20_000;
 const DEFAULT_TIMEOUT_MS = 5 * 60_000;
 
+interface PendingDelegation {
+  id: string;
+  recipe: string;
+  child: ChildProcess;
+  conn: net.Socket;
+  request: ApprovalRequest;
+  startedAt: number;
+  timeoutMs: number;
+  /** Captured stdout so far (drained continuously even while paused). */
+  stdoutSoFar: { value: string; truncated: boolean };
+  /** Captured stderr so far. */
+  stderrSoFar: { value: string };
+  /** Resolved when the child has exited, with the final exit info. */
+  exited: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+  /** Watchdog timer; cleared when approve_delegation runs. */
+  timer: NodeJS.Timeout;
+  /** RPC server (per-call); closed after the child exits. */
+  server: net.Server;
+  /** Socket path; unlinked after close. */
+  sockPath: string;
+}
+
+interface SpawnState {
+  pending: Map<string, PendingDelegation>;
+  cleanupRegistered: boolean;
+}
+
+/** Stash the registry on globalThis so jiti's per-extension module isolation
+ *  doesn't lose entries across imports. Same idiom as agent-bus / deferred-confirm. */
+function getState(): SpawnState {
+  const g = globalThis as { __pi_delegate_pending__?: SpawnState };
+  return (g.__pi_delegate_pending__ ??= { pending: new Map(), cleanupRegistered: false });
+}
+
+function parseFlagList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+function appendBuffer(buf: { value: string; truncated?: boolean }, chunk: Buffer, max: number): void {
+  const s = chunk.toString("utf8");
+  if (buf.value.length + s.length > max) {
+    buf.value += s.slice(0, max - buf.value.length);
+    if ("truncated" in buf) (buf as { truncated: boolean }).truncated = true;
+  } else {
+    buf.value += s;
+  }
+}
+
+function unlinkSafe(p: string): void {
+  try {
+    fs.unlinkSync(p);
+  } catch {
+    /* noop */
+  }
+}
+
+function killSafe(child: ChildProcess, signal: NodeJS.Signals = "SIGTERM"): void {
+  if (!child.killed && child.exitCode === null) {
+    try {
+      child.kill(signal);
+    } catch {
+      /* noop */
+    }
+  }
+}
+
+function ensureProcessCleanup(state: SpawnState): void {
+  if (state.cleanupRegistered) return;
+  state.cleanupRegistered = true;
+  process.once("exit", () => {
+    for (const p of state.pending.values()) {
+      try {
+        p.conn.write(JSON.stringify({ type: "approval-result", approved: false }) + "\n");
+        p.conn.destroy();
+      } catch {
+        /* noop */
+      }
+      killSafe(p.child);
+      try {
+        p.server.close();
+      } catch {
+        /* noop */
+      }
+      unlinkSafe(p.sockPath);
+    }
+    state.pending.clear();
+  });
+}
+
+function formatPreview(p: PendingDelegation, header: string): string {
+  return `${header}\n\nrecipe: ${p.recipe}\ndelegation_id: ${p.id}\n\n${p.request.preview}`;
+}
+
+function finalText(p: PendingDelegation, exit: { code: number | null; signal: NodeJS.Signals | null }): string {
+  const tail = p.stdoutSoFar.truncated ? "\n…(output truncated)" : "";
+  const body = p.stdoutSoFar.value.length > 0 ? `${p.stdoutSoFar.value}${tail}` : p.stderrSoFar.value || "(no output)";
+  const exitTag =
+    exit.code === 0
+      ? ""
+      : `\n[delegate] child exited code=${exit.code} signal=${exit.signal ?? "none"}`;
+  return body + exitTag;
+}
+
 export default function (pi: ExtensionAPI) {
+  pi.registerFlag("allowed-agents", {
+    description:
+      "Comma-separated list of recipe names this agent may delegate to. " +
+      "Set by the runner from the recipe's `agents:` field.",
+    type: "string",
+  });
+
+  const state = getState();
+  ensureProcessCleanup(state);
+
   pi.registerTool({
     name: "delegate",
     label: "Delegate",
     description:
       "Spawn a child agent from a recipe in pi-sandbox/agents/, hand it a " +
-      "task, and block until it exits. Returns the child's captured stdout " +
-      "(truncated to 20KB). Ephemeral and anonymous: the child has no name " +
-      "on the bus and dies after the call. Use this for focused subtasks " +
-      "where you want a structured result; use agent_send for long-lived " +
-      "peer coordination.",
+      "task, and run it. If the child exits without queuing any deferred " +
+      "drafts, returns the captured stdout. If the child queues drafts, " +
+      "the child pauses; this tool returns the preview and a " +
+      "`delegation_id`. Call `approve_delegation` to resume the child " +
+      "with your approval decision (or escalate to the human). Recipe " +
+      "must be in this agent's allowed list (set via the recipe's " +
+      "`agents:` field).",
     parameters: Type.Object({
       recipe: Type.String({
         description: "Name of a recipe in pi-sandbox/agents/ (without .yaml suffix).",
@@ -51,16 +188,47 @@ export default function (pi: ExtensionAPI) {
       }),
       sandbox: Type.Optional(
         Type.String({
-          description: "Optional sandbox root for the child. Defaults to the parent's sandbox root.",
+          description:
+            "Optional sandbox root for the child. Defaults to the parent's sandbox root. " +
+            "Must be equal to OR a subdirectory of the parent's sandbox.",
         }),
       ),
       timeout_ms: Type.Optional(
         Type.Number({
-          description: `Max child runtime in ms before SIGTERM. Defaults to ${DEFAULT_TIMEOUT_MS}.`,
+          description: `Max child runtime in ms (including time spent waiting for approve_delegation). Defaults to ${DEFAULT_TIMEOUT_MS}.`,
         }),
       ),
     }),
     async execute(_id, params, signal, _onUpdate, ctx) {
+      const allowed = parseFlagList(pi.getFlag("allowed-agents") as string | undefined);
+      if (allowed.length === 0 || !allowed.includes(params.recipe)) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `delegate: recipe '${params.recipe}' not in this agent's allowed list [${allowed.join(", ")}]`,
+            },
+          ],
+          details: { error: "recipe_not_allowed", recipe: params.recipe, allowed },
+        };
+      }
+
+      // Sandbox containment: child sandbox must be == or inside parent's.
+      // Parent root is ctx.cwd because the runner spawns pi with cwd=sandboxRoot.
+      const parentRoot = path.resolve(ctx?.cwd || process.cwd());
+      const requested = path.resolve(parentRoot, params.sandbox || parentRoot);
+      if (requested !== parentRoot && !requested.startsWith(parentRoot + path.sep)) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `delegate: sandbox '${requested}' escapes parent root '${parentRoot}'`,
+            },
+          ],
+          details: { error: "sandbox_escape", requested, parentRoot },
+        };
+      }
+
       const recipeFile = path.join(AGENTS_DIR, `${params.recipe}.yaml`);
       if (!existsSync(recipeFile)) {
         return {
@@ -75,13 +243,73 @@ export default function (pi: ExtensionAPI) {
         };
       }
 
-      // pi.getFlag is scoped to the calling extension, so we can't read
-      // sandbox-root cross-extension. ctx.cwd works because the runner
-      // spawns pi with cwd=sandboxRoot.
-      const sandboxRoot = path.resolve(params.sandbox || ctx?.cwd || process.cwd());
       const timeoutMs = typeof params.timeout_ms === "number" ? params.timeout_ms : DEFAULT_TIMEOUT_MS;
 
-      const args = [RUNNER_PATH, params.recipe, "--sandbox", sandboxRoot, "-p", params.task];
+      // Per-call RPC socket. Lives in os.tmpdir() so it's never inside any
+      // sandbox root, can't be seen by sandbox path-rejection, and is
+      // unique per call.
+      const sockPath = path.join(os.tmpdir(), `pi-rpc-${process.pid}-${randomUUID()}.sock`);
+      const id = randomUUID();
+      const stdoutBuf = { value: "", truncated: false };
+      const stderrBuf = { value: "" };
+
+      // The child opens at most one connection and sends at most one
+      // request-approval line per delegation. connectionReady resolves
+      // with that conn + request once the line is received.
+      let resolveConnection!: (value: { conn: net.Socket; req: ApprovalRequest }) => void;
+      const connectionReady = new Promise<{ conn: net.Socket; req: ApprovalRequest }>((resolve) => {
+        resolveConnection = resolve;
+      });
+
+      const server = net.createServer((conn) => {
+        let buf = "";
+        conn.setEncoding("utf8");
+        conn.on("data", (chunk: string) => {
+          buf += chunk;
+          const nl = buf.indexOf("\n");
+          if (nl === -1) return;
+          const line = buf.slice(0, nl);
+          buf = buf.slice(nl + 1);
+          try {
+            const msg = JSON.parse(line) as { type?: string; title?: string; summary?: string; preview?: string };
+            if (
+              msg.type === "request-approval" &&
+              typeof msg.title === "string" &&
+              typeof msg.summary === "string" &&
+              typeof msg.preview === "string"
+            ) {
+              resolveConnection({
+                conn,
+                req: { title: msg.title, summary: msg.summary, preview: msg.preview },
+              });
+              return;
+            }
+          } catch {
+            /* malformed; ignore — child will time out */
+          }
+        });
+        conn.on("error", () => conn.destroy());
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(sockPath, () => {
+          server.removeAllListeners("error");
+          resolve();
+        });
+      });
+
+      const args = [
+        RUNNER_PATH,
+        params.recipe,
+        "--sandbox",
+        requested,
+        "-p",
+        params.task,
+        "--",
+        "--rpc-sock",
+        sockPath,
+      ];
 
       const child = spawn(process.execPath, args, {
         cwd: REPO_ROOT,
@@ -89,58 +317,220 @@ export default function (pi: ExtensionAPI) {
         stdio: ["ignore", "pipe", "pipe"],
       });
 
-      let stdout = "";
-      let stderr = "";
-      let truncated = false;
+      child.stdout?.on("data", (c: Buffer) => appendBuffer(stdoutBuf, c, MAX_OUTPUT_BYTES));
+      child.stderr?.on("data", (c: Buffer) => appendBuffer(stderrBuf, c, MAX_OUTPUT_BYTES));
 
-      const append = (target: "stdout" | "stderr", chunk: Buffer) => {
-        const s = chunk.toString("utf8");
-        if (target === "stdout") {
-          if (stdout.length + s.length > MAX_OUTPUT_BYTES) {
-            stdout += s.slice(0, MAX_OUTPUT_BYTES - stdout.length);
-            truncated = true;
-          } else {
-            stdout += s;
-          }
-        } else {
-          if (stderr.length < MAX_OUTPUT_BYTES) {
-            stderr += s.slice(0, MAX_OUTPUT_BYTES - stderr.length);
-          }
-        }
-      };
-      child.stdout?.on("data", (c: Buffer) => append("stdout", c));
-      child.stderr?.on("data", (c: Buffer) => append("stderr", c));
-
-      const onAbort = () => {
-        if (!child.killed) child.kill("SIGTERM");
-      };
+      const onAbort = () => killSafe(child);
       signal?.addEventListener("abort", onAbort, { once: true });
 
-      const timer = setTimeout(() => {
-        if (!child.killed) child.kill("SIGTERM");
-      }, timeoutMs);
-
-      const exit: { code: number | null; signal: NodeJS.Signals | null } = await new Promise((resolve) => {
+      const exited: Promise<{ code: number | null; signal: NodeJS.Signals | null }> = new Promise((resolve) => {
         child.once("exit", (code, sig) => resolve({ code, signal: sig }));
       });
 
-      clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
+      // Race child-exits-without-RPC against child-requests-approval.
+      const sentinel = await Promise.race([
+        exited.then((exit) => ({ kind: "exit" as const, exit })),
+        connectionReady.then((ready) => ({ kind: "rpc" as const, ready })),
+      ]);
 
-      const tail = truncated ? "\n…(output truncated)" : "";
-      const text = stdout.length > 0 ? `${stdout}${tail}` : stderr || "(no output)";
+      if (sentinel.kind === "exit") {
+        // Child completed with no drafts queued. Today's behavior.
+        signal?.removeEventListener("abort", onAbort);
+        try {
+          server.close();
+        } catch {
+          /* noop */
+        }
+        unlinkSafe(sockPath);
+        const tail = stdoutBuf.truncated ? "\n…(output truncated)" : "";
+        const text = stdoutBuf.value.length > 0 ? `${stdoutBuf.value}${tail}` : stderrBuf.value || "(no output)";
+        return {
+          content: [{ type: "text", text }],
+          details: {
+            recipe: params.recipe,
+            paused: false,
+            exit_code: sentinel.exit.code,
+            exit_signal: sentinel.exit.signal,
+            stdout_bytes: stdoutBuf.value.length,
+            stderr_bytes: stderrBuf.value.length,
+            truncated: stdoutBuf.truncated,
+          },
+        };
+      }
 
+      // Child requested approval. Park the delegation; return preview to LLM.
+      const watchdog = setTimeout(() => {
+        const e = state.pending.get(id);
+        if (!e) return;
+        try {
+          e.conn.write(JSON.stringify({ type: "approval-result", approved: false }) + "\n");
+        } catch {
+          /* noop */
+        }
+        killSafe(e.child);
+      }, timeoutMs);
+
+      const entry: PendingDelegation = {
+        id,
+        recipe: params.recipe,
+        child,
+        conn: sentinel.ready.conn,
+        request: sentinel.ready.req,
+        startedAt: Date.now(),
+        timeoutMs,
+        stdoutSoFar: stdoutBuf,
+        stderrSoFar: stderrBuf,
+        exited,
+        timer: watchdog,
+        server,
+        sockPath,
+      };
+      state.pending.set(id, entry);
+
+      // Best-effort post-cleanup once the child eventually exits. The
+      // registry entry stays in place until approve_delegation consumes
+      // it (or the watchdog tears it down explicitly).
+      exited.then(() => {
+        clearTimeout(watchdog);
+        signal?.removeEventListener("abort", onAbort);
+        try {
+          entry.conn.destroy();
+        } catch {
+          /* noop */
+        }
+        try {
+          server.close();
+        } catch {
+          /* noop */
+        }
+        unlinkSafe(sockPath);
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Child paused awaiting approval. Review the preview below, then call ` +
+              `approve_delegation({ id: "${id}", approved: true|false, escalate?: true, comment?: "..." }).\n\n` +
+              formatPreview(entry, entry.request.title),
+          },
+        ],
+        details: {
+          recipe: params.recipe,
+          paused: true,
+          delegation_id: id,
+          summary: entry.request.summary,
+          timeout_ms: timeoutMs,
+        },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "approve_delegation",
+    label: "Approve Delegation",
+    description:
+      "Resume a paused delegation. Pass { id, approved: true } to apply the " +
+      "child's drafts; { approved: false } to discard them. Pass " +
+      "{ escalate: true } to ask the human user instead — this routes through " +
+      "the same recursive primitive deferred-confirm uses, so it works whether " +
+      "this agent has a UI or is itself running as a child via --rpc-sock " +
+      "(escalation walks up the chain to whoever can answer).",
+    parameters: Type.Object({
+      id: Type.String({ description: "delegation_id from a previous `delegate` call." }),
+      approved: Type.Optional(
+        Type.Boolean({
+          description: "Your decision. Required unless escalate=true.",
+        }),
+      ),
+      escalate: Type.Optional(
+        Type.Boolean({
+          description:
+            "If true, ask the human (or recursively forward up the parent chain) " +
+            "instead of using `approved`.",
+        }),
+      ),
+      comment: Type.Optional(
+        Type.String({ description: "Free-text rationale (recorded in tool details, not shown to the human dialog)." }),
+      ),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const entry = state.pending.get(params.id);
+      if (!entry) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `approve_delegation: no pending delegation with id '${params.id}'.`,
+            },
+          ],
+          details: { error: "unknown_delegation", id: params.id },
+        };
+      }
+
+      let approved: boolean;
+      let source: "agent" | "human";
+      if (params.escalate) {
+        approved = await requestHumanApproval(ctx as ExtensionContext, pi, entry.request);
+        source = "human";
+      } else if (typeof params.approved === "boolean") {
+        approved = params.approved;
+        source = "agent";
+      } else {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "approve_delegation: must pass either `approved: true|false` or `escalate: true`.",
+            },
+          ],
+          details: { error: "missing_decision", id: params.id },
+        };
+      }
+
+      // Send the decision and stop the watchdog.
+      clearTimeout(entry.timer);
+      try {
+        entry.conn.write(JSON.stringify({ type: "approval-result", approved }) + "\n");
+      } catch {
+        /* the child may have died already */
+      }
+
+      // Wait for child to actually finish applying (or rejecting) and exit,
+      // capped by remaining timeout budget.
+      const remaining = Math.max(1000, entry.timeoutMs - (Date.now() - entry.startedAt));
+      const exit = await Promise.race([
+        entry.exited,
+        new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+          setTimeout(() => {
+            killSafe(entry.child);
+            resolve({ code: null, signal: "SIGTERM" });
+          }, remaining);
+        }),
+      ]);
+
+      // Drain registry; final cleanup of socket/server already happens in
+      // the exit handler attached at delegate time.
+      state.pending.delete(params.id);
+
+      const text = finalText(entry, exit);
       return {
         content: [{ type: "text", text }],
         details: {
-          recipe: params.recipe,
+          delegation_id: params.id,
+          recipe: entry.recipe,
+          approved,
+          source,
+          comment: params.comment ?? null,
           exit_code: exit.code,
           exit_signal: exit.signal,
-          stdout_bytes: stdout.length,
-          stderr_bytes: stderr.length,
-          truncated,
+          stdout_bytes: entry.stdoutSoFar.value.length,
+          stderr_bytes: entry.stderrSoFar.value.length,
+          truncated: entry.stdoutSoFar.truncated,
         },
       };
     },
   });
 }
+

--- a/pi-sandbox/.pi/extensions/agent-spawn.ts
+++ b/pi-sandbox/.pi/extensions/agent-spawn.ts
@@ -1,24 +1,27 @@
-// agent-spawn extension — blocking delegation to a focused child agent
+// agent-spawn extension — non-blocking delegation to a focused child agent
 // with parent-driven approval.
 //
 // Two tools:
 //   - `delegate({recipe, task, sandbox?, timeout_ms?})` spawns
-//     `node scripts/run-agent.mjs <recipe> -p <task>` as a subprocess.
-//     If the child exits without queuing any deferred-* drafts, returns
-//     the captured stdout (today's behavior). If the child queues drafts,
-//     the child pauses on the per-call RPC socket, the parent records
-//     the pending delegation in a globalThis registry, and `delegate`
-//     returns the preview + delegation_id so the parent LLM can review
-//     and decide.
-//   - `approve_delegation({id, approved, escalate?, comment?})` resumes
-//     a paused child. If escalate=true, the parent's own
-//     requestHumanApproval primitive is used (which routes to
-//     ctx.ui.confirm locally OR forwards up the parent's --rpc-sock if
-//     the parent itself is a child).
+//     `node scripts/run-agent.mjs <recipe> -p <task>` as a subprocess and
+//     returns immediately with a `delegation_id`. The child runs in the
+//     background. Call `approve_delegation` when ready to collect the result.
+//     Multiple `delegate` calls in sequence start multiple children in parallel.
+//   - `approve_delegation({id, approved?, escalate?, comment?})` is the join
+//     point. Blocks until the child settles (exits or pauses with drafts).
+//     - If child exited without queuing drafts: returns captured stdout.
+//     - If child paused with drafts queued and no decision given: returns the
+//       preview so the parent LLM can review before deciding. Call again with
+//       approved=true/false to send the decision.
+//     - If child paused and approved/escalate is given: sends the decision,
+//       waits for the child to finish applying/discarding, and returns captured
+//       stdout. The preview is included in the result for audit.
+//     - escalate=true asks the human (or forwards up --rpc-sock chain) instead
+//       of using the approved parameter.
 //
-// Why two tools: putting the parent LLM in the approval loop requires
-// returning the preview to the LLM mid-delegation. A single blocking
-// `delegate` can't do that.
+// Why non-blocking delegate: the parent LLM can kick off N children in
+// sequence without waiting for each to settle, so all N run in parallel.
+// approve_delegation is the join point that waits and collects.
 //
 // Why subprocess and not in-process createAgentSession: the parent's
 // extension surface (including agent-bus's socket binding) would re-fire
@@ -52,12 +55,15 @@ const AGENTS_DIR = path.join(REPO_ROOT, "pi-sandbox", "agents");
 const MAX_OUTPUT_BYTES = 20_000;
 const DEFAULT_TIMEOUT_MS = 5 * 60_000;
 
+/** Discriminated union resolved by the settlement Promise. */
+type SpawnOutcome =
+  | { kind: "exit"; exit: { code: number | null; signal: NodeJS.Signals | null } }
+  | { kind: "rpc"; conn: net.Socket; req: ApprovalRequest };
+
 interface PendingDelegation {
   id: string;
   recipe: string;
   child: ChildProcess;
-  conn: net.Socket;
-  request: ApprovalRequest;
   startedAt: number;
   timeoutMs: number;
   /** Captured stdout so far (drained continuously even while paused). */
@@ -66,12 +72,23 @@ interface PendingDelegation {
   stderrSoFar: { value: string };
   /** Resolved when the child has exited, with the final exit info. */
   exited: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
-  /** Watchdog timer; cleared when approve_delegation runs. */
+  /** Watchdog timer; cleared when approve_delegation sends a decision. */
   timer: NodeJS.Timeout;
   /** RPC server (per-call); closed after the child exits. */
   server: net.Server;
   /** Socket path; unlinked after close. */
   sockPath: string;
+  /**
+   * Resolves when the child either exits cleanly (no drafts) or sends a
+   * request-approval over the RPC socket (drafts queued, child paused).
+   */
+  settled: Promise<SpawnOutcome>;
+  /**
+   * Set synchronously once settled resolves as "rpc". Lets the synchronous
+   * process-exit cleanup walker and watchdog send the denial without awaiting
+   * the settled promise inside a sync callback.
+   */
+  resolvedConn?: net.Socket;
 }
 
 interface SpawnState {
@@ -124,11 +141,13 @@ function ensureProcessCleanup(state: SpawnState): void {
   state.cleanupRegistered = true;
   process.once("exit", () => {
     for (const p of state.pending.values()) {
-      try {
-        p.conn.write(JSON.stringify({ type: "approval-result", approved: false }) + "\n");
-        p.conn.destroy();
-      } catch {
-        /* noop */
+      if (p.resolvedConn) {
+        try {
+          p.resolvedConn.write(JSON.stringify({ type: "approval-result", approved: false }) + "\n");
+          p.resolvedConn.destroy();
+        } catch {
+          /* noop */
+        }
       }
       killSafe(p.child);
       try {
@@ -142,8 +161,8 @@ function ensureProcessCleanup(state: SpawnState): void {
   });
 }
 
-function formatPreview(p: PendingDelegation, header: string): string {
-  return `${header}\n\nrecipe: ${p.recipe}\ndelegation_id: ${p.id}\n\n${p.request.preview}`;
+function formatPreview(entry: PendingDelegation, req: ApprovalRequest): string {
+  return `${req.title}\n\nrecipe: ${entry.recipe}\ndelegation_id: ${entry.id}\n\n${req.preview}`;
 }
 
 function finalText(p: PendingDelegation, exit: { code: number | null; signal: NodeJS.Signals | null }): string {
@@ -171,14 +190,12 @@ export default function (pi: ExtensionAPI) {
     name: "delegate",
     label: "Delegate",
     description:
-      "Spawn a child agent from a recipe in pi-sandbox/agents/, hand it a " +
-      "task, and run it. If the child exits without queuing any deferred " +
-      "drafts, returns the captured stdout. If the child queues drafts, " +
-      "the child pauses; this tool returns the preview and a " +
-      "`delegation_id`. Call `approve_delegation` to resume the child " +
-      "with your approval decision (or escalate to the human). Recipe " +
-      "must be in this agent's allowed list (set via the recipe's " +
-      "`agents:` field).",
+      "Spawn a child agent from a recipe in pi-sandbox/agents/ and hand it a task. " +
+      "Returns immediately with a `delegation_id`; the child runs in the background. " +
+      "Call `approve_delegation` (with the id) when you're ready to collect the result " +
+      "or send your approval decision. You may call `delegate` multiple times in " +
+      "sequence before calling `approve_delegation` — all children spawn in parallel. " +
+      "Recipe must be in this agent's allowed list (set via the recipe's `agents:` field).",
     parameters: Type.Object({
       recipe: Type.String({
         description: "Name of a recipe in pi-sandbox/agents/ (without .yaml suffix).",
@@ -327,55 +344,33 @@ export default function (pi: ExtensionAPI) {
         child.once("exit", (code, sig) => resolve({ code, signal: sig }));
       });
 
-      // Race child-exits-without-RPC against child-requests-approval.
-      const sentinel = await Promise.race([
+      // Build the settlement promise but do NOT await it here — delegate
+      // returns immediately so the parent LLM can start more children.
+      const settled: Promise<SpawnOutcome> = Promise.race([
         exited.then((exit) => ({ kind: "exit" as const, exit })),
-        connectionReady.then((ready) => ({ kind: "rpc" as const, ready })),
+        connectionReady.then((ready) => ({ kind: "rpc" as const, conn: ready.conn, req: ready.req })),
       ]);
 
-      if (sentinel.kind === "exit") {
-        // Child completed with no drafts queued. Today's behavior.
-        signal?.removeEventListener("abort", onAbort);
-        try {
-          server.close();
-        } catch {
-          /* noop */
-        }
-        unlinkSafe(sockPath);
-        const tail = stdoutBuf.truncated ? "\n…(output truncated)" : "";
-        const text = stdoutBuf.value.length > 0 ? `${stdoutBuf.value}${tail}` : stderrBuf.value || "(no output)";
-        return {
-          content: [{ type: "text", text }],
-          details: {
-            recipe: params.recipe,
-            paused: false,
-            exit_code: sentinel.exit.code,
-            exit_signal: sentinel.exit.signal,
-            stdout_bytes: stdoutBuf.value.length,
-            stderr_bytes: stderrBuf.value.length,
-            truncated: stdoutBuf.truncated,
-          },
-        };
-      }
-
-      // Child requested approval. Park the delegation; return preview to LLM.
+      // Watchdog: if approve_delegation is never called within timeoutMs,
+      // deny the pending request (if any) and kill the child.
       const watchdog = setTimeout(() => {
         const e = state.pending.get(id);
         if (!e) return;
-        try {
-          e.conn.write(JSON.stringify({ type: "approval-result", approved: false }) + "\n");
-        } catch {
-          /* noop */
+        if (e.resolvedConn) {
+          try {
+            e.resolvedConn.write(JSON.stringify({ type: "approval-result", approved: false }) + "\n");
+          } catch {
+            /* noop */
+          }
         }
         killSafe(e.child);
+        state.pending.delete(id);
       }, timeoutMs);
 
       const entry: PendingDelegation = {
         id,
         recipe: params.recipe,
         child,
-        conn: sentinel.ready.conn,
-        request: sentinel.ready.req,
         startedAt: Date.now(),
         timeoutMs,
         stdoutSoFar: stdoutBuf,
@@ -384,17 +379,24 @@ export default function (pi: ExtensionAPI) {
         timer: watchdog,
         server,
         sockPath,
+        settled,
       };
       state.pending.set(id, entry);
 
-      // Best-effort post-cleanup once the child eventually exits. The
-      // registry entry stays in place until approve_delegation consumes
-      // it (or the watchdog tears it down explicitly).
+      // Cache the conn synchronously once the child pauses so the cleanup
+      // walker and watchdog can use it from synchronous callbacks.
+      settled.then((outcome) => {
+        if (outcome.kind === "rpc") {
+          entry.resolvedConn = outcome.conn;
+        }
+      });
+
+      // Best-effort post-cleanup once the child eventually exits.
       exited.then(() => {
         clearTimeout(watchdog);
         signal?.removeEventListener("abort", onAbort);
         try {
-          entry.conn.destroy();
+          entry.resolvedConn?.destroy();
         } catch {
           /* noop */
         }
@@ -411,16 +413,13 @@ export default function (pi: ExtensionAPI) {
           {
             type: "text",
             text:
-              `Child paused awaiting approval. Review the preview below, then call ` +
-              `approve_delegation({ id: "${id}", approved: true|false, escalate?: true, comment?: "..." }).\n\n` +
-              formatPreview(entry, entry.request.title),
+              `Child spawning. delegation_id: "${id}"\n` +
+              `Call approve_delegation({ id: "${id}", approved: true|false }) when ready.`,
           },
         ],
         details: {
           recipe: params.recipe,
-          paused: true,
           delegation_id: id,
-          summary: entry.request.summary,
           timeout_ms: timeoutMs,
         },
       };
@@ -431,17 +430,21 @@ export default function (pi: ExtensionAPI) {
     name: "approve_delegation",
     label: "Approve Delegation",
     description:
-      "Resume a paused delegation. Pass { id, approved: true } to apply the " +
-      "child's drafts; { approved: false } to discard them. Pass " +
-      "{ escalate: true } to ask the human user instead — this routes through " +
-      "the same recursive primitive deferred-confirm uses, so it works whether " +
-      "this agent has a UI or is itself running as a child via --rpc-sock " +
-      "(escalation walks up the chain to whoever can answer).",
+      "Collect the result of a delegation and, if the child queued file drafts " +
+      "for approval, send your decision. Blocks until the child settles.\n\n" +
+      "- Child exited without queuing drafts: returns captured stdout. No decision needed.\n" +
+      "- Child paused with drafts queued, no `approved`/`escalate` given: returns the " +
+      "preview so you can review it. Call again with `approved: true|false` to decide.\n" +
+      "- Child paused with drafts queued, `approved` given: sends the decision immediately, " +
+      "waits for the child to finish, and returns captured stdout. The preview is included " +
+      "in the result for audit.\n" +
+      "- `escalate: true`: ask the human user instead (routes recursively up the parent " +
+      "chain if this agent is itself a child via --rpc-sock).",
     parameters: Type.Object({
       id: Type.String({ description: "delegation_id from a previous `delegate` call." }),
       approved: Type.Optional(
         Type.Boolean({
-          description: "Your decision. Required unless escalate=true.",
+          description: "Your decision. Required unless escalate=true or the child exited without drafts.",
         }),
       ),
       escalate: Type.Optional(
@@ -469,30 +472,66 @@ export default function (pi: ExtensionAPI) {
         };
       }
 
-      let approved: boolean;
-      let source: "agent" | "human";
-      if (params.escalate) {
-        approved = await requestHumanApproval(ctx as ExtensionContext, pi, entry.request);
-        source = "human";
-      } else if (typeof params.approved === "boolean") {
-        approved = params.approved;
-        source = "agent";
-      } else {
+      // Wait for the child to settle (may already be done if child was fast).
+      const outcome = await entry.settled;
+
+      if (outcome.kind === "exit") {
+        // Child completed without queuing any drafts — no approval needed.
+        clearTimeout(entry.timer);
+        state.pending.delete(params.id);
+        const text = finalText(entry, outcome.exit);
+        return {
+          content: [{ type: "text", text }],
+          details: {
+            delegation_id: params.id,
+            recipe: entry.recipe,
+            paused: false,
+            exit_code: outcome.exit.code,
+            exit_signal: outcome.exit.signal,
+            stdout_bytes: entry.stdoutSoFar.value.length,
+            stderr_bytes: entry.stderrSoFar.value.length,
+            truncated: entry.stdoutSoFar.truncated,
+          },
+        };
+      }
+
+      // Child paused with drafts queued. outcome.conn is the open RPC connection.
+      // Phase 1: if no decision given yet, return the preview for review.
+      if (!params.escalate && typeof params.approved !== "boolean") {
         return {
           content: [
             {
               type: "text",
-              text: "approve_delegation: must pass either `approved: true|false` or `escalate: true`.",
+              text:
+                `Child paused awaiting your decision. Review the preview below, ` +
+                `then call approve_delegation({ id: "${params.id}", approved: true|false, escalate?: true }).\n\n` +
+                formatPreview(entry, outcome.req),
             },
           ],
-          details: { error: "missing_decision", id: params.id },
+          details: {
+            recipe: entry.recipe,
+            paused: true,
+            delegation_id: params.id,
+            summary: outcome.req.summary,
+          },
         };
       }
 
-      // Send the decision and stop the watchdog.
+      // Phase 2: decision provided (or escalated). Send it.
+      let approved: boolean;
+      let source: "agent" | "human";
+      if (params.escalate) {
+        approved = await requestHumanApproval(ctx as ExtensionContext, pi, outcome.req);
+        source = "human";
+      } else {
+        approved = params.approved as boolean;
+        source = "agent";
+      }
+
+      // Stop the watchdog and send the decision.
       clearTimeout(entry.timer);
       try {
-        entry.conn.write(JSON.stringify({ type: "approval-result", approved }) + "\n");
+        outcome.conn.write(JSON.stringify({ type: "approval-result", approved }) + "\n");
       } catch {
         /* the child may have died already */
       }
@@ -510,11 +549,14 @@ export default function (pi: ExtensionAPI) {
         }),
       ]);
 
-      // Drain registry; final cleanup of socket/server already happens in
-      // the exit handler attached at delegate time.
+      // Drain registry; final cleanup of socket/server happens in the exited
+      // handler attached at delegate time.
       state.pending.delete(params.id);
 
-      const text = finalText(entry, exit);
+      // Include the preview in the result so the parent LLM has an audit trail
+      // even when it passed approved=true without a prior preview-only call.
+      const previewAudit = `\n\n--- applied preview ---\n${formatPreview(entry, outcome.req)}`;
+      const text = finalText(entry, exit) + (approved ? previewAudit : "");
       return {
         content: [{ type: "text", text }],
         details: {
@@ -533,4 +575,3 @@ export default function (pi: ExtensionAPI) {
     },
   });
 }
-

--- a/pi-sandbox/.pi/extensions/deferred-confirm.ts
+++ b/pi-sandbox/.pi/extensions/deferred-confirm.ts
@@ -4,13 +4,20 @@
 //   1. A shared registry (the named exports below) that other "deferred-*"
 //      extensions import to register end-of-turn handlers.
 //   2. The coordinator that, on agent_end, drives every registered handler
-//      through prepare -> unified ctx.ui.confirm -> atomic apply.
+//      through prepare -> unified approval prompt -> atomic apply.
+//   3. The owner of the RPC primitive that lets a print-mode child forward
+//      its approval request to its parent's UI. Same primitive is used by
+//      agent-spawn's `approve_delegation` escalation path, so any agent
+//      works whether it's running standalone (with a UI) or as a child
+//      (with --rpc-sock), and escalations bubble recursively up the
+//      parent chain to whoever has a real UI.
 //
 // The handler array is stashed on globalThis so it's shared across
 // extensions even though jiti loads each extension's import graph in
 // isolation (loader.js uses `moduleCache: false` and a fresh createJiti
 // per extension).
 
+import net from "node:net";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 
 export interface DeferredHandler {
@@ -35,6 +42,12 @@ export type PrepareResult =
       apply: () => Promise<{ wrote: string[]; failed: string[] }>;
     };
 
+export interface ApprovalRequest {
+  title: string;
+  summary: string;
+  preview: string;
+}
+
 function getHandlers(): DeferredHandler[] {
   const g = globalThis as { __pi_deferred_handlers__?: DeferredHandler[] };
   return (g.__pi_deferred_handlers__ ??= []);
@@ -49,7 +62,102 @@ export function listDeferredHandlers(): readonly DeferredHandler[] {
   return handlers;
 }
 
+/**
+ * Recursive approval primitive. Routes a request to whoever can answer:
+ *   - if ctx.hasUI, render ctx.ui.confirm locally (this process is the human's terminal)
+ *   - else if --rpc-sock is set, forward to the parent agent's RPC server
+ *     (parent itself recurses if it's also headless, so escalation walks
+ *     up the chain to the human at the top)
+ *   - else loud-fail to stderr and return false
+ *
+ * Used by deferred-confirm's own agent_end and by agent-spawn's
+ * approve_delegation when the parent LLM chooses to escalate.
+ */
+export async function requestHumanApproval(
+  ctx: ExtensionContext,
+  pi: ExtensionAPI,
+  req: ApprovalRequest,
+): Promise<boolean> {
+  if (ctx.hasUI) {
+    return ctx.ui.confirm(req.title, req.preview);
+  }
+  const sockPath = pi.getFlag("rpc-sock") as string | undefined;
+  if (sockPath) {
+    return rpcRequestApproval(sockPath, req);
+  }
+  process.stderr.write(
+    `[deferred] dropped: no UI and no --rpc-sock (title: ${req.title})\n`,
+  );
+  return false;
+}
+
+/**
+ * Connect to the parent's RPC server, send one request, await one reply.
+ * Any failure (parent died, EPIPE, malformed reply, server closed without
+ * replying) settles as approved=false. No retries, no offline queueing.
+ */
+function rpcRequestApproval(sockPath: string, req: ApprovalRequest): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = net.connect(sockPath);
+    let buf = "";
+    let settled = false;
+    const settle = (approved: boolean) => {
+      if (settled) return;
+      settled = true;
+      sock.removeAllListeners();
+      sock.destroy();
+      resolve(approved);
+    };
+    sock.setEncoding("utf8");
+    sock.once("connect", () => {
+      const line = JSON.stringify({ type: "request-approval", ...req }) + "\n";
+      sock.write(line, "utf8", (err?: Error | null) => {
+        if (err) settle(false);
+      });
+    });
+    sock.on("data", (chunk: string) => {
+      buf += chunk;
+      const nl = buf.indexOf("\n");
+      if (nl === -1) return;
+      const line = buf.slice(0, nl);
+      try {
+        const msg = JSON.parse(line) as { type?: string; approved?: unknown };
+        if (msg.type === "approval-result" && typeof msg.approved === "boolean") {
+          settle(msg.approved);
+          return;
+        }
+      } catch {
+        /* fall through to false */
+      }
+      settle(false);
+    });
+    sock.once("error", () => settle(false));
+    sock.once("close", () => settle(false));
+  });
+}
+
+/**
+ * Route an info/error notification through the right channel.
+ * If we have a UI, use ctx.ui.notify; otherwise write a tagged line to
+ * stdout so the parent's tool-call result captures it.
+ */
+function tell(ctx: ExtensionContext, level: "info" | "error", message: string) {
+  if (ctx.hasUI) {
+    ctx.ui.notify(message, level);
+    return;
+  }
+  const tag = level === "error" ? "[deferred:error]" : "[deferred]";
+  process.stdout.write(`${tag} ${message}\n`);
+}
+
 export default function (pi: ExtensionAPI) {
+  pi.registerFlag("rpc-sock", {
+    description:
+      "Unix socket path used to forward end-of-turn approval requests to a parent agent. " +
+      "Set by agent-spawn when launching a child; leave unset for interactive runs.",
+    type: "string",
+  });
+
   pi.on("agent_end", async (_event, ctx) => {
     if (handlers.length === 0) return;
 
@@ -72,12 +180,7 @@ export default function (pi: ExtensionAPI) {
         : [],
     );
     if (errors.length > 0) {
-      if (ctx.hasUI) {
-        ctx.ui.notify(
-          `deferred batch aborted (re-validation failed):\n${errors.join("\n")}`,
-          "error",
-        );
-      }
+      tell(ctx, "error", `deferred batch aborted (re-validation failed):\n${errors.join("\n")}`);
       return;
     }
 
@@ -86,11 +189,6 @@ export default function (pi: ExtensionAPI) {
       p.result.status === "ok" ? [{ handler: p.handler, result: p.result }] : [],
     );
     if (oks.length === 0) return;
-
-    if (!ctx.hasUI) {
-      // Non-interactive: refuse to apply without confirmation.
-      return;
-    }
 
     oks.sort((a, b) => a.handler.priority - b.handler.priority);
 
@@ -101,12 +199,13 @@ export default function (pi: ExtensionAPI) {
       .map((p) => `${p.handler.label} (${p.result.summary})\n\n${p.result.preview}`)
       .join("\n\n---\n\n");
 
-    const ok = await ctx.ui.confirm(
-      `Apply pending changes?  (${summaryLine})`,
-      previewBody,
-    );
+    const ok = await requestHumanApproval(ctx, pi, {
+      title: `Apply pending changes?  (${summaryLine})`,
+      summary: summaryLine,
+      preview: previewBody,
+    });
     if (!ok) {
-      ctx.ui.notify("deferred batch cancelled, nothing applied", "info");
+      tell(ctx, "info", "deferred batch cancelled, nothing applied");
       return;
     }
 
@@ -114,13 +213,13 @@ export default function (pi: ExtensionAPI) {
       try {
         const r = await p.result.apply();
         if (r.failed.length > 0) {
-          ctx.ui.notify(`${p.handler.label} failures:\n${r.failed.join("\n")}`, "error");
+          tell(ctx, "error", `${p.handler.label} failures:\n${r.failed.join("\n")}`);
         }
         if (r.wrote.length > 0) {
-          ctx.ui.notify(`${p.handler.label} applied:\n${r.wrote.join("\n")}`, "info");
+          tell(ctx, "info", `${p.handler.label} applied:\n${r.wrote.join("\n")}`);
         }
       } catch (e) {
-        ctx.ui.notify(`${p.handler.label} crashed: ${(e as Error).message}`, "error");
+        tell(ctx, "error", `${p.handler.label} crashed: ${(e as Error).message}`);
       }
     }
   });

--- a/pi-sandbox/agents/delegator.yaml
+++ b/pi-sandbox/agents/delegator.yaml
@@ -21,19 +21,25 @@ prompt: |
   You are a planner. Your job is to decompose the user's request into
   focused subtasks and hand each to the right recipe via `delegate`.
 
+  `delegate` is non-blocking: it spawns a child and returns a
+  `delegation_id` immediately. You can call `delegate` multiple times in
+  a row to start several children in parallel before collecting any
+  results. `approve_delegation` is the join point that waits for a child
+  to settle and, if the child queued file drafts, lets you approve or
+  reject them.
+
   Tools:
   - `delegate({recipe, task, sandbox?, timeout_ms?})` — spawns a child
-    agent from pi-sandbox/agents/<recipe>.yaml as a subprocess. If the
-    child finishes without queuing file drafts, the tool returns the
-    captured stdout. If the child queues drafts, the tool returns a
-    preview and a `delegation_id`; the child is paused awaiting your
-    decision.
-  - `approve_delegation({id, approved, escalate?, comment?})` — resumes
-    a paused child. Pass `approved: true` to apply the drafts (files
-    land on disk in the child's sandbox), `approved: false` to discard
-    them, or `escalate: true` to ask the human for the call instead.
-    You MUST call this after every paused delegation; if you skip it
-    the child times out and its drafts are dropped.
+    agent from pi-sandbox/agents/<recipe>.yaml as a subprocess. Returns
+    a `delegation_id` immediately; the child runs in the background.
+  - `approve_delegation({id, approved?, escalate?, comment?})` — collects
+    the result of a delegation. If the child exited without queuing
+    drafts, returns captured stdout. If the child queued drafts and you
+    give no decision, returns the preview for review; call again with
+    `approved: true|false` to decide. Pass `escalate: true` to ask the
+    human for the call instead. You MUST call this for every delegation
+    you start; if you skip it the child times out and its drafts are
+    dropped.
   - `read`, `ls`, `grep` — local fs (sandboxed) for picking the right
     recipe and crafting the task prompt.
 
@@ -43,6 +49,9 @@ prompt: |
     you to the recipes listed under `agents:` below.
   - Each `delegate` call spawns a fresh pi process — there's startup
     latency. Don't delegate trivial work you could do inline.
+  - For independent subtasks (no ordering dependency), call `delegate`
+    for all of them before calling `approve_delegation` for any — all
+    children run in parallel.
   - When a delegation pauses, READ the preview before deciding.
     Auto-approve if the drafts match the task; reject if they don't;
     escalate if you're genuinely unsure. Don't escalate routinely —

--- a/pi-sandbox/agents/delegator.yaml
+++ b/pi-sandbox/agents/delegator.yaml
@@ -1,10 +1,17 @@
-# Delegator — demo agent for the agent-spawn extension. Spawns a child
-# agent from another recipe via `delegate(recipe, task)` and blocks
-# until the child exits, returning its captured stdout.
+# Delegator — demo agent for the agent-spawn extension. Decomposes
+# the user's request into focused subtasks and dispatches each to a
+# child agent via `delegate`. Children that queue file drafts pause
+# until the delegator reviews them and calls `approve_delegation`.
 #
-# Compose with peer-chatter (or any other recipe) as the worker target:
-#   npm run agent -- delegator --sandbox /tmp/p
+# `agents:` declares the closed allowlist of recipes this delegator
+# can spawn. The runner (scripts/run-agent.mjs) auto-loads the
+# agent-spawn extension and wires the `delegate` and
+# `approve_delegation` tools — declaring them again here would be
+# redundant but harmless.
+#
+# Run: npm run agent -- delegator --sandbox /tmp/p
 #   > "delegate to recipe peer-chatter with task 'list files in cwd'"
+#   > "delegate to recipe deferred-writer with task 'draft README.md'"
 
 model: LEAD_HARE_MODEL
 
@@ -16,25 +23,42 @@ prompt: |
 
   Tools:
   - `delegate({recipe, task, sandbox?, timeout_ms?})` — spawns a child
-    agent from pi-sandbox/agents/<recipe>.yaml in print mode (`-p`),
-    blocks until it exits, returns its stdout. The child runs through
-    the same runner as `npm run agent`, so it gets the full baseline
-    rails (sandbox, no-edit if its recipe loads it).
+    agent from pi-sandbox/agents/<recipe>.yaml as a subprocess. If the
+    child finishes without queuing file drafts, the tool returns the
+    captured stdout. If the child queues drafts, the tool returns a
+    preview and a `delegation_id`; the child is paused awaiting your
+    decision.
+  - `approve_delegation({id, approved, escalate?, comment?})` — resumes
+    a paused child. Pass `approved: true` to apply the drafts (files
+    land on disk in the child's sandbox), `approved: false` to discard
+    them, or `escalate: true` to ask the human for the call instead.
+    You MUST call this after every paused delegation; if you skip it
+    the child times out and its drafts are dropped.
   - `read`, `ls`, `grep` — local fs (sandboxed) for picking the right
     recipe and crafting the task prompt.
 
   Rules:
   - Pick the smallest recipe that fits the subtask. Read
-    pi-sandbox/agents/ to see what's available.
-  - Each `delegate` call is blocking and adds startup latency (a fresh
-    pi process). Don't delegate trivial work you could do inline.
+    pi-sandbox/agents/ to see what's available; the runner restricts
+    you to the recipes listed under `agents:` below.
+  - Each `delegate` call spawns a fresh pi process — there's startup
+    latency. Don't delegate trivial work you could do inline.
+  - When a delegation pauses, READ the preview before deciding.
+    Auto-approve if the drafts match the task; reject if they don't;
+    escalate if you're genuinely unsure. Don't escalate routinely —
+    that's a sign the task you handed off was too vague.
   - Summarise child output in your reply; don't dump raw stdout.
+
+agents:
+  - change-reviewer
+  - code-reviewer
+  - deferred-author
+  - deferred-editor
+  - deferred-writer
+  - peer-chatter
+  - writer-foreman
 
 tools:
   - read
   - ls
   - grep
-  - delegate
-
-extensions:
-  - agent-spawn

--- a/pi-sandbox/agents/writer-foreman.yaml
+++ b/pi-sandbox/agents/writer-foreman.yaml
@@ -1,0 +1,72 @@
+# Writer-foreman — decomposes a file-drafting request into focused
+# batches and dispatches each to a `deferred-writer` child via
+# `delegate`. The foreman LLM reviews each child's drafts itself before
+# approving via `approve_delegation`. If a request is genuinely
+# ambiguous (or touches sensitive files), the foreman can `escalate`
+# the approval to the human at the top of the chain.
+#
+# Wiring: `agents: [deferred-writer]` is enough. The runner
+# (scripts/run-agent.mjs) auto-loads the agent-spawn extension and
+# adds `delegate` + `approve_delegation` to the tool allowlist.
+#
+# Run: `npm run agent -- writer-foreman --sandbox /tmp/foreman-test`
+
+model: LEAD_HARE_MODEL
+
+description: Decomposes a drafting request, delegates batches to deferred-writer, and approves the children itself.
+
+prompt: |
+  You are a foreman that produces files by decomposing the user's request
+  into focused batches and dispatching each to a `deferred-writer` child.
+  The child drafts files in memory and returns a preview for your review.
+
+  Workflow per batch:
+
+  1. Read the user's request. Use `read`, `ls`, `grep`, `find` to inspect
+     the existing project so the task you hand off is concrete.
+  2. Call `delegate({recipe: "deferred-writer", task: "<concrete drafting
+     task>"})`. The child runs, queues drafts, pauses, and you receive
+     the preview as the tool result with a `delegation_id`.
+  3. Read the preview carefully. For each file the child drafted, check
+     that its path and content match what the user asked for.
+
+  Your decision (call `approve_delegation`):
+
+  - **Drafts match the task** → `approve_delegation({id, approved: true})`.
+    Files land on disk in the sandbox immediately. Your judgment, no
+    human asked.
+  - **Drafts are wrong** (wrong file, wrong content, missing line, etc.)
+    → `approve_delegation({id, approved: false})` and explain why in
+    your reply. Re-delegate with a clearer task if appropriate.
+  - **Genuinely unsure** (request was ambiguous, drafts touch sensitive
+    files like `.ssh/`, secrets, or anything outside the spirit of the
+    request) → `approve_delegation({id, escalate: true})`. The human
+    will see the preview and decide. Use this sparingly; if you find
+    yourself escalating routinely, the prompt to the child is too vague.
+
+  Approval is irreversible once `approved: true`: files are written
+  immediately and there's no undo. Be deliberate.
+
+  Do not call `approve_delegation` without first reading the preview.
+  Do not skip `approve_delegation` and start a new `delegate` — the
+  paused child will time out and its drafts will be discarded. Always
+  decide on each delegation before moving on.
+
+  Other rules:
+  - You do NOT have `write`, `edit`, `bash`, or any deferred-* tool
+    yourself. The only way to put files on disk is through a child.
+  - Each delegation has a fresh sandbox scope; by default the child
+    works in your sandbox root. Use the `sandbox` parameter to scope a
+    child to a subdirectory (e.g. `sandbox: "src/components"`) when
+    helpful.
+  - End your turn with a short summary: which files you approved,
+    which you rejected, anything you escalated.
+
+agents:
+  - deferred-writer
+
+tools:
+  - read
+  - ls
+  - grep
+  - find

--- a/pi-sandbox/agents/writer-foreman.yaml
+++ b/pi-sandbox/agents/writer-foreman.yaml
@@ -20,17 +20,25 @@ prompt: |
   into focused batches and dispatching each to a `deferred-writer` child.
   The child drafts files in memory and returns a preview for your review.
 
-  Workflow per batch:
+  `delegate` is non-blocking: it spawns the child and returns a
+  `delegation_id` immediately. You can call `delegate` multiple times in
+  a row to start several children in parallel before collecting any
+  results. `approve_delegation` is the join point that waits for a child
+  to settle and, if it queued drafts, lets you approve or reject them.
+
+  Workflow per batch (single file or tightly coupled set):
 
   1. Read the user's request. Use `read`, `ls`, `grep`, `find` to inspect
      the existing project so the task you hand off is concrete.
   2. Call `delegate({recipe: "deferred-writer", task: "<concrete drafting
-     task>"})`. The child runs, queues drafts, pauses, and you receive
-     the preview as the tool result with a `delegation_id`.
-  3. Read the preview carefully. For each file the child drafted, check
-     that its path and content match what the user asked for.
+     task>"})`. Returns a `delegation_id` immediately; the child is now
+     running in the background. Repeat for each independent batch.
+  3. For each delegation, call `approve_delegation({id})` to collect the
+     result. If the child queued drafts this returns the preview.
+  4. Read the preview. For each file, check that its path and content
+     match what the user asked for.
 
-  Your decision (call `approve_delegation`):
+  Your decision (call `approve_delegation` again with your decision):
 
   - **Drafts match the task** → `approve_delegation({id, approved: true})`.
     Files land on disk in the sandbox immediately. Your judgment, no
@@ -41,16 +49,27 @@ prompt: |
   - **Genuinely unsure** (request was ambiguous, drafts touch sensitive
     files like `.ssh/`, secrets, or anything outside the spirit of the
     request) → `approve_delegation({id, escalate: true})`. The human
-    will see the preview and decide. Use this sparingly; if you find
-    yourself escalating routinely, the prompt to the child is too vague.
+    will see the preview and decide. Use this sparingly.
+
+  Parallel dispatch shortcut: if you trust the task is unambiguous, you
+  can skip the preview-first step and call
+  `approve_delegation({id, approved: true})` directly. It blocks until
+  the child settles, applies the drafts, and returns the preview as an
+  audit trail in the result.
+
+  Example (two independent files in parallel):
+    delegate(recipe: "deferred-writer", task: "draft hello.txt with Hi") → id_A
+    delegate(recipe: "deferred-writer", task: "draft world.txt with World") → id_B
+    # Both children running simultaneously now
+    approve_delegation({id: id_A, approved: true})   # blocks, applies, audit
+    approve_delegation({id: id_B, approved: true})   # B may already be done
 
   Approval is irreversible once `approved: true`: files are written
   immediately and there's no undo. Be deliberate.
 
-  Do not call `approve_delegation` without first reading the preview.
-  Do not skip `approve_delegation` and start a new `delegate` — the
-  paused child will time out and its drafts will be discarded. Always
-  decide on each delegation before moving on.
+  Do not skip `approve_delegation` for any delegation you've started —
+  the paused child will time out and its drafts will be discarded if
+  you never call it. Always collect every delegation before ending your turn.
 
   Other rules:
   - You do NOT have `write`, `edit`, `bash`, or any deferred-* tool

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -102,6 +102,50 @@ function loadRecipe(name) {
   return recipe;
 }
 
+// Implicit-wire the agent-spawn extension and its tools when a recipe
+// declares `agents: [...]`. Mirrors the conditional `usesBus` push for
+// --agent-bus-root: only push --allowed-agents when agent-spawn actually
+// runs, otherwise pi rejects the flag as unknown.
+//
+// Inverse rejection: if a recipe loads agent-spawn or its tools without
+// declaring `agents:`, that's a misconfiguration — fail loudly so the
+// allowlist is never accidentally empty.
+function applyAgentsField(recipe, name) {
+  const declared = Array.isArray(recipe.agents) ? recipe.agents.filter((a) => typeof a === "string") : [];
+  const explicitExts = Array.isArray(recipe.extensions) ? recipe.extensions.slice() : [];
+  const explicitTools = Array.isArray(recipe.tools) ? recipe.tools.slice() : [];
+  const SPAWN_TOOLS = ["delegate", "approve_delegation"];
+
+  if (declared.length === 0) {
+    if (explicitExts.includes("agent-spawn")) {
+      die(
+        `recipe ${name} loads extension 'agent-spawn' but has no 'agents:' list — ` +
+          `declare which child recipes are allowed (or drop the extension)`,
+      );
+    }
+    for (const t of SPAWN_TOOLS) {
+      if (explicitTools.includes(t)) {
+        die(
+          `recipe ${name} declares tool '${t}' but has no 'agents:' list — ` +
+            `declare which child recipes are allowed (or drop the tool)`,
+        );
+      }
+    }
+    return { allowed: [], extensions: explicitExts, tools: explicitTools };
+  }
+
+  for (const a of declared) {
+    if (!existsSync(path.join(AGENTS_DIR, `${a}.yaml`))) {
+      die(`recipe ${name} agents: lists '${a}', but pi-sandbox/agents/${a}.yaml does not exist`);
+    }
+  }
+
+  const extensions = explicitExts.includes("agent-spawn") ? explicitExts : [...explicitExts, "agent-spawn"];
+  const tools = explicitTools.slice();
+  for (const t of SPAWN_TOOLS) if (!tools.includes(t)) tools.push(t);
+  return { allowed: declared, extensions, tools };
+}
+
 function resolveModel(tierOrId) {
   const requested = tierOrId || "TASK_RABBIT_MODEL";
   if (TIER_VARS.has(requested)) {
@@ -148,7 +192,8 @@ if (!existsSync(sandboxRoot)) die(`sandbox dir does not exist: ${sandboxRoot}`);
 
 const recipeModel = recipe.model || "TASK_RABBIT_MODEL";
 const model = resolveModel(recipeModel);
-const extensionPaths = resolveExtensionPaths(Array.isArray(recipe.extensions) ? recipe.extensions : []);
+const wired = applyAgentsField(recipe, args.name);
+const extensionPaths = resolveExtensionPaths(wired.extensions);
 const skillPaths = resolveSkillPaths(Array.isArray(recipe.skills) ? recipe.skills : []);
 
 const piArgs = [
@@ -160,7 +205,7 @@ const piArgs = [
   "--model",
   model,
   "--tools",
-  recipe.tools.join(","),
+  wired.tools.join(","),
   "--system-prompt",
   recipe.prompt,
 ];
@@ -187,11 +232,11 @@ const busRoot =
   args.agentBus ||
   process.env.PI_AGENT_BUS_ROOT ||
   path.join(os.homedir(), ".pi-agent-bus", path.basename(sandboxRoot));
-// Only push --agent-bus-root when agent-bus is loaded; otherwise pi
-// rejects the flag as unknown.
-const recipeExtensions = Array.isArray(recipe.extensions) ? recipe.extensions : [];
-const usesBus = recipeExtensions.includes("agent-bus");
+// Only push extension-owned flags when their owning extension is
+// actually loaded; otherwise pi rejects the flag as unknown.
+const usesBus = wired.extensions.includes("agent-bus");
 if (usesBus) piArgs.push("--agent-bus-root", busRoot);
+if (wired.allowed.length > 0) piArgs.push("--allowed-agents", wired.allowed.join(","));
 if (typeof recipe.description === "string" && recipe.description.trim()) {
   piArgs.push("--agent-description", recipe.description.trim());
 }


### PR DESCRIPTION
## Summary

Transforms `agent-spawn` from a blocking delegation model to a non-blocking model with parent-driven approval. Children can now pause with file drafts queued and wait for the parent LLM (or human via escalation) to review and approve before applying changes. This enables parallel child execution and more deliberate approval workflows.

## Key Changes

### agent-spawn extension (`pi-sandbox/.pi/extensions/agent-spawn.ts`)
- **Two-tool model**: Split blocking `delegate` into non-blocking `delegate` + `approve_delegation`
  - `delegate({recipe, task, sandbox?, timeout_ms?})` spawns a child and returns immediately with a `delegation_id`
  - `approve_delegation({id, approved?, escalate?, comment?})` is the join point that blocks until the child settles
- **RPC socket protocol**: Children communicate approval requests back to parent via Unix socket (newline-delimited JSON)
  - Child sends `{type: "request-approval", title, summary, preview}` when paused with drafts
  - Parent sends `{type: "approval-result", approved: boolean}` with decision
- **Pending delegation registry**: Tracks in-flight delegations in `globalThis.__pi_delegate_pending__` (survives jiti's module isolation)
- **Pre-flight validation**: 
  - Recipe allowlist check against `--allowed-agents` flag
  - Sandbox containment check (child sandbox must be inside parent's)
- **Watchdog timeout**: Automatically denies pending requests if `approve_delegation` is never called within the timeout window
- **Parallel execution**: Parent can call `delegate` multiple times before collecting results; all children run simultaneously

### deferred-confirm extension (`pi-sandbox/.pi/extensions/deferred-confirm.ts`)
- **New `requestHumanApproval` primitive**: Recursive approval routing that picks the right channel
  - If `ctx.hasUI`: render locally via `ctx.ui.confirm`
  - Else if `--rpc-sock` set: forward to parent agent's RPC server (recurses up chain)
  - Else: fail loudly to stderr and return false
- **RPC server implementation**: `rpcRequestApproval` connects to parent socket, sends request, awaits reply
- **Notification routing**: `tell()` helper routes info/error messages through UI or stdout (for parent capture)
- **Non-interactive approval**: Removed the blanket refusal to apply without UI; now routes through RPC chain instead

### Runner integration (`scripts/run-agent.mjs`)
- **Implicit wiring**: `applyAgentsField()` auto-loads `agent-spawn` extension and adds `delegate`/`approve_delegation` tools when recipe declares `agents: [...]`
- **Allowlist flag**: Passes `--allowed-agents <a,b,c>` to child processes
- **Validation**: Rejects recipes that load `agent-spawn` or its tools without declaring `agents:` (prevents accidental empty allowlist)

### Documentation (`docs/agents.md`)
- Comprehensive explanation of approval routing and RPC protocol
- Worked example: `writer-foreman` recipe that decomposes requests and approves children
- Multi-agent comparison: `agent-spawn` (non-blocking delegation) vs `agent-bus` (peer messaging)
- Debugging and error handling guidance

### New recipe (`pi-sandbox/agents/writer-foreman.yaml`)
- Demonstrates the foreman pattern: decompose request → delegate batches → review previews → approve/reject
- Shows parallel dispatch and escalation to human for ambiguous cases

### Updated recipe (`pi-sandbox/agents/delegator.yaml`)
- Refreshed to reflect non-blocking model and approval workflow
- Clarifies that children may queue drafts requiring approval

## Notable Implementation Details

- **Timeout scope**: Measured from `delegate` call, includes time spent waiting in `approve_delegation`
- **Output capture**: Continuously drains stdout/stderr even while child is paused, truncated to 20KB
- **Cleanup**: Process-exit handler denies all pending requests and kills children; per-child cleanup after exit
- **Audit trail**: Preview included in final result for approval decisions
- **Escalation chain**:

https://claude.ai/code/session_01HPXqTm7ifbp968CnyREvib