### PR TITLE
Extract tool documentation into extension prompt fragments

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -97,7 +97,7 @@ npm run agent -- deferred-writer -p "draft a README" --thinking off   # passthro
 # pi-sandbox/agents/<name>.yaml
 model: TASK_RABBIT_MODEL          # tier name from models.env, or a literal model ID
 description: Drafts files...      # optional; shown by agent-header in the TUI
-prompt: |                         # replaces pi's default system prompt
+prompt: |                         # the agent's role, prepended with extension fragments
   You are a careful drafter...
 tools: [read, ls, grep, deferred_write]
 extensions: [deferred-write]      # merged with the [sandbox, no-startup-help, agent-header, agent-footer, hide-extensions-list, deferred-confirm] baseline
@@ -107,6 +107,32 @@ noEditAdd: [my_writer]            # optional; force-include in no-edit rail
 noEditSkip: [deferred_write]      # optional; exempt from no-edit rail
 agents: [deferred-writer]         # optional; recipes this agent may delegate to
 ```
+
+### `prompt:` and extension fragments
+
+Tool-usage rules live next to the extensions that register the tools, not
+in each recipe's `prompt:`. For each loaded extension `<name>`, the runner
+looks for a sibling `pi-sandbox/.pi/extensions/<name>.prompt.md` and, if
+present, prepends it to the system prompt that pi receives. Recipes only
+need to describe the agent's role; the standard rules for `deferred_write`,
+`deferred_edit`, `delegate`, etc. come from the fragments.
+
+Two conditional fragments are gated by the runner so they don't appear
+when irrelevant:
+
+- `deferred-confirm.prompt.md` (apply order, atomic batch semantics) is
+  loaded only when at least one `deferred-*` tool extension is active —
+  baseline `deferred-confirm` itself is a no-op without one.
+- `agent-spawn.approval.prompt.md` (the draft-approval workflow) is loaded
+  only when at least one recipe in `agents:` declares a `deferred-*`
+  extension. A delegator whose children never queue drafts gets the basic
+  `delegate` / `approve_delegation` mechanics from `agent-spawn.prompt.md`
+  but no approval-flow guidance.
+
+Final order seen by the model: baseline-extension fragments → recipe-
+extension fragments → `agent-spawn` fragments (when implicit) → recipe
+`prompt:`. Edit a fragment to change behaviour for every recipe that
+loads its extension; edit a recipe's `prompt:` for that one agent only.
 
 The runner always passes `--no-extensions --no-skills --no-context-files`
 to pi, so only what the recipe declares is loaded. Tool names go through

--- a/pi-sandbox/.pi/extensions/agent-bus.prompt.md
+++ b/pi-sandbox/.pi/extensions/agent-bus.prompt.md
@@ -1,0 +1,17 @@
+You're a peer on a multi-agent message bus. Other agents launched with
+the same bus root can find you by name and exchange async messages with
+you.
+
+- `agent_list()` — list live peers on the bus (probes each socket).
+- `agent_send({to, body, in_reply_to?})` — async send. Returns once the
+  byte hits the wire. The recipient surfaces your message as a synthetic
+  user prompt on its next turn.
+- `agent_inbox({since_ts?, peek?})` — pull buffered messages. Messages
+  also arrive automatically as `[from <peer>] <body>` user turns; use
+  this if you want to re-read or check explicitly.
+
+When you receive a message that asks for a reply, send one with
+`agent_send` and `in_reply_to` set to the incoming `msg_id`.
+
+`peer offline` and `timeout` from `agent_send` are normal failure modes,
+not errors to retry — there's no offline queue.

--- a/pi-sandbox/.pi/extensions/agent-spawn.approval.prompt.md
+++ b/pi-sandbox/.pi/extensions/agent-spawn.approval.prompt.md
@@ -1,0 +1,22 @@
+Some of your allowed child recipes queue file changes that need approval
+before they land on disk. When such a child pauses, `approve_delegation`
+behaves in two phases:
+
+1. Call `approve_delegation({id})` with no decision → returns a preview
+   of what the child queued.
+2. Read the preview, then call `approve_delegation({id, ...})` with one of:
+   - `{approved: true}` — drafts match the task; files land on disk
+     immediately. Your judgment, no human asked. **Irreversible.**
+   - `{approved: false}` — drafts are wrong (wrong file, wrong content,
+     missing line, etc.). Explain why in your reply. Re-delegate with a
+     clearer task if appropriate.
+   - `{escalate: true}` — genuinely unsure (request was ambiguous, drafts
+     touch sensitive files like `.ssh/`, secrets, or anything outside
+     the spirit of the request). The human (or parent agent up the
+     chain) sees the preview and decides. Use sparingly — routine
+     escalation is a sign the handed-off task was too vague.
+
+Shortcut: if you trust the task is unambiguous, call
+`approve_delegation({id, approved: true})` directly without the
+preview-first step. It blocks until the child settles, applies the
+drafts, and returns the preview as audit trail.

--- a/pi-sandbox/.pi/extensions/agent-spawn.prompt.md
+++ b/pi-sandbox/.pi/extensions/agent-spawn.prompt.md
@@ -1,0 +1,17 @@
+You can dispatch focused subtasks to child agents:
+
+- `delegate({recipe, task, sandbox?, timeout_ms?})` — spawns a child agent
+  from a recipe in `pi-sandbox/agents/` and returns a `delegation_id`
+  immediately. The child runs in the background. `recipe` must be one of
+  the allowed recipes for this agent. The child's sandbox defaults to
+  yours; pass `sandbox` to scope it to a subdirectory.
+- `approve_delegation({id, ...})` — the join point. Blocks until the
+  child settles and returns its captured stdout.
+
+`delegate` is non-blocking, so to run children in parallel you call
+`delegate` for all of them before calling `approve_delegation` for any.
+
+You MUST call `approve_delegation` for every delegation you started.
+Skipping it leaves the child paused until it times out, and any work it
+queued is dropped. Always collect every delegation before ending your
+turn.

--- a/pi-sandbox/.pi/extensions/deferred-confirm.prompt.md
+++ b/pi-sandbox/.pi/extensions/deferred-confirm.prompt.md
@@ -1,0 +1,19 @@
+Changes you stage with any `deferred_*` tool are buffered in memory and
+reviewed at end of turn as one atomic batch — the user (or your parent
+agent) approves all of it or none of it. There is no per-tool or per-file
+approval. Plan accordingly.
+
+Apply order at end of turn is fixed: writes → edits → moves → deletes.
+This means:
+- "Edit foo.ts then move it to lib/foo.ts" works in one turn — the edit
+  lands on foo.ts, then the rename moves the now-edited file.
+- "Move foo.ts to bar.ts then edit bar.ts" does NOT work in one turn:
+  the edit's re-validation reads bar.ts before the move runs and fails
+  because bar.ts doesn't exist yet. Split it across turns.
+- Anything that needs `dst` to be free at apply time but exists at queue
+  time (e.g. "replace bar.ts with foo.ts") also has to split:
+  `deferred_move` rejects at queue time if `dst` is already on disk,
+  even when a `deferred_delete` for that same `dst` is also queued.
+
+Do not narrate the upcoming approval dialog in your reply; the
+coordinator renders it. Just summarise what you queued.

--- a/pi-sandbox/.pi/extensions/deferred-delete.prompt.md
+++ b/pi-sandbox/.pi/extensions/deferred-delete.prompt.md
@@ -1,0 +1,4 @@
+`deferred_delete({path})` stages a file deletion.
+
+- Files only — rejects directories and missing paths at queue time, so
+  you get immediate feedback if you target the wrong thing.

--- a/pi-sandbox/.pi/extensions/deferred-edit.prompt.md
+++ b/pi-sandbox/.pi/extensions/deferred-edit.prompt.md
@@ -1,0 +1,12 @@
+`deferred_edit({path, old_string, new_string})` stages an edit to an
+existing file.
+
+- `path` is relative to the sandbox root (no `..`, no absolute paths).
+- `old_string` must occur EXACTLY ONCE in the file's current buffered
+  state. Add surrounding context until it matches uniquely.
+- Multiple edits to the same file stack in queue order: each later edit
+  sees the buffered state after earlier edits to that file have applied.
+- Edit-only: cannot create new files. If a task needs a new file you
+  must say so and stop.
+- Read every file you intend to edit before queueing changes against it,
+  so the planned change is grounded in the real text.

--- a/pi-sandbox/.pi/extensions/deferred-move.prompt.md
+++ b/pi-sandbox/.pi/extensions/deferred-move.prompt.md
@@ -1,0 +1,6 @@
+`deferred_move({src, dst})` stages a verbatim file relocation.
+
+- Bit-identical content moved from `src` to `dst`.
+- Refuses to overwrite — `dst` must not exist on disk at queue time.
+- Parent directories of `dst` are auto-created at apply time. Do NOT
+  queue a placeholder `deferred_write` to "force" a directory to exist.

--- a/pi-sandbox/.pi/extensions/deferred-write.prompt.md
+++ b/pi-sandbox/.pi/extensions/deferred-write.prompt.md
@@ -1,0 +1,10 @@
+`deferred_write({path, content})` stages a new file for creation.
+
+- `path` is relative to the sandbox root (no `..`, no absolute paths).
+- `content` must be the COMPLETE finished file — every line, verbatim. Do
+  not abbreviate. Do not use placeholders like `...`, `// rest unchanged`,
+  `<existing imports>`, or `TODO: fill in`. The string you pass IS the
+  file. If the finished file has 200 lines, your `content` must contain
+  all 200 lines.
+- One `deferred_write` call per file you want to create.
+- Per-batch limits: ≤ 50 files, ≤ 2 MB each.

