### PR TITLE
Reorder agent footer lines: skills/delegation before cost/model

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -34,10 +34,7 @@ agent gets six baseline extensions:
   `approve_delegation` are filtered out of the tool list because every
   delegating agent has them — they tell the user nothing about what
   the recipe can actually do, and the agents-it-can-spawn list on
-  line 3 already conveys delegation capability. Line 2 shows `$cost`
-  and the context-usage percent on the left, model id on the right —
-  pi's default token-flow stats (↑input, ↓output, cache R/W, context
-  window size) are intentionally dropped. Line 3 (when populated)
+  line 2 already conveys delegation capability. Line 2 (when populated)
   shows the recipe's `skills:` list on the left and the recipes this
   agent may `delegate` to on the right — both as plain comma-separated
   lists, no labels, matching line 1's bare style. Read from the
@@ -45,7 +42,10 @@ agent gets six baseline extensions:
   (pi.getFlag is scoped per-extension, so cross-extension flag reads
   have to bounce through env, mirroring how `agent-status-reporter`
   reads `--rpc-sock`); the line is skipped entirely when both lists
-  are empty. Line 4 is the extension-status line.
+  are empty. Line 3 shows `$cost` and the context-usage percent on
+  the left, model id on the right — pi's default token-flow stats
+  (↑input, ↓output, cache R/W, context window size) are intentionally
+  dropped. Line 4 is the extension-status line.
 - `hide-extensions-list` — strips pi's `[Extensions]` section (added by
   `showLoadedResources` to the chat history at startup) since the
   agent-footer already shows the active tools and the path listing is

--- a/pi-sandbox/.pi/extensions/agent-footer.ts
+++ b/pi-sandbox/.pi/extensions/agent-footer.ts
@@ -13,14 +13,7 @@
 //                  Truncated with an ellipsis on narrow terminals;
 //                  dropped entirely if there is no room for a 2-column
 //                  gap after the sandbox path.
-//   line 2, left:  `<bar>| $cost` — 5-cell eighths-block context-usage
-//                  bar (warning tint > 70%, error tint > 90%), followed
-//                  by the accumulated assistant cost from session
-//                  history. pi's default token-flow stats (↑input,
-//                  ↓output, cache R/W, /<window-size>) are
-//                  intentionally dropped.
-//   line 2, right: model id.
-//   line 3 (opt):  the recipe's `skills:` list on the left and the
+//   line 2 (opt):  the recipe's `skills:` list on the left and the
 //                  recipes this agent may `delegate` to on the right
 //                  (comma-separated, no labels — matches line 1's
 //                  bare-list style). Read from the PI_AGENT_SKILLS /
@@ -29,6 +22,13 @@
 //                  cross-extension flag reads have to bounce through
 //                  env, mirroring how agent-status-reporter reads
 //                  --rpc-sock). Skipped when both lists are empty.
+//   line 3, left:  `<bar>| $cost` — 5-cell eighths-block context-usage
+//                  bar (warning tint > 70%, error tint > 90%), followed
+//                  by the accumulated assistant cost from session
+//                  history. pi's default token-flow stats (↑input,
+//                  ↓output, cache R/W, /<window-size>) are
+//                  intentionally dropped.
+//   line 3, right: model id.
 //   line 4 (opt):  extension status texts set via ctx.ui.setStatus().
 
 import os from "node:os";
@@ -53,7 +53,7 @@ function sanitizeStatusText(text: string): string {
 // Tools that every delegating agent gets via the implicit-wire in
 // run-agent.mjs. Always-on tools tell the user nothing about the
 // recipe, so we drop them from the line-1 tool list — agents-it-can-
-// spawn is conveyed on line 3 instead.
+// spawn is conveyed on line 2 instead.
 const HIDDEN_TOOLS = new Set(["delegate", "approve_delegation"]);
 
 function parseEnvList(value: string | undefined): string[] {
@@ -152,12 +152,14 @@ export default function (pi: ExtensionAPI) {
 
         const dimLeft = theme.fg("dim", left);
         const dimRest = theme.fg("dim", statsLine.slice(left.length));
-        const lines = [pwdLine, dimLeft + dimRest];
+        const lines = [pwdLine];
 
         if (skills.length > 0 || agents.length > 0) {
           const composedLine = renderLeftRight(width, skills.join(", "), agents.join(", "), "…");
           lines.push(truncateToWidth(theme.fg("dim", composedLine), width, theme.fg("dim", "...")));
         }
+
+        lines.push(dimLeft + dimRest);
 
         const statuses = footerData.getExtensionStatuses();
         if (statuses.size > 0) {


### PR DESCRIPTION
## Summary
Reorganizes the agent footer display layout to show the skills and delegation information before the cost and model information. This improves the logical flow of the footer by presenting recipe capabilities before resource usage details.

## Key Changes
- **Line reordering in agent-footer.ts**: Moved the cost/model line (previously line 2) to line 3, and promoted the skills/delegation line (previously line 3) to line 2
  - Skills and delegation agents now display immediately after the working directory
  - Cost and model information now appear after the optional skills/delegation line
  - Extension status texts remain on line 4
  
- **Updated documentation**: Modified `docs/agents.md` to reflect the new line numbering and layout order, ensuring the documentation matches the implementation

- **Updated inline comments**: Fixed references in code comments that previously mentioned "line 3" for delegation capability to now correctly reference "line 2"

## Implementation Details
The change reorders how lines are pushed to the footer output array:
1. Working directory line (line 1)
2. Skills/delegation line (line 2, optional)
3. Cost/model line (line 3)
4. Extension status line (line 4, optional)

This maintains all existing functionality while improving the visual hierarchy and information flow of the footer display.

https://claude.ai/code/session_01AKQrFXd2pRrkNk4W23d8Rq