### PR TITLE
Filter hidden tools and display agent skills/delegation info

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -30,10 +30,21 @@ agent gets six baseline extensions:
 - `agent-footer` — replaces pi's default footer. Line 1 shows the
   sandbox root on the left and the comma-separated active tools (from
   `pi.getActiveTools()`, i.e. the recipe's `tools:` allowlist plus any
-  extension-registered tools) on the right. Line 2 shows `$cost` and
-  the context-usage percent on the left, model id on the right —
+  extension-registered tools) on the right. `delegate` and
+  `approve_delegation` are filtered out of the tool list because every
+  delegating agent has them — they tell the user nothing about what
+  the recipe can actually do, and the agents-it-can-spawn list on
+  line 3 already conveys delegation capability. Line 2 shows `$cost`
+  and the context-usage percent on the left, model id on the right —
   pi's default token-flow stats (↑input, ↓output, cache R/W, context
-  window size) are intentionally dropped. Line 3 is the
+  window size) are intentionally dropped. Line 3 (when populated)
+  shows `skills: <names>` on the left and `agents: <names>` on the
+  right — the recipe's `skills:` list and the recipes this agent
+  may `delegate` to. Read from the `PI_AGENT_SKILLS` /
+  `PI_AGENT_AGENTS` env vars set by the runner (pi.getFlag is scoped
+  per-extension, so cross-extension flag reads have to bounce through
+  env, mirroring how `agent-status-reporter` reads `--rpc-sock`); the
+  line is skipped entirely when both lists are empty. Line 4 is the
   extension-status line.
 - `hide-extensions-list` — strips pi's `[Extensions]` section (added by
   `showLoadedResources` to the chat history at startup) since the

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -38,14 +38,14 @@ agent gets six baseline extensions:
   and the context-usage percent on the left, model id on the right —
   pi's default token-flow stats (↑input, ↓output, cache R/W, context
   window size) are intentionally dropped. Line 3 (when populated)
-  shows `skills: <names>` on the left and `agents: <names>` on the
-  right — the recipe's `skills:` list and the recipes this agent
-  may `delegate` to. Read from the `PI_AGENT_SKILLS` /
-  `PI_AGENT_AGENTS` env vars set by the runner (pi.getFlag is scoped
-  per-extension, so cross-extension flag reads have to bounce through
-  env, mirroring how `agent-status-reporter` reads `--rpc-sock`); the
-  line is skipped entirely when both lists are empty. Line 4 is the
-  extension-status line.
+  shows the recipe's `skills:` list on the left and the recipes this
+  agent may `delegate` to on the right — both as plain comma-separated
+  lists, no labels, matching line 1's bare style. Read from the
+  `PI_AGENT_SKILLS` / `PI_AGENT_AGENTS` env vars set by the runner
+  (pi.getFlag is scoped per-extension, so cross-extension flag reads
+  have to bounce through env, mirroring how `agent-status-reporter`
+  reads `--rpc-sock`); the line is skipped entirely when both lists
+  are empty. Line 4 is the extension-status line.
 - `hide-extensions-list` — strips pi's `[Extensions]` section (added by
   `showLoadedResources` to the chat history at startup) since the
   agent-footer already shows the active tools and the path listing is

--- a/pi-sandbox/.pi/extensions/agent-footer.ts
+++ b/pi-sandbox/.pi/extensions/agent-footer.ts
@@ -20,11 +20,12 @@
 //                  ↓output, cache R/W, /<window-size>) are
 //                  intentionally dropped.
 //   line 2, right: model id.
-//   line 3 (opt):  `skills: <names>` on the left and `agents: <names>`
-//                  on the right — the recipe's `skills:` list and the
-//                  recipes this agent may `delegate` to. Read from the
-//                  PI_AGENT_SKILLS / PI_AGENT_AGENTS env vars set by
-//                  the runner (pi.getFlag is scoped per extension, so
+//   line 3 (opt):  the recipe's `skills:` list on the left and the
+//                  recipes this agent may `delegate` to on the right
+//                  (comma-separated, no labels — matches line 1's
+//                  bare-list style). Read from the PI_AGENT_SKILLS /
+//                  PI_AGENT_AGENTS env vars set by the runner
+//                  (pi.getFlag is scoped per extension, so
 //                  cross-extension flag reads have to bounce through
 //                  env, mirroring how agent-status-reporter reads
 //                  --rpc-sock). Skipped when both lists are empty.