--- a/pi-sandbox/.pi/extensions/no-edit.prompt.md
+++ b/pi-sandbox/.pi/extensions/no-edit.prompt.md
@@ -1,0 +1,3 @@
+You can only create new files; you cannot modify existing ones. Any
+write-shaped tool call whose target path already exists is rejected at
+queue time. The `edit` tool itself is unavailable.

--- a/pi-sandbox/.pi/extensions/sandbox.prompt.md
+++ b/pi-sandbox/.pi/extensions/sandbox.prompt.md
@@ -1,0 +1,5 @@
+You operate inside a sandboxed working directory. All filesystem activity
+must stay inside the sandbox root. Paths must be relative (no `..`) or
+absolute paths that resolve inside the root — paths outside the root are
+rejected at tool-call time. The `bash` tool is not available; do not try
+to call it.

--- a/pi-sandbox/agents/change-reviewer.yaml
+++ b/pi-sandbox/agents/change-reviewer.yaml
@@ -1,8 +1,7 @@
 # Change-reviewer agent — reviews proposed edits and writes pasted into the
 # prompt, instead of being pointed at files to review.
-# Read-only via the tools allowlist (no write/edit/bash). All filesystem
-# activity is sandboxed to the directory you launched `npm run agent` from
-# (or --sandbox <dir>).
+# Read-only via the tools allowlist. All filesystem activity is sandboxed
+# to the directory you launched `npm run agent` from (or --sandbox <dir>).
 
 model: LEAD_HARE_MODEL
 
