### PR TITLE
Add live delegation status boxes above input editor

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -121,7 +121,11 @@ All seven appear under "Extension CLI Flags" in `pi --help`.
 
 When `agents:` is non-empty the runner also implicitly:
 
-- adds `agent-spawn` to `extensions:`, and
+- adds `agent-spawn` to `extensions:`,
+- adds `delegation-boxes` to `extensions:` (renders one status box
+  per pending delegation above the input editor — name, 3-cell
+  context bar, cost, turn, state — laid out 2 or 3 boxes per row
+  depending on terminal width), and
 - adds `delegate` and `approve_delegation` to `tools:`.
 
 Explicit duplicates in the recipe are fine. The inverse is rejected
@@ -129,6 +133,46 @@ loudly: declaring `extensions: [agent-spawn]` or
 `tools: [delegate | approve_delegation]` without `agents:` causes the
 runner to `die()` so the allowlist is never accidentally empty. To
 disable delegation, drop the `agents:` field entirely.
+
+The boxes are populated by the **`agent-status-reporter`** baseline
+extension running inside each delegated child. It self-gates on
+`--rpc-sock` (a no-op for top-level runs) and pushes newline-delimited
+JSON envelopes over the existing per-call socket whenever it crosses a
+turn / tool / provider-response boundary, throttled to one write per
+250 ms. Envelopes:
+
+```jsonc
+// Once per child connection. Tags the conn so subsequent status
+// envelopes can omit `delegation_id`.
+{"type": "hello", "id": "<delegation_id>"}
+
+// Many per child. Cached on the parent's PendingDelegation entry
+// and rendered by delegation-boxes.
+{
+  "type": "status",
+  "delegation_id": "<optional once tagged>",
+  "agent_name": "<from --agent-name>",
+  "model_id": "<ctx.model.id>",
+  "context_pct": 12.4,
+  "context_tokens": 2480,
+  "context_window": 200000,
+  "cost_usd": 0.0123,
+  "turn_count": 3,
+  "state": "running" | "paused" | "settled"
+}
+```
+
+The parent's `agent-spawn` server consumes both envelope types on the
+same socket as the existing `request-approval` flow; a long-lived
+status conn and short-lived approval conn(s) coexist without
+coordination. Status updates are best-effort: connect failures and
+mid-session disconnects retry once at 500 ms then give up silently.
+The parent stamps `state: "paused"` when the child sends
+`request-approval` and `state: "settled"` once the child exits, so the
+final box transitions are visible even if the reporter dropped its
+connection. The 3-cell context bar uses the same eighths-block format
+as the footer (`renderBar(pct, 3)` from
+`pi-sandbox/.pi/extensions/_lib/context-bar.ts`).
 
 ## Where agent code lives
 