@@ -154,9 +155,7 @@ export default function (pi: ExtensionAPI) {
         const lines = [pwdLine, dimLeft + dimRest];
 
         if (skills.length > 0 || agents.length > 0) {
-          const skillsLabel = skills.length > 0 ? `skills: ${skills.join(", ")}` : "";
-          const agentsLabel = agents.length > 0 ? `agents: ${agents.join(", ")}` : "";
-          const composedLine = renderLeftRight(width, skillsLabel, agentsLabel, "…");
+          const composedLine = renderLeftRight(width, skills.join(", "), agents.join(", "), "…");
           lines.push(truncateToWidth(theme.fg("dim", composedLine), width, theme.fg("dim", "...")));
         }
 

--- a/pi-sandbox/.pi/extensions/agent-footer.ts
+++ b/pi-sandbox/.pi/extensions/agent-footer.ts
@@ -6,9 +6,13 @@
 //                  misleading noise.
 //   line 1, right: comma-separated active tools from pi.getActiveTools()
 //                  — the recipe's `tools:` allowlist plus any tools
-//                  registered by extensions. Truncated with an ellipsis
-//                  on narrow terminals; dropped entirely if there is no
-//                  room for a 2-column gap after the sandbox path.
+//                  registered by extensions. `delegate` and
+//                  `approve_delegation` are hidden because every
+//                  delegating agent has them; they're noise next to
+//                  the tools that actually distinguish the recipe.
+//                  Truncated with an ellipsis on narrow terminals;
+//                  dropped entirely if there is no room for a 2-column
+//                  gap after the sandbox path.
 //   line 2, left:  `<bar>| $cost` — 5-cell eighths-block context-usage
 //                  bar (warning tint > 70%, error tint > 90%), followed
 //                  by the accumulated assistant cost from session
@@ -16,7 +20,15 @@
 //                  ↓output, cache R/W, /<window-size>) are
 //                  intentionally dropped.
 //   line 2, right: model id.
-//   line 3 (opt):  extension status texts set via ctx.ui.setStatus().
+//   line 3 (opt):  `skills: <names>` on the left and `agents: <names>`
+//                  on the right — the recipe's `skills:` list and the
+//                  recipes this agent may `delegate` to. Read from the
+//                  PI_AGENT_SKILLS / PI_AGENT_AGENTS env vars set by
+//                  the runner (pi.getFlag is scoped per extension, so
+//                  cross-extension flag reads have to bounce through
+//                  env, mirroring how agent-status-reporter reads
+//                  --rpc-sock). Skipped when both lists are empty.
+//   line 4 (opt):  extension status texts set via ctx.ui.setStatus().
 
 import os from "node:os";
 import path from "node:path";
@@ -37,10 +49,54 @@ function sanitizeStatusText(text: string): string {
   return text.replace(/[\r\n\t]/g, " ").replace(/ +/g, " ").trim();
 }
 
+// Tools that every delegating agent gets via the implicit-wire in
+// run-agent.mjs. Always-on tools tell the user nothing about the
+// recipe, so we drop them from the line-1 tool list — agents-it-can-
+// spawn is conveyed on line 3 instead.
+const HIDDEN_TOOLS = new Set(["delegate", "approve_delegation"]);
+
+function parseEnvList(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function renderLeftRight(
+  width: number,
+  left: string,
+  right: string,
+  truncIndicator: string,
+): string {
+  const lW = visibleWidth(left);
+  const rW = visibleWidth(right);
+  const minGap = 2;
+  if (lW === 0 && rW === 0) return "";
+  if (lW === 0) {
+    if (rW <= width) return " ".repeat(width - rW) + right;
+    return truncateToWidth(right, width, truncIndicator);
+  }
+  if (rW === 0) {
+    return truncateToWidth(left, width, truncIndicator);
+  }
+  if (lW + minGap + rW <= width) {
+    return left + " ".repeat(width - lW - rW) + right;
+  }
+  if (lW + minGap < width) {
+    const truncR = truncateToWidth(right, width - lW - minGap, truncIndicator);
+    const padW = Math.max(0, width - lW - visibleWidth(truncR));
+    return left + " ".repeat(padW) + truncR;
+  }
+  return truncateToWidth(left, width, truncIndicator);
+}
+
 export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     const root = path.resolve((pi.getFlag("sandbox-root") as string | undefined) || ctx.cwd);
     const displayRoot = homeReplace(root);
+    const skills = parseEnvList(process.env.PI_AGENT_SKILLS);
+    const agents = parseEnvList(process.env.PI_AGENT_AGENTS);
 
     ctx.ui.setFooter((_tui, theme, footerData) => ({
       invalidate() {},
@@ -52,20 +108,9 @@ export default function (pi: ExtensionAPI) {
         } catch {
           // getActiveTools may not be ready in some session states.
         }
-        const toolsLabel = activeTools.length > 0 ? activeTools.join(", ") : "";
-        const sbW = visibleWidth(sandboxLabel);
-        const tlW = visibleWidth(toolsLabel);
-        const minGap = 2;
-
-        let pwdContent: string;
-        if (toolsLabel.length > 0 && sbW + minGap + tlW <= width) {
-          pwdContent = sandboxLabel + " ".repeat(width - sbW - tlW) + toolsLabel;
-        } else if (toolsLabel.length > 0 && sbW + minGap < width) {
-          const truncT = truncateToWidth(toolsLabel, width - sbW - minGap, "…");
-          pwdContent = sandboxLabel + " ".repeat(Math.max(0, width - sbW - visibleWidth(truncT))) + truncT;
-        } else {
-          pwdContent = sandboxLabel;
-        }
+        const visibleTools = activeTools.filter((t) => !HIDDEN_TOOLS.has(t));
+        const toolsLabel = visibleTools.length > 0 ? visibleTools.join(", ") : "";
+        const pwdContent = renderLeftRight(width, sandboxLabel, toolsLabel, "…");
         const pwdLine = truncateToWidth(theme.fg("dim", pwdContent), width, theme.fg("dim", "..."));
 
         let cost = 0;
@@ -107,6 +152,13 @@ export default function (pi: ExtensionAPI) {
         const dimLeft = theme.fg("dim", left);
         const dimRest = theme.fg("dim", statsLine.slice(left.length));
         const lines = [pwdLine, dimLeft + dimRest];
+
+        if (skills.length > 0 || agents.length > 0) {
+          const skillsLabel = skills.length > 0 ? `skills: ${skills.join(", ")}` : "";
+          const agentsLabel = agents.length > 0 ? `agents: ${agents.join(", ")}` : "";
+          const composedLine = renderLeftRight(width, skillsLabel, agentsLabel, "…");
+          lines.push(truncateToWidth(theme.fg("dim", composedLine), width, theme.fg("dim", "...")));
+        }
 
         const statuses = footerData.getExtensionStatuses();
         if (statuses.size > 0) {

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -270,16 +270,22 @@ piArgs.push(...args.passthrough);
 
 if (!existsSync(PI_BIN)) die(`pi binary missing: ${PI_BIN} (run npm install)`);
 
+const recipeSkills = Array.isArray(recipe.skills) ? recipe.skills.filter((s) => typeof s === "string") : [];
+
 const child = spawn(PI_BIN, piArgs, {
   cwd: sandboxRoot,
   stdio: "inherit",
   // Mirror the agent name + bus root + rpc sock into env vars so
   // extensions that can't read the CLI flags via pi.getFlag (which is
-  // scoped per extension) still see them.
+  // scoped per extension) still see them. Skills and allowed-agents
+  // are mirrored too so agent-footer can render them on its third
+  // line without duplicating flag registrations.
   env: {
     ...process.env,
     PI_AGENT_NAME: agentName,
     PI_AGENT_BUS_ROOT: busRoot,
+    PI_AGENT_SKILLS: recipeSkills.join(","),
+    PI_AGENT_AGENTS: wired.allowed.join(","),
     ...(rpcSock ? { PI_RPC_SOCK: rpcSock } : {}),
   },
 });


### PR DESCRIPTION
## Summary
This PR enhances the agent footer display to filter out noise-generating tools and add a new line showing the agent's skills and delegation capabilities.

## Key Changes

- **Filter hidden tools from line 1**: `delegate` and `approve_delegation` are now hidden from the active tools list since every delegating agent has them and they don't distinguish recipes. This reduces visual clutter while delegation capability is conveyed on the new line 3.

- **Add skills and delegation line**: A new optional line 3 displays the recipe's `skills:` list on the left and allowed delegation targets on the right, read from `PI_AGENT_SKILLS` and `PI_AGENT_AGENTS` environment variables set by the runner.

- **Refactor layout logic**: Extracted the left-right column rendering logic into a reusable `renderLeftRight()` helper function to handle spacing, truncation, and edge cases consistently across multiple footer lines.

- **Environment variable mirroring**: Updated `run-agent.mjs` to pass recipe skills and allowed agents through environment variables since `pi.getFlag()` is scoped per-extension and cross-extension reads must bounce through env.

## Implementation Details

- The `HIDDEN_TOOLS` set defines tools that are always-on and provide no recipe-specific information
- `parseEnvList()` safely parses comma-separated environment variable values
- `renderLeftRight()` handles all combinations of empty/full left/right content with proper spacing and truncation
- The new line is skipped entirely when both skills and agents lists are empty
- Documentation updated in both code comments and `docs/agents.md` to reflect the new footer structure (lines now numbered 1-4 instead of 1-3)

https://claude.ai/code/session_01Drs2XFKYidLu7XgA5G6sbm