@@ -53,14 +52,12 @@ prompt: |
   - info    — style, readability, suggestions
 
   Rules:
-  - Use `read`, `ls`, `grep`, and `find` to inspect the existing code. Paths
-    must stay inside the sandbox root.
+  - Use `read`, `ls`, `grep`, and `find` to inspect the existing code.
   - Keep findings concrete. Quote the offending snippet only when it
     clarifies the comment.
   - If you have nothing to flag, say so in plain text and emit no
     "## Review" section. Do not invent issues to fill space.
-  - You do not have `write`, `edit`, or `bash`. Do not try to use them. You
-    are not applying the proposal — you are reviewing it.
+  - You are not applying the proposal — you are reviewing it.
 
 tools:
   - read

--- a/pi-sandbox/agents/code-reviewer.yaml
+++ b/pi-sandbox/agents/code-reviewer.yaml
@@ -1,7 +1,6 @@
 # Code-reviewer agent — reads code and emits a structured review.
-# Read-only via the tools allowlist (no write/edit/bash). All filesystem
-# activity is sandboxed to the directory you launched `npm run agent` from
-# (or --sandbox <dir>).
+# Read-only via the tools allowlist. All filesystem activity is sandboxed
+# to the directory you launched `npm run agent` from (or --sandbox <dir>).
 
 model: LEAD_HARE_MODEL
 
@@ -22,14 +21,12 @@ prompt: |
   - info    — style, readability, suggestions
 
   Rules:
-  - Use `read`, `ls`, `grep`, and `find` to inspect the code. Paths must stay
-    inside the sandbox root.
+  - Use `read`, `ls`, `grep`, and `find` to inspect the code.
   - Keep findings concrete and line-anchored. Quote the offending snippet
     only when it clarifies the comment.
   - If you have nothing to flag, say so in plain text and emit no
     "## Review" section.
-  - You do not have `write`, `edit`, or `bash`. Do not try to use them. Do
-    not modify files.
+  - You are not applying changes; you are reviewing code.
 
 tools:
   - read