--- a/pi-sandbox/.pi/extensions/_lib/context-bar.ts
+++ b/pi-sandbox/.pi/extensions/_lib/context-bar.ts
@@ -1,0 +1,17 @@
+// Eighths-block horizontal context-usage bar shared by agent-footer and
+// delegation-boxes so the two never drift. Each cell covers 8 eighths,
+// so a 5-cell bar has 40 buckets (~2.5%/bucket); a 3-cell bar has 24
+// buckets (~4%/bucket).
+
+export const BAR_BLOCKS = ["░", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"];
+
+export function renderBar(percent: number, width: number): string {
+  const max = width * 8;
+  const totalEighths = Math.max(0, Math.min(max, Math.round((percent / 100) * max)));
+  let out = "";
+  for (let i = 0; i < width; i++) {
+    const cellEighths = Math.max(0, Math.min(8, totalEighths - i * 8));
+    out += BAR_BLOCKS[cellEighths];
+  }
+  return out;
+}

--- a/pi-sandbox/.pi/extensions/agent-footer.ts
+++ b/pi-sandbox/.pi/extensions/agent-footer.ts
@@ -23,21 +23,7 @@ import path from "node:path";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-
-// Eighths-block horizontal bar. 5 cells × 8 eighths = 40 buckets, so each
-// bucket covers ~2.5% of context. Empty cells render `░` so the track is
-// visible even at 0%; partial cells use the standard left-fill set.
-const BAR_BLOCKS = ["░", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"];
-function renderBar(percent: number, width: number): string {
-  const max = width * 8;
-  const totalEighths = Math.max(0, Math.min(max, Math.round((percent / 100) * max)));
-  let out = "";
-  for (let i = 0; i < width; i++) {
-    const cellEighths = Math.max(0, Math.min(8, totalEighths - i * 8));
-    out += BAR_BLOCKS[cellEighths];
-  }
-  return out;
-}
+import { renderBar } from "./_lib/context-bar";
 
 function homeReplace(p: string): string {
   const home = os.homedir();

--- a/pi-sandbox/.pi/extensions/agent-spawn.ts
+++ b/pi-sandbox/.pi/extensions/agent-spawn.ts
@@ -34,6 +34,21 @@
 // A recipe that wants both delegation and peer messaging loads both
 // extensions independently — though typically `agents:` in the recipe
 // implicitly wires agent-spawn for you.
+//
+// RPC protocol (newline-delimited JSON, multi-message on a single conn):
+//   client → server : {type: "hello", id: <delegation_id>}
+//                     // Optional. Tags the conn so subsequent status
+//                     // envelopes can omit `delegation_id`.
+//   client → server : {type: "request-approval", title, summary, preview}
+//                     // End-of-turn approval forwarding (pre-existing).
+//   server → client : {type: "approval-result", approved: boolean}
+//   client → server : {type: "status", delegation_id?, agent_name,
+//                      model_id, context_pct, context_tokens,
+//                      context_window, cost_usd, turn_count, state}
+//                     // Pushed by the child's agent-status-reporter on
+//                     // turn / tool / response boundaries; cached on
+//                     // the entry's `lastStatus` for the
+//                     // delegation-boxes widget.
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
@@ -59,6 +74,21 @@ const DEFAULT_TIMEOUT_MS = 5 * 60_000;
 type SpawnOutcome =
   | { kind: "exit"; exit: { code: number | null; signal: NodeJS.Signals | null } }
   | { kind: "rpc"; conn: net.Socket; req: ApprovalRequest };
+
+/** Latest status snapshot pushed by the child's agent-status-reporter
+ *  over the RPC socket. Read by the delegation-boxes widget to render
+ *  per-delegation context-fill / cost / state above the input editor. */
+interface DelegationStatus {
+  receivedAt: number;
+  agentName: string;
+  modelId: string;
+  contextPct: number;
+  contextTokens: number;
+  contextWindow: number;
+  costUsd: number;
+  turnCount: number;
+  state: "running" | "paused" | "settled";
+}
 
 interface PendingDelegation {
   id: string;
@@ -89,6 +119,16 @@ interface PendingDelegation {
    * the settled promise inside a sync callback.
    */
   resolvedConn?: net.Socket;
+  /** Latest snapshot from the child's status reporter, if any. */
+  lastStatus?: DelegationStatus;
+}
+
+function notifyWidget(): void {
+  try {
+    (globalThis as { __pi_delegate_invalidate__?: () => void }).__pi_delegate_invalidate__?.();
+  } catch {
+    /* noop */
+  }
 }
 
 interface SpawnState {
@@ -283,26 +323,78 @@ export default function (pi: ExtensionAPI) {
         conn.setEncoding("utf8");
         conn.on("data", (chunk: string) => {
           buf += chunk;
-          const nl = buf.indexOf("\n");
-          if (nl === -1) return;
-          const line = buf.slice(0, nl);
-          buf = buf.slice(nl + 1);
-          try {
-            const msg = JSON.parse(line) as { type?: string; title?: string; summary?: string; preview?: string };
-            if (
-              msg.type === "request-approval" &&
-              typeof msg.title === "string" &&
-              typeof msg.summary === "string" &&
-              typeof msg.preview === "string"
-            ) {
-              resolveConnection({
-                conn,
-                req: { title: msg.title, summary: msg.summary, preview: msg.preview },
-              });
-              return;
+          // The status reporter holds a long-lived conn and may emit many
+          // newline-delimited envelopes; drain every complete line.
+          while (true) {
+            const nl = buf.indexOf("\n");
+            if (nl === -1) return;
+            const line = buf.slice(0, nl);
+            buf = buf.slice(nl + 1);
+            try {
+              const msg = JSON.parse(line) as {
+                type?: string;
+                title?: string;
+                summary?: string;
+                preview?: string;
+                id?: string;
+                delegation_id?: string;
+                agent_name?: string;
+                model_id?: string;
+                context_pct?: number;
+                context_tokens?: number;
+                context_window?: number;
+                cost_usd?: number;
+                turn_count?: number;
+                state?: string;
+              };
+              if (
+                msg.type === "request-approval" &&
+                typeof msg.title === "string" &&
+                typeof msg.summary === "string" &&
+                typeof msg.preview === "string"
+              ) {
+                resolveConnection({
+                  conn,
+                  req: { title: msg.title, summary: msg.summary, preview: msg.preview },
+                });
+                continue;
+              }
+              if (msg.type === "hello" && typeof msg.id === "string") {
+                // Tag the conn so we don't have to re-parse delegation_id on
+                // every status envelope. Status messages may omit it once
+                // the conn is tagged.
+                (conn as unknown as { __delegationId?: string }).__delegationId = msg.id;
+                continue;
+              }
+              if (msg.type === "status") {
+                const targetId =
+                  (typeof msg.delegation_id === "string" && msg.delegation_id) ||
+                  (conn as unknown as { __delegationId?: string }).__delegationId ||
+                  "";
+                if (!targetId) continue;
+                const targetEntry = state.pending.get(targetId);
+                if (!targetEntry) continue;
+                const newState =
+                  msg.state === "paused" || msg.state === "settled" || msg.state === "running"
+                    ? msg.state
+                    : "running";
+                targetEntry.lastStatus = {
+                  receivedAt: Date.now(),
+                  agentName: typeof msg.agent_name === "string" ? msg.agent_name : "",
+                  modelId: typeof msg.model_id === "string" ? msg.model_id : "",
+                  contextPct: typeof msg.context_pct === "number" ? msg.context_pct : 0,
+                  contextTokens: typeof msg.context_tokens === "number" ? msg.context_tokens : 0,
+                  contextWindow: typeof msg.context_window === "number" ? msg.context_window : 0,
+                  costUsd: typeof msg.cost_usd === "number" ? msg.cost_usd : 0,
+                  turnCount: typeof msg.turn_count === "number" ? msg.turn_count : 0,
+                  state: newState,
+                };
+                notifyWidget();
+                continue;
+              }
+            } catch {
+              /* malformed; ignore — child will time out */
             }
-          } catch {
-            /* malformed; ignore — child will time out */
           }
         });
         conn.on("error", () => conn.destroy());
@@ -330,7 +422,7 @@ export default function (pi: ExtensionAPI) {
 
       const child = spawn(process.execPath, args, {
         cwd: REPO_ROOT,
-        env: process.env,
+        env: { ...process.env, PI_AGENT_DELEGATION_ID: id },
         stdio: ["ignore", "pipe", "pipe"],
       });
 
@@ -365,6 +457,7 @@ export default function (pi: ExtensionAPI) {
         }
         killSafe(e.child);
         state.pending.delete(id);
+        notifyWidget();
       }, timeoutMs);
 
       const entry: PendingDelegation = {
@@ -382,12 +475,15 @@ export default function (pi: ExtensionAPI) {
         settled,
       };
       state.pending.set(id, entry);
+      notifyWidget();
 
       // Cache the conn synchronously once the child pauses so the cleanup
       // walker and watchdog can use it from synchronous callbacks.
       settled.then((outcome) => {
         if (outcome.kind === "rpc") {
           entry.resolvedConn = outcome.conn;
+          if (entry.lastStatus) entry.lastStatus.state = "paused";
+          notifyWidget();
         }
       });
 
@@ -395,6 +491,8 @@ export default function (pi: ExtensionAPI) {
       exited.then(() => {
         clearTimeout(watchdog);
         signal?.removeEventListener("abort", onAbort);
+        if (entry.lastStatus) entry.lastStatus.state = "settled";
+        notifyWidget();
         try {
           entry.resolvedConn?.destroy();
         } catch {
@@ -479,6 +577,7 @@ export default function (pi: ExtensionAPI) {
         // Child completed without queuing any drafts — no approval needed.
         clearTimeout(entry.timer);
         state.pending.delete(params.id);
+        notifyWidget();
         const text = finalText(entry, outcome.exit);
         return {
           content: [{ type: "text", text }],
@@ -552,6 +651,7 @@ export default function (pi: ExtensionAPI) {
       // Drain registry; final cleanup of socket/server happens in the exited
       // handler attached at delegate time.
       state.pending.delete(params.id);
+      notifyWidget();
 
       // Include the preview in the result so the parent LLM has an audit trail
       // even when it passed approved=true without a prior preview-only call.

--- a/pi-sandbox/.pi/extensions/agent-status-reporter.ts
+++ b/pi-sandbox/.pi/extensions/agent-status-reporter.ts
@@ -1,0 +1,187 @@
+// agent-status-reporter — child-side companion to agent-spawn's RPC server.
+//
+// When this agent runs as a delegated child (i.e. --rpc-sock is set), open
+// a long-lived connection to the parent's per-call RPC socket and push
+// session-stat snapshots whenever the agent's state changes meaningfully
+// (turn boundaries, tool boundaries, provider responses). The parent's
+// agent-spawn caches the latest snapshot per delegation and the
+// delegation-boxes widget renders it above the input.
+//
+// No-ops for top-level (non-delegated) runs — same gating idiom as
+// requestHumanApproval in deferred-confirm.
+//
+// Status updates run on the same socket pi already uses for end-of-turn
+// approval forwarding. The parent's net.createServer happily accepts
+// multiple concurrent connections; the long-lived status conn and the
+// short-lived approval conn(s) coexist without coordination.
+//
+// Failure semantics: best-effort. Connect failures, mid-session
+// disconnects, and EPIPE all settle silently after one 500 ms reconnect
+// attempt — status is non-fatal, the child must keep running even if
+// the parent stops listening.
+
+import net from "node:net";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+const THROTTLE_MS = 250;
+const RECONNECT_DELAY_MS = 500;
+
+type ReporterState = "running" | "paused" | "settled";
+
+interface ReporterRuntime {
+  sock: net.Socket | null;
+  reconnectAttempted: boolean;
+  pendingTimer: NodeJS.Timeout | null;
+  lastSendAt: number;
+  helloSent: boolean;
+  giveUp: boolean;
+  state: ReporterState;
+  delegationId: string;
+  agentName: string;
+}
+
+function computeCost(ctx: ExtensionContext): number {
+  let total = 0;
+  for (const entry of ctx.sessionManager.getEntries()) {
+    if (entry.type === "message" && entry.message.role === "assistant") {
+      total += (entry.message as AssistantMessage).usage.cost.total;
+    }
+  }
+  return total;
+}
+
+function countTurns(ctx: ExtensionContext): number {
+  let n = 0;
+  for (const entry of ctx.sessionManager.getEntries()) {
+    if (entry.type === "message" && entry.message.role === "assistant") n++;
+  }
+  return n;
+}
+
+function buildSnapshot(rt: ReporterRuntime, ctx: ExtensionContext, modelId: string) {
+  const usage = ctx.getContextUsage();
+  return {
+    type: "status" as const,
+    delegation_id: rt.delegationId,
+    agent_name: rt.agentName,
+    model_id: modelId,
+    context_pct: usage?.percent ?? 0,
+    context_tokens: usage?.tokens ?? 0,
+    context_window: usage?.contextWindow ?? 0,
+    cost_usd: computeCost(ctx),
+    turn_count: countTurns(ctx),
+    state: rt.state,
+  };
+}
+
+function writeLine(sock: net.Socket, obj: unknown): boolean {
+  try {
+    return sock.write(JSON.stringify(obj) + "\n");
+  } catch {
+    return false;
+  }
+}
+
+function send(rt: ReporterRuntime, ctx: ExtensionContext) {
+  if (rt.giveUp || !rt.sock || rt.sock.destroyed) return;
+  const now = Date.now();
+  const sinceLast = now - rt.lastSendAt;
+  if (sinceLast < THROTTLE_MS) {
+    if (rt.pendingTimer) return;
+    rt.pendingTimer = setTimeout(() => {
+      rt.pendingTimer = null;
+      send(rt, ctx);
+    }, THROTTLE_MS - sinceLast);
+    return;
+  }
+  rt.lastSendAt = now;
+  if (!rt.helloSent) {
+    writeLine(rt.sock, { type: "hello", id: rt.delegationId });
+    rt.helloSent = true;
+  }
+  writeLine(rt.sock, buildSnapshot(rt, ctx, ctx.model?.id ?? ""));
+}
+
+function attachSocket(rt: ReporterRuntime, sockPath: string, ctx: ExtensionContext): void {
+  const sock = net.connect(sockPath);
+  rt.sock = sock;
+  rt.helloSent = false;
+  sock.once("connect", () => send(rt, ctx));
+  sock.once("error", () => handleDisconnect(rt, sockPath, ctx));
+  sock.once("close", () => handleDisconnect(rt, sockPath, ctx));
+}
+
+function handleDisconnect(rt: ReporterRuntime, sockPath: string, ctx: ExtensionContext): void {
+  if (rt.giveUp) return;
+  try {
+    rt.sock?.destroy();
+  } catch {
+    /* noop */
+  }
+  rt.sock = null;
+  rt.helloSent = false;
+  if (rt.reconnectAttempted) {
+    rt.giveUp = true;
+    return;
+  }
+  rt.reconnectAttempted = true;
+  setTimeout(() => {
+    if (rt.giveUp) return;
+    attachSocket(rt, sockPath, ctx);
+  }, RECONNECT_DELAY_MS);
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    // pi.getFlag("rpc-sock") would only work for the extension that
+    // registered the flag (deferred-confirm). The runner mirrors the
+    // CLI value into PI_RPC_SOCK so cross-extension readers like this
+    // one can see it.
+    const sockPath = (process.env.PI_RPC_SOCK || "").trim();
+    if (!sockPath) return; // top-level run, no parent to talk to
+
+    const delegationId = (process.env.PI_AGENT_DELEGATION_ID || "").trim();
+    if (!delegationId) return; // spawned without a delegation id; can't be routed
+
+    const agentName =
+      ((pi.getFlag("agent-name") as string | undefined) || process.env.PI_AGENT_NAME || "agent").trim();
+
+    const rt: ReporterRuntime = {
+      sock: null,
+      reconnectAttempted: false,
+      pendingTimer: null,
+      lastSendAt: 0,
+      helloSent: false,
+      giveUp: false,
+      state: "running",
+      delegationId,
+      agentName,
+    };
+
+    attachSocket(rt, sockPath, ctx);
+
+    const tick = () => send(rt, ctx);
+    pi.on("turn_start", async () => {
+      rt.state = "running";
+      tick();
+    });
+    pi.on("turn_end", async () => {
+      tick();
+    });
+    pi.on("tool_execution_end", async () => {
+      tick();
+    });
+    pi.on("after_provider_response", async () => {
+      tick();
+    });
+    pi.on("agent_end", async () => {
+      // The deferred-confirm handler runs after this; if it forwards an
+      // approval request, the child is effectively paused awaiting the
+      // parent's decision. Reporting "paused" here lets the box's state
+      // line transition before the approval round-trip completes.
+      rt.state = "paused";
+      tick();
+    });
+  });
+}

--- a/pi-sandbox/.pi/extensions/delegation-boxes.ts
+++ b/pi-sandbox/.pi/extensions/delegation-boxes.ts
@@ -1,0 +1,208 @@
+// delegation-boxes — parent-side widget that renders a status box per
+// pending delegation, above the input editor. Composes with agent-spawn
+// (which owns the registry at globalThis.__pi_delegate_pending__) and
+// agent-status-reporter (which pushes child stats over the per-call RPC
+// socket). When no delegations are active the widget collapses to zero
+// height. Wraps to 2 boxes per row by default, 3 on terminals ≥ 120
+// columns wide.
+//
+// Re-render is triggered by agent-spawn calling
+// globalThis.__pi_delegate_invalidate__ whenever it caches a fresh
+// status snapshot or when an entry settles. The factory captures the
+// TUI instance and exposes its requestRender via that global.
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { Component } from "@mariozechner/pi-tui";
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { renderBar } from "./_lib/context-bar";
+
+const BAR_CELLS = 3;
+
+type DelegationState = "running" | "paused" | "settled";
+
+interface LastStatus {
+  receivedAt: number;
+  agentName: string;
+  modelId: string;
+  contextPct: number;
+  contextTokens: number;
+  contextWindow: number;
+  costUsd: number;
+  turnCount: number;
+  state: DelegationState;
+}
+
+interface PendingEntry {
+  id: string;
+  recipe: string;
+  startedAt: number;
+  lastStatus?: LastStatus;
+}
+
+interface SpawnRegistry {
+  pending: Map<string, PendingEntry>;
+}
+
+function getRegistry(): SpawnRegistry | undefined {
+  return (globalThis as { __pi_delegate_pending__?: SpawnRegistry }).__pi_delegate_pending__;
+}
+
+function pickCols(width: number, count: number): number {
+  if (count <= 0) return 1;
+  if (width >= 120 && count >= 3) return 3;
+  if (width >= 60 && count >= 2) return 2;
+  return 1;
+}
+
+interface Theme {
+  fg(level: "accent" | "dim" | "warning" | "error" | "info", text: string): string;
+  bold(text: string): string;
+}
+
+function colorBar(theme: Theme, bar: string, pct: number): string {
+  if (pct > 90) return theme.fg("error", bar);
+  if (pct > 70) return theme.fg("warning", bar);
+  return bar;
+}
+
+function colorState(theme: Theme, state: DelegationState): string {
+  if (state === "paused") return theme.fg("warning", "paused");
+  if (state === "settled") return theme.fg("dim", "settled");
+  return theme.fg("accent", "running");
+}
+
+// Rounded-border box, 4 lines tall. boxWidth is the visible width of
+// every line (including the corners). Returns exactly 4 strings.
+function renderBox(theme: Theme, entry: PendingEntry, boxWidth: number): string[] {
+  const inner = boxWidth - 2; // between the corners
+  const status = entry.lastStatus;
+  const name = entry.recipe;
+  const modelId = status?.modelId ?? "";
+  const pct = status?.contextPct ?? 0;
+  const cost = status?.costUsd ?? 0;
+  const turn = status?.turnCount ?? 0;
+  const state: DelegationState = status?.state ?? "running";
+
+  // --- Line 1: ╭ name ──── bar ╮ ---
+  // Budget inside the corners: " " + name + " " + dashes + " " + bar + " "
+  // dashWidth = inner - 4 (four spaces) - nameWidth - barWidth
+  let nameMax = inner - 4 - 1 - BAR_CELLS; // need at least 1 dash
+  if (nameMax < 3) nameMax = Math.max(0, inner - 4 - BAR_CELLS);
+  const nameTrunc = truncateToWidth(name, nameMax, "…");
+  const nameW = visibleWidth(nameTrunc);
+  let dashCount = inner - 4 - nameW - BAR_CELLS;
+  if (dashCount < 1) dashCount = 1;
+  const bar = renderBar(pct, BAR_CELLS);
+  const coloredBar = colorBar(theme, bar, pct);
+  const top =
+    theme.fg("dim", "╭") +
+    " " +
+    theme.bold(theme.fg("accent", nameTrunc)) +
+    " " +
+    theme.fg("dim", "─".repeat(dashCount)) +
+    " " +
+    coloredBar +
+    " " +
+    theme.fg("dim", "╮");
+
+  // --- Line 2: │ model id (padded) │ ---
+  const modelMax = inner - 2;
+  const modelTrunc = truncateToWidth(modelId, modelMax, "…");
+  const modelPad = " ".repeat(Math.max(0, modelMax - visibleWidth(modelTrunc)));
+  const line2 =
+    theme.fg("dim", "│") +
+    " " +
+    theme.fg("dim", modelTrunc) +
+    modelPad +
+    " " +
+    theme.fg("dim", "│");
+
+  // --- Line 3: │ $cost · turn N · state (padded) │ ---
+  const costStr = `$${cost.toFixed(4)}`;
+  const turnStr = `turn ${turn}`;
+  const stateColored = colorState(theme, state);
+  const stateRaw = state; // for width math
+  const sep = " · ";
+  // Visible width of the assembled content.
+  const contentW = visibleWidth(costStr) + visibleWidth(sep) + visibleWidth(turnStr) + visibleWidth(sep) + visibleWidth(stateRaw);
+  let assembled =
+    theme.bold(costStr) +
+    theme.fg("dim", sep) +
+    turnStr +
+    theme.fg("dim", sep) +
+    stateColored;
+  const stateMax = inner - 2;
+  if (contentW > stateMax) {
+    // Drop turn segment; if still too wide, drop cost precision.
+    const compactCost = `$${cost.toFixed(2)}`;
+    const compactW = visibleWidth(compactCost) + visibleWidth(sep) + visibleWidth(stateRaw);
+    if (compactW <= stateMax) {
+      assembled = theme.bold(compactCost) + theme.fg("dim", sep) + stateColored;
+    } else {
+      assembled = stateColored;
+    }
+  }
+  const finalW = visibleWidth(assembled.replace(/\x1b\[[0-9;]*m/g, ""));
+  const pad = " ".repeat(Math.max(0, stateMax - finalW));
+  const line3 = theme.fg("dim", "│") + " " + assembled + pad + " " + theme.fg("dim", "│");
+
+  // --- Line 4: bottom border ---
+  const bottom = theme.fg("dim", "╰" + "─".repeat(inner) + "╯");
+
+  return [top, line2, line3, bottom];
+}
+
+function joinBoxesRow(boxes: string[][], boxWidth: number, gap: string): string[] {
+  // Each box has 4 lines; zip them.
+  const rows: string[] = [];
+  for (let line = 0; line < 4; line++) {
+    const parts: string[] = [];
+    for (let i = 0; i < boxes.length; i++) {
+      const b = boxes[i]!;
+      const cell = b[line] ?? " ".repeat(boxWidth);
+      parts.push(cell);
+    }
+    rows.push(parts.join(gap));
+  }
+  return rows;
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    let cachedTui: Component | undefined;
+
+    const factory = (tui: Component) => {
+      cachedTui = tui;
+      (globalThis as { __pi_delegate_invalidate__?: () => void }).__pi_delegate_invalidate__ = () => {
+        try {
+          (cachedTui as { requestRender?: () => void } | undefined)?.requestRender?.();
+        } catch {
+          /* noop */
+        }
+      };
+      return {
+        invalidate() {},
+        render(width: number): string[] {
+          const reg = getRegistry();
+          if (!reg || reg.pending.size === 0) return [];
+          const entries = Array.from(reg.pending.values());
+          const cols = pickCols(width, entries.length);
+          const gap = "  ";
+          const totalGap = gap.length * (cols - 1);
+          const boxWidth = Math.max(20, Math.floor((width - totalGap) / cols));
+          const theme = (ctx.ui as { theme: Theme }).theme;
+
+          const lines: string[] = [];
+          for (let i = 0; i < entries.length; i += cols) {
+            const slice = entries.slice(i, i + cols);
+            const boxes = slice.map((e) => renderBox(theme, e, boxWidth));
+            lines.push(...joinBoxesRow(boxes, boxWidth, gap));
+          }
+          return lines;
+        },
+      };
+    };
+
+    ctx.ui.setWidget("delegation-boxes", factory, { placement: "aboveEditor" });
+  });
+}

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -20,6 +20,10 @@ const BASELINE_EXTENSIONS = [
   "agent-footer",
   "hide-extensions-list",
   "deferred-confirm",
+  // Reports {context %, cost, state} over --rpc-sock when run as a
+  // delegated child. Self-gates on the flag, so it no-ops for
+  // top-level runs.
+  "agent-status-reporter",
 ];
 const TIER_VARS = new Set(["RABBIT_SAGE_MODEL", "LEAD_HARE_MODEL", "TASK_RABBIT_MODEL"]);
 
@@ -140,7 +144,12 @@ function applyAgentsField(recipe, name) {
     }
   }
 
-  const extensions = explicitExts.includes("agent-spawn") ? explicitExts : [...explicitExts, "agent-spawn"];
+  let extensions = explicitExts.includes("agent-spawn") ? explicitExts : [...explicitExts, "agent-spawn"];
+  // Pair the spawn extension with the per-delegation widget so the parent's
+  // TUI shows live status boxes above the input. delegation-boxes reads
+  // agent-spawn's globalThis registry; loading one without the other would
+  // leave the boxes wired but empty (or the registry rendered nowhere).
+  if (!extensions.includes("delegation-boxes")) extensions = [...extensions, "delegation-boxes"];
   const tools = explicitTools.slice();
   for (const t of SPAWN_TOOLS) if (!tools.includes(t)) tools.push(t);
   return { allowed: declared, extensions, tools };
@@ -213,14 +222,22 @@ for (const p of extensionPaths) piArgs.push("-e", p);
 for (const p of skillPaths) piArgs.push("--skill", p);
 piArgs.push("--sandbox-root", sandboxRoot);
 
-// Pull --agent-name out of passthrough so we can apply the override to
-// both the CLI flag (read by agent-header) and the env var (read by
-// agent-bus, since pi.getFlag is scoped per-extension).
+// Pull --agent-name and --rpc-sock out of passthrough so we can mirror
+// them to env vars. pi.getFlag is scoped to the extension that
+// registered the flag, so cross-extension reads need to bounce through
+// the env (already the case for --agent-name read by agent-bus, and
+// now --rpc-sock read by agent-status-reporter while deferred-confirm
+// owns the flag registration).
 let agentName = args.name;
+let rpcSock = "";
 const passthrough = [];
 for (let i = 0; i < args.passthrough.length; i++) {
   if (args.passthrough[i] === "--agent-name" && i + 1 < args.passthrough.length) {
     agentName = args.passthrough[++i];
+  } else if (args.passthrough[i] === "--rpc-sock" && i + 1 < args.passthrough.length) {
+    rpcSock = args.passthrough[++i];
+    // Keep --rpc-sock in passthrough too so deferred-confirm still sees it.
+    passthrough.push("--rpc-sock", rpcSock);
   } else {
     passthrough.push(args.passthrough[i]);
   }
@@ -256,10 +273,15 @@ if (!existsSync(PI_BIN)) die(`pi binary missing: ${PI_BIN} (run npm install)`);
 const child = spawn(PI_BIN, piArgs, {
   cwd: sandboxRoot,
   stdio: "inherit",
-  // Mirror the agent name + bus root into env vars so extensions that
-  // can't read the CLI flags via pi.getFlag (which is scoped per
-  // extension) still see them.
-  env: { ...process.env, PI_AGENT_NAME: agentName, PI_AGENT_BUS_ROOT: busRoot },
+  // Mirror the agent name + bus root + rpc sock into env vars so
+  // extensions that can't read the CLI flags via pi.getFlag (which is
+  // scoped per extension) still see them.
+  env: {
+    ...process.env,
+    PI_AGENT_NAME: agentName,
+    PI_AGENT_BUS_ROOT: busRoot,
+    ...(rpcSock ? { PI_RPC_SOCK: rpcSock } : {}),
+  },
 });
 
 child.on("exit", (code, signal) => {


### PR DESCRIPTION
## Summary

Adds real-time status monitoring for delegated agent runs. When agents are spawned as children, their execution metrics (context usage, cost, turn count, state) are now displayed in live-updating boxes above the input editor in the parent's TUI.

## Key Changes

- **New `delegation-boxes` extension**: Renders a 4-line bordered status box per pending delegation, displaying recipe name, model ID, cost, turn count, and execution state. Boxes wrap to 2 or 3 per row depending on terminal width (≥120 columns = 3 cols, ≥60 = 2 cols).

- **New `agent-status-reporter` extension**: Child-side companion that pushes status snapshots over the existing per-call RPC socket whenever the agent crosses turn/tool/provider-response boundaries. Throttled to one write per 250 ms. Self-gates on `--rpc-sock` so it no-ops for top-level runs.

- **Enhanced `agent-spawn` RPC protocol**: Extended the newline-delimited JSON protocol to handle:
  - `hello` messages to tag connections with delegation IDs
  - `status` messages carrying context %, tokens, cost, turn count, and state ("running"/"paused"/"settled")
  - Caches latest status on each `PendingDelegation` entry for the widget to render

- **Extracted shared `context-bar` utility**: Moved the eighths-block bar rendering logic from `agent-footer` to `_lib/context-bar.ts` so both footer and delegation boxes use identical formatting.

- **Updated baseline extensions**: Added `agent-status-reporter` to `BASELINE_EXTENSIONS` in `run-agent.mjs` and auto-wired `delegation-boxes` whenever `agents:` field triggers `agent-spawn`.

- **Environment variable mirroring**: Extended `run-agent.mjs` to mirror `--rpc-sock` to `PI_RPC_SOCK` env var so `agent-status-reporter` can read it cross-extension (similar to existing `PI_AGENT_NAME` pattern).

## Implementation Details

- Status updates are best-effort: connection failures and mid-session disconnects retry once at 500 ms then give up silently, ensuring child execution is never blocked.
- Parent stamps `state: "paused"` when child sends approval request and `state: "settled"` on exit, so final transitions are visible even if reporter connection drops.
- The 3-cell context bar in delegation boxes uses the same `renderBar(pct, 3)` function as the 5-cell footer bar, ensuring consistent visual representation.
- Long-lived status connection and short-lived approval connection(s) coexist on the same socket without coordination.
- Widget invalidation is triggered via `globalThis.__pi_delegate_invalidate__` callback, allowing the child's reporter to request parent TUI re-renders.

https://claude.ai/code/session_01KBikgWKtHCaFyVfHaBE1W9