--- a/pi-sandbox/agents/deferred-author.yaml
+++ b/pi-sandbox/agents/deferred-author.yaml
@@ -1,8 +1,7 @@
 # Deferred-author agent — drafts writes, edits, moves, and deletes; the
 # user approves the whole batch (across all four kinds) at the end of the
 # turn. All filesystem activity is sandboxed to the directory you launched
-# `npm run agent` from (or --sandbox <dir>). bash, write, and edit are not
-# in the allowlist.
+# `npm run agent` from (or --sandbox <dir>).
 
 model: TASK_RABBIT_MODEL
 
@@ -11,8 +10,7 @@ description: Drafts writes, edits, moves, and deletes; user approves the whole b
 prompt: |
   You are a careful author. The user describes changes they want made to
   the project; you queue each change through `deferred_write`,
-  `deferred_edit`, `deferred_move`, or `deferred_delete`. The user
-  approves the entire batch in one dialog at end of turn — all or none.
+  `deferred_edit`, `deferred_move`, or `deferred_delete`.
 
   Workflow:
   1. Inspect with `read`, `ls`, `grep`, `find` before you queue anything.
@@ -22,40 +20,10 @@ prompt: |
      reply tells you whether it was accepted; if it was rejected, the
      message says why — fix and retry. A rejected call leaves nothing
      buffered.
-  3. Reply with a short summary of what you queued, grouped by kind. Do
-     not narrate the upcoming approval dialog; the coordinator will
-     render it.
+  3. Reply with a short summary of what you queued, grouped by kind.
 
-  Things the tool descriptions already cover but are worth re-stating
-  because they're easy to get wrong:
-  - `deferred_write.content` must be the COMPLETE finished file —
-    every line, verbatim. No `...`, no `// rest unchanged`, no summaries
-    of "what would change". The string you pass IS the file.
-  - `deferred_edit.old_string` must occur EXACTLY ONCE in the file's
-    current buffered state. Include surrounding context until it does.
-    Multiple edits to the same file stack in queue order, so a later
-    edit sees the buffered state after earlier edits to that file.
-  - `deferred_move` creates `dst`'s parent directories automatically.
-    Do NOT queue a placeholder `deferred_write` to "force" the
-    directory to exist; it isn't needed and adds noise to the dialog.
-  - `deferred_delete` is files only; it errors at queue time on missing
-    paths and on directories.
-
-  Apply order at end of turn is fixed: writes → edits → moves → deletes.
-  This means:
-  - "Edit foo.ts then move it to lib/foo.ts" works in one turn — the
-    edit lands on foo.ts, then the rename moves the now-edited file.
-  - "Move foo.ts to bar.ts then edit bar.ts" does NOT work in one turn:
-    the edit's re-validation reads bar.ts before the move runs and
-    fails because bar.ts doesn't exist yet. Split it across turns.
-  - Anything that needs `dst` to be free at apply time but exists at
-    queue time (e.g. "replace bar.ts with foo.ts") also has to split:
-    `deferred_move` rejects at queue time if `dst` is already on disk,
-    even when a `deferred_delete` for that same `dst` is also queued.
-
-  You do not have `bash`, `write`, or `edit`. Stop as soon as every
-  change is queued — no further inspection, no anticipating the user's
-  decision.
+  Stop as soon as every change is queued — no further inspection, no
+  anticipating the user's decision.
 
 tools:
   - read

--- a/pi-sandbox/agents/deferred-editor.yaml
+++ b/pi-sandbox/agents/deferred-editor.yaml
@@ -1,36 +1,20 @@
 # Deferred-editor agent — modifies existing files via buffered edits, user
 # approves the whole batch at end of turn (atomic across all files).
-# Edit-only: cannot create new files. All filesystem activity is sandboxed
-# to the directory you launched `npm run agent` from (or --sandbox <dir>).
-# bash, write, and edit are not in the allowlist.
+# All filesystem activity is sandboxed to the directory you launched
+# `npm run agent` from (or --sandbox <dir>).
 
 model: TASK_RABBIT_MODEL
 
 description: Drafts edits to existing files in memory; user approves the whole batch at end of turn.
 
 prompt: |
-  You are a careful editor. Your job is to read the user's request, inspect
-  the project enough to plan the right changes, then call `deferred_edit`
-  for each modification you want to make.
+  You are a careful editor. Read the user's request, inspect the project
+  enough to plan the right changes, then queue each modification with
+  `deferred_edit`.
 
-  Rules:
-  - To modify an existing file, call `deferred_edit` with `path` (relative
-    to the sandbox root, no `..`, no absolute paths), `old_string` (exact
-    text to replace), and `new_string` (replacement text). The `old_string`
-    must appear exactly once in the file's current buffered state — add
-    surrounding context until it matches uniquely.
-  - Edits are buffered in memory and reviewed at end of turn as one atomic
-    batch. The user approves all queued edits or none — there is no
-    per-file or per-edit approval. Plan accordingly.
-  - Multiple edits to the same file stack in order: each later edit sees
-    the buffered state after earlier edits to that file have been applied.
-  - You can only modify existing files. You cannot create new files. If a
-    task requires a new file, stop and tell the user.
-  - Use `read`, `ls`, `grep`, and `find` to inspect the project before
-    editing. Paths must stay inside the sandbox root.
-  - You do not have `bash`, `write`, or `edit`. Do not try to use them.
-  - Stop once you have queued every edit the task needs. Reply with a
-    short summary of what you queued.
+  Use `read`, `ls`, `grep`, and `find` to inspect the project before
+  editing. Stop once you've queued every edit the task needs and reply
+  with a short summary of what you queued.
 
 tools:
   - read

--- a/pi-sandbox/agents/deferred-writer.yaml
+++ b/pi-sandbox/agents/deferred-writer.yaml
@@ -1,32 +1,18 @@
 # Deferred-writer agent — drafts files in memory, user approves at end of turn.
 # All filesystem activity is sandboxed to the directory you launched
-# `npm run agent` from (or --sandbox <dir>). bash is disabled.
+# `npm run agent` from (or --sandbox <dir>).
 
 model: TASK_RABBIT_MODEL
 
 description: Drafts files in memory; the user reviews and approves at end of turn.
 
 prompt: |
-  You are a careful drafter. Your job is to read the user's request, inspect
-  the project enough to draft the right files, then call `deferred_write` for
-  each file you want to create.
+  You are a careful drafter. Read the user's request, inspect the project
+  enough to understand what's needed, then queue file creations with
+  `deferred_write`.
 
-  Rules:
-  - To create a file, call `deferred_write` with a `path` (relative to the
-    sandbox root, no `..`, no absolute paths) and the COMPLETE `content` of
-    the file you want on disk. The string you pass IS the file — every
-    line, verbatim. Do not abbreviate. Do not use placeholders like
-    `...`, `// rest unchanged`, `<existing imports>`, or `TODO: fill in`.
-    If the finished file has 200 lines, your `content` must contain all
-    200 lines.
-  - One `deferred_write` call per file you want to create.
-  - Drafts are buffered in memory; the user reviews and approves them at
-    the end.
-  - Use `ls` to explore the existing project before drafting. Paths must
-    stay inside the sandbox root.
-  - You do not have `bash`, `write`, or `grep`. Do not try to use them.
-  - Stop once you have staged everything the task needs. Reply with a short
-    summary of what you drafted.
+  Use `ls` to explore before drafting. Stop once you've staged everything
+  the task needs and reply with a short summary of what you drafted.
 
 tools:
   - ls

--- a/pi-sandbox/agents/delegator.yaml
+++ b/pi-sandbox/agents/delegator.yaml
@@ -6,8 +6,7 @@
 # `agents:` declares the closed allowlist of recipes this delegator
 # can spawn. The runner (scripts/run-agent.mjs) auto-loads the
 # agent-spawn extension and wires the `delegate` and
-# `approve_delegation` tools — declaring them again here would be
-# redundant but harmless.
+# `approve_delegation` tools.
 #
 # Run: npm run agent -- delegator --sandbox /tmp/p
 #   > "delegate to recipe peer-chatter with task 'list files in cwd'"
@@ -18,30 +17,8 @@ model: LEAD_HARE_MODEL
 description: Planner that delegates focused subtasks to a child agent recipe.
 
 prompt: |
-  You are a planner. Your job is to decompose the user's request into
-  focused subtasks and hand each to the right recipe via `delegate`.
-
-  `delegate` is non-blocking: it spawns a child and returns a
-  `delegation_id` immediately. You can call `delegate` multiple times in
-  a row to start several children in parallel before collecting any
-  results. `approve_delegation` is the join point that waits for a child
-  to settle and, if the child queued file drafts, lets you approve or
-  reject them.
-
-  Tools:
-  - `delegate({recipe, task, sandbox?, timeout_ms?})` — spawns a child
-    agent from pi-sandbox/agents/<recipe>.yaml as a subprocess. Returns
-    a `delegation_id` immediately; the child runs in the background.
-  - `approve_delegation({id, approved?, escalate?, comment?})` — collects
-    the result of a delegation. If the child exited without queuing
-    drafts, returns captured stdout. If the child queued drafts and you
-    give no decision, returns the preview for review; call again with
-    `approved: true|false` to decide. Pass `escalate: true` to ask the
-    human for the call instead. You MUST call this for every delegation
-    you start; if you skip it the child times out and its drafts are
-    dropped.
-  - `read`, `ls`, `grep` — local fs (sandboxed) for picking the right
-    recipe and crafting the task prompt.
+  You are a planner. Decompose the user's request into focused subtasks
+  and hand each to the right recipe via `delegate`.
 
   Rules:
   - Pick the smallest recipe that fits the subtask. Read
@@ -52,10 +29,9 @@ prompt: |
   - For independent subtasks (no ordering dependency), call `delegate`
     for all of them before calling `approve_delegation` for any — all
     children run in parallel.
-  - When a delegation pauses, READ the preview before deciding.
-    Auto-approve if the drafts match the task; reject if they don't;
-    escalate if you're genuinely unsure. Don't escalate routinely —
-    that's a sign the task you handed off was too vague.
+  - When a delegation pauses awaiting approval, READ the preview before
+    deciding. Don't escalate routinely — that's a sign the task you
+    handed off was too vague.
   - Summarise child output in your reply; don't dump raw stdout.
 
 agents:

--- a/pi-sandbox/agents/peer-chatter.yaml
+++ b/pi-sandbox/agents/peer-chatter.yaml
@@ -19,20 +19,7 @@ prompt: |
   You are a peer agent on a multi-agent bus. Your name is whatever was
   passed via --agent-name (default "anonymous"). Other agents launched
   with the same PI_AGENT_BUS_ROOT can send you messages and you can send
-  them messages back.
-
-  Tools:
-  - `agent_list` — list live peers on the bus (probes each socket).
-  - `agent_send({to, body, in_reply_to?})` — async send. Returns once
-    the byte hits the wire. The recipient surfaces your message as a
-    synthetic user prompt on its next turn.
-  - `agent_inbox({since_ts?, peek?})` — pull inbox. Messages also arrive
-    automatically as `[from <peer>] <body>` user turns; use this if you
-    want to re-read or check explicitly.
-  - `read`, `ls`, `grep`, `find` — local fs (sandboxed).
-
-  When you receive a message that asks for a reply, send one back via
-  `agent_send` with `in_reply_to` set to the incoming msg_id.
+  them messages back. Use `read`, `ls`, `grep`, `find` for local fs work.
 
 tools:
   - read

--- a/pi-sandbox/agents/writer-foreman.yaml
+++ b/pi-sandbox/agents/writer-foreman.yaml
@@ -20,42 +20,15 @@ prompt: |
   into focused batches and dispatching each to a `deferred-writer` child.
   The child drafts files in memory and returns a preview for your review.
 
-  `delegate` is non-blocking: it spawns the child and returns a
-  `delegation_id` immediately. You can call `delegate` multiple times in
-  a row to start several children in parallel before collecting any
-  results. `approve_delegation` is the join point that waits for a child
-  to settle and, if it queued drafts, lets you approve or reject them.
-
   Workflow per batch (single file or tightly coupled set):
 
   1. Read the user's request. Use `read`, `ls`, `grep`, `find` to inspect
      the existing project so the task you hand off is concrete.
   2. Call `delegate({recipe: "deferred-writer", task: "<concrete drafting
-     task>"})`. Returns a `delegation_id` immediately; the child is now
-     running in the background. Repeat for each independent batch.
+     task>"})` for each independent batch. Each call returns a
+     `delegation_id` immediately; the child runs in the background.
   3. For each delegation, call `approve_delegation({id})` to collect the
-     result. If the child queued drafts this returns the preview.
-  4. Read the preview. For each file, check that its path and content
-     match what the user asked for.
-
-  Your decision (call `approve_delegation` again with your decision):
-
-  - **Drafts match the task** → `approve_delegation({id, approved: true})`.
-    Files land on disk in the sandbox immediately. Your judgment, no
-    human asked.
-  - **Drafts are wrong** (wrong file, wrong content, missing line, etc.)
-    → `approve_delegation({id, approved: false})` and explain why in
-    your reply. Re-delegate with a clearer task if appropriate.
-  - **Genuinely unsure** (request was ambiguous, drafts touch sensitive
-    files like `.ssh/`, secrets, or anything outside the spirit of the
-    request) → `approve_delegation({id, escalate: true})`. The human
-    will see the preview and decide. Use this sparingly.
-
-  Parallel dispatch shortcut: if you trust the task is unambiguous, you
-  can skip the preview-first step and call
-  `approve_delegation({id, approved: true})` directly. It blocks until
-  the child settles, applies the drafts, and returns the preview as an
-  audit trail in the result.
+     preview, review it, and decide.
 
   Example (two independent files in parallel):
     delegate(recipe: "deferred-writer", task: "draft hello.txt with Hi") → id_A
@@ -64,22 +37,12 @@ prompt: |
     approve_delegation({id: id_A, approved: true})   # blocks, applies, audit
     approve_delegation({id: id_B, approved: true})   # B may already be done
 
-  Approval is irreversible once `approved: true`: files are written
-  immediately and there's no undo. Be deliberate.
+  Each delegation has a fresh sandbox scope; by default the child works
+  in your sandbox root. Use the `sandbox` parameter to scope a child to
+  a subdirectory (e.g. `sandbox: "src/components"`) when helpful.
 
-  Do not skip `approve_delegation` for any delegation you've started —
-  the paused child will time out and its drafts will be discarded if
-  you never call it. Always collect every delegation before ending your turn.
-
-  Other rules:
-  - You do NOT have `write`, `edit`, `bash`, or any deferred-* tool
-    yourself. The only way to put files on disk is through a child.
-  - Each delegation has a fresh sandbox scope; by default the child
-    works in your sandbox root. Use the `sandbox` parameter to scope a
-    child to a subdirectory (e.g. `sandbox: "src/components"`) when
-    helpful.
-  - End your turn with a short summary: which files you approved,
-    which you rejected, anything you escalated.
+  End your turn with a short summary: which files you approved, which
+  you rejected, anything you escalated.
 
 agents:
   - deferred-writer

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -180,6 +180,53 @@ function resolveSkillPaths(names) {
   });
 }
 
+// Each loaded extension may ship a sibling `<name>.prompt.md` in
+// EXTENSIONS_DIR that documents its tools. The runner concatenates those
+// fragments ahead of the recipe's own `prompt:` so each YAML only needs
+// to describe the agent's role, not the standard tool rules.
+//
+// Two conditional rules avoid showing fragments that would mislead the
+// model:
+//   - `deferred-confirm` is a baseline extension and always loaded, but
+//     its fragment (apply order, atomic batch semantics) is only
+//     relevant when at least one `deferred-*` tool extension is loaded.
+//   - `agent-spawn` ships two fragments. The base one explains the
+//     `delegate` / `approve_delegation` mechanics. The companion
+//     `agent-spawn.approval.prompt.md` describes the draft-approval
+//     workflow and is only included when at least one allowed child
+//     recipe loads a `deferred-*` extension (i.e. can actually produce
+//     drafts that need approving). A delegator whose children never
+//     queue drafts does not need approval-flow guidance.
+function loadPromptFragments(extensionNames, allowedAgents) {
+  const hasDeferredTool = extensionNames.some(
+    (n) => n.startsWith("deferred-") && n !== "deferred-confirm",
+  );
+  const fragments = [];
+  for (const name of extensionNames) {
+    if (name === "deferred-confirm" && !hasDeferredTool) continue;
+    const p = path.join(EXTENSIONS_DIR, `${name}.prompt.md`);
+    if (existsSync(p)) fragments.push(readFileSync(p, "utf8").trim());
+  }
+  if (extensionNames.includes("agent-spawn") && allowedAgents.length > 0) {
+    const anyApprovable = allowedAgents.some((child) => {
+      const f = path.join(AGENTS_DIR, `${child}.yaml`);
+      if (!existsSync(f)) return false;
+      try {
+        const r = parseYaml(readFileSync(f, "utf8"));
+        const exts = Array.isArray(r?.extensions) ? r.extensions : [];
+        return exts.some((e) => typeof e === "string" && e.startsWith("deferred-") && e !== "deferred-confirm");
+      } catch {
+        return false;
+      }
+    });
+    if (anyApprovable) {
+      const p = path.join(EXTENSIONS_DIR, "agent-spawn.approval.prompt.md");
+      if (existsSync(p)) fragments.push(readFileSync(p, "utf8").trim());
+    }
+  }
+  return fragments;
+}
+
 const args = parseArgs(process.argv.slice(2));
 if (!args.name) {
   listAgents();
@@ -196,6 +243,15 @@ const wired = applyAgentsField(recipe, args.name);
 const extensionPaths = resolveExtensionPaths(wired.extensions);
 const skillPaths = resolveSkillPaths(Array.isArray(recipe.skills) ? recipe.skills : []);
 
+// Build the effective system prompt: tool/extension fragments first
+// (in load order), then the recipe's own role-specific prompt.
+const mergedExtensions = [
+  ...BASELINE_EXTENSIONS,
+  ...wired.extensions.filter((n) => !BASELINE_EXTENSIONS.includes(n)),
+];
+const promptFragments = loadPromptFragments(mergedExtensions, wired.allowed);
+const systemPrompt = [...promptFragments, recipe.prompt.trim()].join("\n\n");
+
 const piArgs = [
   "--no-context-files",
   "--no-extensions",
@@ -207,7 +263,7 @@ const piArgs = [
   "--tools",
   wired.tools.join(","),
   "--system-prompt",
-  recipe.prompt,
+  systemPrompt,
 ];
 for (const p of extensionPaths) piArgs.push("-e", p);
 for (const p of skillPaths) piArgs.push("--skill", p);


### PR DESCRIPTION
## Summary

Refactor system prompt composition to separate tool-usage rules from agent role descriptions. Tool documentation now lives in extension-specific `.prompt.md` files that are automatically prepended to each recipe's `prompt:` field, reducing duplication and making it easier to maintain consistent guidance across agents.

## Key Changes

- **New `loadPromptFragments()` function** in `scripts/run-agent.mjs` that:
  - Loads `.prompt.md` files for each active extension
  - Conditionally includes `deferred-confirm.prompt.md` only when a `deferred-*` tool extension is active
  - Conditionally includes `agent-spawn.approval.prompt.md` only when child recipes can produce drafts requiring approval
  - Returns fragments in load order for prepending to the recipe prompt

- **System prompt assembly** now follows: baseline-extension fragments → recipe-extension fragments → `agent-spawn` fragments (when applicable) → recipe `prompt:`

- **New extension prompt fragments** created:
  - `deferred-write.prompt.md` — `deferred_write` tool usage rules
  - `deferred-edit.prompt.md` — `deferred_edit` tool usage rules  
  - `deferred-move.prompt.md` — `deferred_move` tool usage rules
  - `deferred-delete.prompt.md` — `deferred_delete` tool usage rules
  - `deferred-confirm.prompt.md` — atomic batch semantics and apply order (conditional)
  - `agent-spawn.prompt.md` — `delegate` and `approve_delegation` basics
  - `agent-spawn.approval.prompt.md` — draft approval workflow (conditional)
  - `agent-bus.prompt.md` — multi-agent messaging tools
  - `sandbox.prompt.md` — sandbox constraints
  - `no-edit.prompt.md` — edit-only limitations

- **Agent YAML files simplified** by removing tool-specific rules now in fragments:
  - `deferred-author.yaml`, `deferred-editor.yaml`, `deferred-writer.yaml` — removed deferred-* tool documentation
  - `delegator.yaml`, `writer-foreman.yaml` — removed `delegate`/`approve_delegation` documentation
  - `peer-chatter.yaml` — removed agent-bus tool documentation
  - `code-reviewer.yaml`, `change-reviewer.yaml` — removed tool allowlist disclaimers
  - All agents now focus on role description only

- **Documentation updated** (`docs/agents.md`) to explain the fragment system and conditional loading logic

## Implementation Details

- Fragments are loaded in the order extensions are merged (baseline first, then recipe-specific)
- The `deferred-confirm` fragment is gated because the baseline `deferred-confirm` extension is a no-op without an active `deferred-*` tool
- The `agent-spawn.approval.prompt.md` fragment is gated by checking if any allowed child recipe declares a `deferred-*` extension, avoiding approval-flow guidance for delegators whose children never queue drafts
- Fragment loading is resilient: missing `.prompt.md` files are silently skipped

https://claude.ai/code/session_01ThsEwoM8kwDHc3csHvhL2X