### PR TITLE
Introduce Habitat: centralized per-instance containment spec

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,7 +28,7 @@ A model class — `RABBIT_SAGE_MODEL` (planner), `LEAD_HARE_MODEL` (overseer), `
 ### Containment
 
 **Habitat**:
-Per-instance containment perimeter for one **Peer** — scratch FS, peer allowlists, supervisor, submitTo, tools, model — resolved once at session start; **Rails** read from it.
+Per-instance containment perimeter for one **Peer** — scratch FS, peer allowlists, supervisor, submitTo, tools, model — resolved once at session start; **Rails** read from it. Materialised at session_start by the `habitat` baseline extension; rails read fields via `getHabitat()` from `_lib/habitat.ts`.
 _Avoid_: sandbox (overloaded), environment, scope, surface
 
 **Scratch Sandbox**:

--- a/pi-sandbox/.pi/extensions/_lib/habitat.test.ts
+++ b/pi-sandbox/.pi/extensions/_lib/habitat.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { materialiseHabitat, setHabitat, getHabitat, type Habitat } from "./habitat";
+
+// Wipe the globalThis stash between tests so set/get tests are isolated.
+beforeEach(() => {
+  (globalThis as { __pi_habitat__?: Habitat }).__pi_habitat__ = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// materialiseHabitat
+// ---------------------------------------------------------------------------
+
+const MINIMAL_VALID = JSON.stringify({
+  agentName: "cottontail-writer",
+  scratchRoot: "/tmp/scratch",
+  busRoot: "/home/user/.pi-agent-bus/scratch",
+});
+
+describe("materialiseHabitat", () => {
+  it("returns a Habitat for a minimal valid spec", () => {
+    const h = materialiseHabitat(MINIMAL_VALID);
+    expect(h.agentName).toBe("cottontail-writer");
+    expect(h.scratchRoot).toBe("/tmp/scratch");
+    expect(h.busRoot).toBe("/home/user/.pi-agent-bus/scratch");
+  });
+
+  it("defaults list fields to [] when absent", () => {
+    const h = materialiseHabitat(MINIMAL_VALID);
+    expect(h.skills).toEqual([]);
+    expect(h.agents).toEqual([]);
+    expect(h.noEditAdd).toEqual([]);
+    expect(h.noEditSkip).toEqual([]);
+  });
+
+  it("optional string fields are undefined when absent", () => {
+    const h = materialiseHabitat(MINIMAL_VALID);
+    expect(h.description).toBeUndefined();
+    expect(h.tier).toBeUndefined();
+    expect(h.type).toBeUndefined();
+    expect(h.rpcSock).toBeUndefined();
+    expect(h.delegationId).toBeUndefined();
+  });
+
+  it("preserves all optional fields when present", () => {
+    const spec = JSON.stringify({
+      agentName: "x-writer",
+      scratchRoot: "/tmp/s",
+      busRoot: "/tmp/b",
+      description: "Does things",
+      tier: "TASK_RABBIT_MODEL",
+      type: "deferred-writer",
+      rpcSock: "/tmp/pi-rpc-123.sock",
+      delegationId: "abc-def",
+      skills: ["pi-agent-builder"],
+      agents: ["deferred-writer"],
+      noEditAdd: ["my_tool"],
+      noEditSkip: ["deferred_write"],
+    });
+    const h = materialiseHabitat(spec);
+    expect(h.description).toBe("Does things");
+    expect(h.tier).toBe("TASK_RABBIT_MODEL");
+    expect(h.type).toBe("deferred-writer");
+    expect(h.rpcSock).toBe("/tmp/pi-rpc-123.sock");
+    expect(h.delegationId).toBe("abc-def");
+    expect(h.skills).toEqual(["pi-agent-builder"]);
+    expect(h.agents).toEqual(["deferred-writer"]);
+    expect(h.noEditAdd).toEqual(["my_tool"]);
+    expect(h.noEditSkip).toEqual(["deferred_write"]);
+  });
+
+  it("throws on malformed JSON", () => {
+    expect(() => materialiseHabitat("{not valid")).toThrow();
+  });
+
+  it("throws when agentName is missing", () => {
+    const spec = JSON.stringify({ scratchRoot: "/tmp/s", busRoot: "/tmp/b" });
+    expect(() => materialiseHabitat(spec)).toThrow(/agentName/);
+  });
+
+  it("throws when scratchRoot is missing", () => {
+    const spec = JSON.stringify({ agentName: "a", busRoot: "/tmp/b" });
+    expect(() => materialiseHabitat(spec)).toThrow(/scratchRoot/);
+  });
+
+  it("throws when busRoot is missing", () => {
+    const spec = JSON.stringify({ agentName: "a", scratchRoot: "/tmp/s" });
+    expect(() => materialiseHabitat(spec)).toThrow(/busRoot/);
+  });
+
+  it("throws when agentName is not a string", () => {
+    const spec = JSON.stringify({ agentName: 42, scratchRoot: "/tmp/s", busRoot: "/tmp/b" });
+    expect(() => materialiseHabitat(spec)).toThrow(/agentName/);
+  });
+
+  it("throws when scratchRoot is not a string", () => {
+    const spec = JSON.stringify({ agentName: "a", scratchRoot: null, busRoot: "/tmp/b" });
+    expect(() => materialiseHabitat(spec)).toThrow(/scratchRoot/);
+  });
+
+  it("throws when busRoot is not a string", () => {
+    const spec = JSON.stringify({ agentName: "a", scratchRoot: "/tmp/s", busRoot: [] });
+    expect(() => materialiseHabitat(spec)).toThrow(/busRoot/);
+  });
+
+  it("ignores non-string items in list fields", () => {
+    const spec = JSON.stringify({
+      agentName: "a",
+      scratchRoot: "/tmp/s",
+      busRoot: "/tmp/b",
+      skills: ["valid", 42, null, "also-valid"],
+    });
+    const h = materialiseHabitat(spec);
+    expect(h.skills).toEqual(["valid", "also-valid"]);
+  });
+
+  it("treats a non-array list field as []", () => {
+    const spec = JSON.stringify({
+      agentName: "a",
+      scratchRoot: "/tmp/s",
+      busRoot: "/tmp/b",
+      skills: "pi-agent-builder",
+    });
+    const h = materialiseHabitat(spec);
+    expect(h.skills).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setHabitat / getHabitat
+// ---------------------------------------------------------------------------
+
+describe("setHabitat / getHabitat", () => {
+  it("getHabitat throws before setHabitat is called", () => {
+    expect(() => getHabitat()).toThrow();
+  });
+
+  it("getHabitat returns the habitat after setHabitat", () => {
+    const h = materialiseHabitat(MINIMAL_VALID);
+    setHabitat(h);
+    expect(getHabitat()).toBe(h);
+  });
+
+  it("stashes on globalThis under __pi_habitat__", () => {
+    const h = materialiseHabitat(MINIMAL_VALID);
+    setHabitat(h);
+    expect((globalThis as { __pi_habitat__?: Habitat }).__pi_habitat__).toBe(h);
+  });
+
+  it("overwrite: setHabitat replaces previous value", () => {
+    const h1 = materialiseHabitat(MINIMAL_VALID);
+    const h2 = materialiseHabitat(
+      JSON.stringify({ agentName: "b", scratchRoot: "/tmp/b", busRoot: "/tmp/bb" }),
+    );
+    setHabitat(h1);
+    setHabitat(h2);
+    expect(getHabitat().agentName).toBe("b");
+  });
+});

--- a/pi-sandbox/.pi/extensions/_lib/habitat.ts
+++ b/pi-sandbox/.pi/extensions/_lib/habitat.ts
@@ -1,0 +1,84 @@
+export interface Habitat {
+  // Identity
+  agentName: string;
+  description?: string;
+  tier?: string;
+  type?: string;
+
+  // Filesystem
+  scratchRoot: string;
+
+  // Bus
+  busRoot: string;
+
+  // Recipe metadata exposed for footer rendering
+  skills: string[];
+  agents: string[];
+
+  // No-edit rail config (carried forward; recipe-schema removal deferred)
+  noEditAdd: string[];
+  noEditSkip: string[];
+
+  // Delegation-only context (still in use until Phase 5)
+  rpcSock?: string;
+  delegationId?: string;
+}
+
+function requireString(obj: Record<string, unknown>, key: string): string {
+  const v = obj[key];
+  if (typeof v !== "string") {
+    throw new Error(`materialiseHabitat: required field '${key}' must be a non-null string (got ${JSON.stringify(v)})`);
+  }
+  return v;
+}
+
+function optionalString(obj: Record<string, unknown>, key: string): string | undefined {
+  const v = obj[key];
+  if (v === undefined || v === null) return undefined;
+  if (typeof v !== "string") return undefined;
+  return v;
+}
+
+function stringList(obj: Record<string, unknown>, key: string): string[] {
+  const v = obj[key];
+  if (!Array.isArray(v)) return [];
+  return v.filter((item): item is string => typeof item === "string");
+}
+
+export function materialiseHabitat(rawJson: string): Habitat {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch (e) {
+    throw new Error(`materialiseHabitat: invalid JSON: ${(e as Error).message}`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("materialiseHabitat: spec must be a JSON object");
+  }
+  const obj = parsed as Record<string, unknown>;
+
+  return {
+    agentName: requireString(obj, "agentName"),
+    scratchRoot: requireString(obj, "scratchRoot"),
+    busRoot: requireString(obj, "busRoot"),
+    description: optionalString(obj, "description"),
+    tier: optionalString(obj, "tier"),
+    type: optionalString(obj, "type"),
+    rpcSock: optionalString(obj, "rpcSock"),
+    delegationId: optionalString(obj, "delegationId"),
+    skills: stringList(obj, "skills"),
+    agents: stringList(obj, "agents"),
+    noEditAdd: stringList(obj, "noEditAdd"),
+    noEditSkip: stringList(obj, "noEditSkip"),
+  };
+}
+
+export function setHabitat(h: Habitat): void {
+  (globalThis as { __pi_habitat__?: Habitat }).__pi_habitat__ = h;
+}
+
+export function getHabitat(): Habitat {
+  const h = (globalThis as { __pi_habitat__?: Habitat }).__pi_habitat__;
+  if (!h) throw new Error("getHabitat: Habitat has not been materialised yet; habitat.ts extension must load first");
+  return h;
+}

--- a/pi-sandbox/.pi/extensions/agent-bus.ts
+++ b/pi-sandbox/.pi/extensions/agent-bus.ts
@@ -21,6 +21,7 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
+import { getHabitat } from "./_lib/habitat";
 
 interface Envelope {
   v: 1;
@@ -65,14 +66,8 @@ function getState(): BusState {
   });
 }
 
-function resolveBusRoot(pi: ExtensionAPI, sandboxRoot: string): string {
-  const flag = pi.getFlag("agent-bus-root") as string | undefined;
-  if (flag) return path.resolve(flag);
-  // PI_AGENT_BUS_ROOT is also honored by the runner; reading it here
-  // covers the case where pi was launched directly without the runner.
-  if (process.env.PI_AGENT_BUS_ROOT) return path.resolve(process.env.PI_AGENT_BUS_ROOT);
-  return path.join(os.homedir(), ".pi-agent-bus", path.basename(sandboxRoot));
-}
+// busRoot and agentName are resolved from the Habitat materialised by
+// the habitat baseline extension before this session_start runs.
 
 function probeSocketLive(sockPath: string, timeoutMs = 200): Promise<boolean> {
   return new Promise((resolve) => {
@@ -244,23 +239,24 @@ async function listLivePeers(state: BusState): Promise<{ name: string; addr: str
 }
 
 export default function (pi: ExtensionAPI) {
-  pi.registerFlag("agent-bus-root", {
-    description: "Rendezvous directory for inter-agent Unix sockets (one .sock per agent name)",
-    type: "string",
-  });
-
   const state = getState();
   state.pi = pi;
 
   pi.on("session_start", async (_event, ctx) => {
-    // pi.getFlag is scoped to the calling extension, so reading flags
-    // owned by sandbox/agent-header doesn't work cross-extension. The
-    // runner mirrors agent-name into PI_AGENT_NAME for us; sandbox-root
-    // equals ctx.cwd because the runner spawns pi with cwd=sandboxRoot.
-    const name = (process.env.PI_AGENT_NAME || "anonymous").trim() || "anonymous";
-    const sandboxRoot = path.resolve(ctx.cwd);
+    let name = "anonymous";
+    let busRoot: string;
+    try {
+      const h = getHabitat();
+      name = (h.agentName || "anonymous").trim() || "anonymous";
+      busRoot = path.resolve(h.busRoot);
+    } catch {
+      // Habitat not available (direct pi invocation); fall back to ctx.cwd-derived defaults.
+      name = (process.env.PI_AGENT_NAME || "anonymous").trim() || "anonymous";
+      const sandboxRoot = path.resolve(ctx.cwd);
+      busRoot = path.join(os.homedir(), ".pi-agent-bus", path.basename(sandboxRoot));
+    }
     state.name = name;
-    state.busRoot = resolveBusRoot(pi, sandboxRoot);
+    state.busRoot = busRoot;
 
     try {
       await bindServer(state, ctx);

--- a/pi-sandbox/.pi/extensions/agent-footer.ts
+++ b/pi-sandbox/.pi/extensions/agent-footer.ts
@@ -1,35 +1,14 @@
 // agent-footer — replaces pi's default footer with one that fits the
 // `npm run agent` rails:
-//   line 1, left:  the `--sandbox-root` flag value (home replaced by
-//                  ~), instead of pi's `cwd (branch)`. The agent can't
-//                  escape the sandbox so the host cwd / branch are
-//                  misleading noise.
+//   line 1, left:  the sandbox scratch root (home replaced by ~).
 //   line 1, right: comma-separated active tools from pi.getActiveTools()
-//                  — the recipe's `tools:` allowlist plus any tools
-//                  registered by extensions. `delegate` and
-//                  `approve_delegation` are hidden because every
-//                  delegating agent has them; they're noise next to
-//                  the tools that actually distinguish the recipe.
-//                  Truncated with an ellipsis on narrow terminals;
-//                  dropped entirely if there is no room for a 2-column
-//                  gap after the sandbox path.
-//   line 2 (opt):  the recipe's `skills:` list on the left and the
-//                  recipes this agent may `delegate` to on the right
-//                  (comma-separated, no labels — matches line 1's
-//                  bare-list style). Read from the PI_AGENT_SKILLS /
-//                  PI_AGENT_AGENTS env vars set by the runner
-//                  (pi.getFlag is scoped per extension, so
-//                  cross-extension flag reads have to bounce through
-//                  env, mirroring how agent-status-reporter reads
-//                  --rpc-sock). Skipped when both lists are empty.
-//   line 3, left:  `<bar>| $cost` — 5-cell eighths-block context-usage
-//                  bar (warning tint > 70%, error tint > 90%), followed
-//                  by the accumulated assistant cost from session
-//                  history. pi's default token-flow stats (↑input,
-//                  ↓output, cache R/W, /<window-size>) are
-//                  intentionally dropped.
+//                  — `delegate` and `approve_delegation` hidden.
+//   line 2 (opt):  skills list on the left, agent delegation list on
+//                  the right. Both read from getHabitat(). Skipped when
+//                  both are empty.
+//   line 3, left:  `<bar>| $cost` — 5-cell context-usage bar + cost.
 //   line 3, right: model id.
-//   line 4 (opt):  extension status texts set via ctx.ui.setStatus().
+//   line 4 (opt):  extension status texts.
 
 import os from "node:os";
 import path from "node:path";
@@ -37,6 +16,7 @@ import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { renderBar } from "./_lib/context-bar";
+import { getHabitat } from "./_lib/habitat";
 
 function homeReplace(p: string): string {
   const home = os.homedir();
@@ -50,19 +30,7 @@ function sanitizeStatusText(text: string): string {
   return text.replace(/[\r\n\t]/g, " ").replace(/ +/g, " ").trim();
 }
 
-// Tools that every delegating agent gets via the implicit-wire in
-// run-agent.mjs. Always-on tools tell the user nothing about the
-// recipe, so we drop them from the line-1 tool list — agents-it-can-
-// spawn is conveyed on line 2 instead.
 const HIDDEN_TOOLS = new Set(["delegate", "approve_delegation"]);
-
-function parseEnvList(value: string | undefined): string[] {
-  if (!value) return [];
-  return value
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-}
 
 function renderLeftRight(
   width: number,
@@ -94,10 +62,18 @@ function renderLeftRight(
 
 export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
-    const root = path.resolve((pi.getFlag("sandbox-root") as string | undefined) || ctx.cwd);
-    const displayRoot = homeReplace(root);
-    const skills = parseEnvList(process.env.PI_AGENT_SKILLS);
-    const agents = parseEnvList(process.env.PI_AGENT_AGENTS);
+    let scratchRoot = path.resolve(ctx.cwd);
+    let skills: string[] = [];
+    let agents: string[] = [];
+    try {
+      const h = getHabitat();
+      scratchRoot = path.resolve(h.scratchRoot);
+      skills = h.skills;
+      agents = h.agents;
+    } catch {
+      // Habitat not available; fall back to ctx.cwd with empty lists.
+    }
+    const displayRoot = homeReplace(scratchRoot);
 
     ctx.ui.setFooter((_tui, theme, footerData) => ({
       invalidate() {},

--- a/pi-sandbox/.pi/extensions/agent-header.ts
+++ b/pi-sandbox/.pi/extensions/agent-header.ts
@@ -1,12 +1,8 @@
 // agent-header — replaces pi's default startup header with a two-line
 // banner: the agent name (bold accent), optionally suffixed dim with the
 // model tier (e.g. "deferred-writer · Task Rabbit"), and the recipe
-// description on the next line (dim). Reads `--agent-name`,
-// `--agent-description`, and `--agent-tier`; the runner sets all three
-// from the recipe filename, `description:`, and `model:` (when the
-// latter is a tier var name). If none are set, the header stays empty
-// (no-startup-help's empty render keeps applying). Each flag can be
-// passed on the `npm run agent --` line to override the recipe.
+// description on the next line (dim). Reads identity fields from
+// getHabitat(); falls back gracefully when Habitat is unavailable.
 //
 // Pi wraps the header component in two `Spacer(1)` lines that aren't
 // removable via the public API, so the banner sits with one blank line
@@ -15,6 +11,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Container, Text } from "@mariozechner/pi-tui";
 import { prettify } from "./_lib/agent-naming";
+import { getHabitat } from "./_lib/habitat";
 
 // TASK_RABBIT_MODEL → "Task Rabbit"; LEAD_HARE_MODEL → "Lead Hare"; etc.
 function formatTier(tier: string): string {
@@ -27,28 +24,21 @@ function formatTier(tier: string): string {
 }
 
 export default function (pi: ExtensionAPI) {
-  pi.registerFlag("agent-name", {
-    description: "Agent name shown bold/accent on the first line of the TUI header banner",
-    type: "string",
-  });
-  pi.registerFlag("agent-description", {
-    description: "One-line description shown dim under the agent name in the TUI header banner",
-    type: "string",
-  });
-  pi.registerFlag("agent-tier", {
-    description: "Model tier var name (e.g. TASK_RABBIT_MODEL) appended dim after the agent name",
-    type: "string",
-  });
-  pi.registerFlag("agent-type", {
-    description: "Recipe filename (e.g. deferred-author); prettified into a type label before the description",
-    type: "string",
-  });
-
   pi.on("session_start", async (_event, ctx) => {
-    const name = (pi.getFlag("agent-name") as string | undefined)?.trim();
-    const description = (pi.getFlag("agent-description") as string | undefined)?.trim();
-    const tier = (pi.getFlag("agent-tier") as string | undefined)?.trim();
-    const type = (pi.getFlag("agent-type") as string | undefined)?.trim();
+    let name: string | undefined;
+    let description: string | undefined;
+    let tier: string | undefined;
+    let type: string | undefined;
+    try {
+      const h = getHabitat();
+      name = h.agentName?.trim() || undefined;
+      description = h.description?.trim() || undefined;
+      tier = h.tier?.trim() || undefined;
+      type = h.type?.trim() || undefined;
+    } catch {
+      // Habitat not available; render nothing.
+    }
+
     if (!name && !description && !type) return;
 
     const tierLabel = tier ? formatTier(tier) : "";
@@ -61,9 +51,8 @@ export default function (pi: ExtensionAPI) {
         // <breed>-<shortName> slug) with the prettified recipe
         // filename, giving "Cinnamon Deferred Author" rather than the
         // compact slug-prettify "Cinnamon Author". Falls back to plain
-        // prettify(name) when the runner didn't pass --agent-type or
-        // when --agent-name was manually overridden to a no-hyphen
-        // value (e.g. `-- --agent-name planner`).
+        // prettify(name) when --agent-type was not set or when
+        // agentName has no hyphen (e.g. a manually-set peer name).
         const breed = name.includes("-") ? name.split("-")[0] : "";
         const displayName = typeLabel && breed
           ? `${prettify(breed)} ${typeLabel}`

--- a/pi-sandbox/.pi/extensions/agent-spawn.ts
+++ b/pi-sandbox/.pi/extensions/agent-spawn.ts
@@ -63,6 +63,7 @@ import { Type } from "typebox";
 import { parse as parseYaml } from "yaml";
 import { generateInstanceName } from "./_lib/agent-naming";
 import { requestHumanApproval, type ApprovalRequest } from "./deferred-confirm";
+import { getHabitat } from "./_lib/habitat";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
@@ -147,11 +148,6 @@ interface SpawnState {
 function getState(): SpawnState {
   const g = globalThis as { __pi_delegate_pending__?: SpawnState };
   return (g.__pi_delegate_pending__ ??= { pending: new Map(), cleanupRegistered: false });
-}
-
-function parseFlagList(raw: string | undefined): string[] {
-  if (!raw) return [];
-  return raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
 }
 
 /** Read the child recipe's `shortName:` and `model:` so the parent can
@@ -243,13 +239,6 @@ function finalText(p: PendingDelegation, exit: { code: number | null; signal: No
 }
 
 export default function (pi: ExtensionAPI) {
-  pi.registerFlag("allowed-agents", {
-    description:
-      "Comma-separated list of recipe names this agent may delegate to. " +
-      "Set by the runner from the recipe's `agents:` field.",
-    type: "string",
-  });
-
   const state = getState();
   ensureProcessCleanup(state);
 
@@ -284,7 +273,12 @@ export default function (pi: ExtensionAPI) {
       ),
     }),
     async execute(_id, params, signal, _onUpdate, ctx) {
-      const allowed = parseFlagList(pi.getFlag("allowed-agents") as string | undefined);
+      let allowed: string[] = [];
+      try {
+        allowed = getHabitat().agents;
+      } catch {
+        // Habitat not yet set; no allowed list — all recipes denied.
+      }
       if (allowed.length === 0 || !allowed.includes(params.recipe)) {
         return {
           content: [

--- a/pi-sandbox/.pi/extensions/agent-status-reporter.ts
+++ b/pi-sandbox/.pi/extensions/agent-status-reporter.ts
@@ -1,7 +1,7 @@
 // agent-status-reporter — child-side companion to agent-spawn's RPC server.
 //
-// When this agent runs as a delegated child (i.e. --rpc-sock is set), open
-// a long-lived connection to the parent's per-call RPC socket and push
+// When this agent runs as a delegated child (i.e. Habitat.rpcSock is set),
+// open a long-lived connection to the parent's per-call RPC socket and push
 // session-stat snapshots whenever the agent's state changes meaningfully
 // (turn boundaries, tool boundaries, provider responses). The parent's
 // agent-spawn caches the latest snapshot per delegation and the
@@ -9,11 +9,6 @@
 //
 // No-ops for top-level (non-delegated) runs — same gating idiom as
 // requestHumanApproval in deferred-confirm.
-//
-// Status updates run on the same socket pi already uses for end-of-turn
-// approval forwarding. The parent's net.createServer happily accepts
-// multiple concurrent connections; the long-lived status conn and the
-// short-lived approval conn(s) coexist without coordination.
 //
 // Failure semantics: best-effort. Connect failures, mid-session
 // disconnects, and EPIPE all settle silently after one 500 ms reconnect
@@ -23,6 +18,7 @@
 import net from "node:net";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { getHabitat } from "./_lib/habitat";
 
 const THROTTLE_MS = 250;
 const RECONNECT_DELAY_MS = 500;
@@ -134,18 +130,26 @@ function handleDisconnect(rt: ReporterRuntime, sockPath: string, ctx: ExtensionC
 
 export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
-    // pi.getFlag("rpc-sock") would only work for the extension that
-    // registered the flag (deferred-confirm). The runner mirrors the
-    // CLI value into PI_RPC_SOCK so cross-extension readers like this
-    // one can see it.
-    const sockPath = (process.env.PI_RPC_SOCK || "").trim();
+    // Read rpcSock, delegationId, and agentName from Habitat.
+    // Falls back to env vars so the extension keeps working if habitat.ts
+    // somehow loaded without a valid spec (e.g. a stale child invoked
+    // without the runner).
+    let sockPath = "";
+    let delegationId = "";
+    let agentName = "agent";
+    try {
+      const h = getHabitat();
+      sockPath = (h.rpcSock || "").trim();
+      delegationId = (h.delegationId || "").trim();
+      agentName = (h.agentName || "agent").trim() || "agent";
+    } catch {
+      sockPath = (process.env.PI_RPC_SOCK || "").trim();
+      delegationId = (process.env.PI_AGENT_DELEGATION_ID || "").trim();
+      agentName = (process.env.PI_AGENT_NAME || "agent").trim() || "agent";
+    }
+
     if (!sockPath) return; // top-level run, no parent to talk to
-
-    const delegationId = (process.env.PI_AGENT_DELEGATION_ID || "").trim();
     if (!delegationId) return; // spawned without a delegation id; can't be routed
-
-    const agentName =
-      ((pi.getFlag("agent-name") as string | undefined) || process.env.PI_AGENT_NAME || "agent").trim();
 
     const rt: ReporterRuntime = {
       sock: null,

--- a/pi-sandbox/.pi/extensions/habitat.ts
+++ b/pi-sandbox/.pi/extensions/habitat.ts
@@ -1,0 +1,69 @@
+// habitat — baseline extension that materialises the per-instance
+// containment perimeter once at session_start and stashes it on
+// globalThis for all other rails to read via getHabitat().
+//
+// The runner serialises the fully-resolved Habitat into a single
+// --habitat-spec <json> flag. On fallback (direct `pi` invocations
+// without the runner), a minimal Habitat is assembled from ctx.cwd
+// and PI_AGENT_NAME so the session still boots cleanly.
+//
+// This extension must be first in BASELINE_EXTENSIONS so it runs
+// before any rail that calls getHabitat() in its own session_start.
+
+import os from "node:os";
+import path from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { materialiseHabitat, setHabitat, type Habitat } from "./_lib/habitat";
+
+export default function (pi: ExtensionAPI) {
+  pi.registerFlag("habitat-spec", {
+    description: "JSON-serialised Habitat spec built by scripts/run-agent.mjs",
+    type: "string",
+  });
+
+  pi.on("session_start", async (_event, ctx) => {
+    const raw = (pi.getFlag("habitat-spec") as string | undefined)?.trim();
+
+    if (raw) {
+      try {
+        const h = materialiseHabitat(raw);
+        setHabitat(h);
+        if (process.env.AGENT_DEBUG === "1") {
+          const dump = `habitat: agentName=${h.agentName} scratchRoot=${h.scratchRoot} busRoot=${h.busRoot}`;
+          ctx.ui.notify(dump, "info");
+          process.stderr.write(`[AGENT_DEBUG] ${dump}\n`);
+        }
+        return;
+      } catch (e) {
+        ctx.ui.notify(`habitat: malformed --habitat-spec: ${(e as Error).message}`, "warning");
+        // fall through to fallback
+      }
+    }
+
+    // Fallback for direct `pi` invocations that don't pass --habitat-spec.
+    const agentName = (process.env.PI_AGENT_NAME || "anonymous").trim() || "anonymous";
+    const scratchRoot = path.resolve(ctx.cwd);
+    const busRoot =
+      process.env.PI_AGENT_BUS_ROOT ||
+      path.join(os.homedir(), ".pi-agent-bus", path.basename(scratchRoot));
+
+    const fallback: Habitat = {
+      agentName,
+      scratchRoot,
+      busRoot,
+      skills: [],
+      agents: [],
+      noEditAdd: [],
+      noEditSkip: [],
+      rpcSock: process.env.PI_RPC_SOCK || undefined,
+      delegationId: process.env.PI_AGENT_DELEGATION_ID || undefined,
+    };
+    setHabitat(fallback);
+
+    if (process.env.AGENT_DEBUG === "1") {
+      const dump = `habitat: fallback agentName=${fallback.agentName} scratchRoot=${fallback.scratchRoot}`;
+      ctx.ui.notify(dump, "info");
+      process.stderr.write(`[AGENT_DEBUG] ${dump}\n`);
+    }
+  });
+}

--- a/pi-sandbox/.pi/extensions/no-edit.ts
+++ b/pi-sandbox/.pi/extensions/no-edit.ts
@@ -13,15 +13,14 @@
 //   pi.getAllTools(); the static fallback covers pi 0.70's built-in
 //   `write` plus our `deferred_write`.
 //
-// Recipe overrides (forwarded by scripts/run-agent.mjs):
-//   noEditAdd:  [tool, ...]   →  --no-edit-add  <a,b,...>   (force-include)
-//   noEditSkip: [tool, ...]   →  --no-edit-skip <a,b,...>   (force-exclude)
-// The sandbox-root path used to compare resolved targets is read from
-// the `--sandbox-root` flag (registered by the sandbox extension).
+// Recipe overrides via Habitat (getHabitat().noEditAdd / noEditSkip),
+// forwarded by scripts/run-agent.mjs from the recipe's noEditAdd /
+// noEditSkip fields.
 
 import fs from "node:fs";
 import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { getHabitat } from "./_lib/habitat";
 
 const STATIC_CREATE_ONLY_TOOLS = ["write", "deferred_write"];
 const CONTENT_KEYS = ["content", "text", "body"];
@@ -36,21 +35,7 @@ function declaresWriteShape(parameters: unknown): boolean {
   }
 }
 
-function parseFlagList(raw: string | undefined): string[] {
-  if (!raw) return [];
-  return raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
-}
-
 export default function (pi: ExtensionAPI) {
-  pi.registerFlag("no-edit-add", {
-    description: "Comma-separated extra tools to force-include in the no-edit (create-only) rail",
-    type: "string",
-  });
-  pi.registerFlag("no-edit-skip", {
-    description: "Comma-separated tools to exempt from the no-edit (create-only) rail",
-    type: "string",
-  });
-
   const createOnlyTools = new Set<string>(STATIC_CREATE_ONLY_TOOLS);
 
   pi.on("session_start", async (_event, ctx) => {
@@ -65,8 +50,17 @@ export default function (pi: ExtensionAPI) {
       );
     }
 
-    for (const t of parseFlagList(pi.getFlag("no-edit-add") as string | undefined)) createOnlyTools.add(t);
-    for (const t of parseFlagList(pi.getFlag("no-edit-skip") as string | undefined)) createOnlyTools.delete(t);
+    let noEditAdd: string[] = [];
+    let noEditSkip: string[] = [];
+    try {
+      const h = getHabitat();
+      noEditAdd = h.noEditAdd;
+      noEditSkip = h.noEditSkip;
+    } catch {
+      // Habitat not yet set; use empty lists (no recipe overrides).
+    }
+    for (const t of noEditAdd) createOnlyTools.add(t);
+    for (const t of noEditSkip) createOnlyTools.delete(t);
 
     if (process.env.AGENT_DEBUG === "1") {
       const dump = `no-edit createOnlyTools = [${[...createOnlyTools].sort().join(", ")}]`;
@@ -85,7 +79,12 @@ export default function (pi: ExtensionAPI) {
     const raw = (event.input as Record<string, unknown>).path;
     if (typeof raw !== "string" || raw.length === 0) return undefined;
 
-    const root = path.resolve((pi.getFlag("sandbox-root") as string | undefined) || process.cwd());
+    let root: string;
+    try {
+      root = path.resolve(getHabitat().scratchRoot);
+    } catch {
+      root = path.resolve(process.cwd());
+    }
     const abs = path.isAbsolute(raw) ? raw : path.resolve(root, raw);
 
     if (fs.existsSync(abs)) {

--- a/pi-sandbox/.pi/extensions/sandbox.ts
+++ b/pi-sandbox/.pi/extensions/sandbox.ts
@@ -8,18 +8,16 @@
 // installed pi 0.70 built-ins; introspection automatically picks up
 // custom tools (including deferred_write) and any future built-ins.
 //
-// Sandbox root is read from the `--sandbox-root` flag (set by
-// scripts/run-agent.mjs) and falls back to ctx.cwd. The runner spawns pi
-// with cwd = sandbox root, so a missing/empty `path` (which the built-in
-// tools resolve to ".") is always inside the root. This extension owns
-// the `--sandbox-root` flag; the agent-footer, deferred-write, and
-// no-edit extensions read it via pi.getFlag.
+// Sandbox root is read from getHabitat().scratchRoot (materialised by
+// the habitat baseline extension before this session_start runs).
+// Falls back to ctx.cwd for direct `pi` invocations without the runner.
 //
 // Footer rendering (sandbox dir, tools list, stats) lives in the
 // `agent-footer` extension.
 
 import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { getHabitat } from "./_lib/habitat";
 
 const STATIC_PATH_TOOLS = ["read", "write", "edit", "ls", "grep", "find"];
 
@@ -33,11 +31,6 @@ function declaresPathString(parameters: unknown): boolean {
 }
 
 export default function (pi: ExtensionAPI) {
-  pi.registerFlag("sandbox-root", {
-    description: "Root directory for the sandbox; tool calls outside it are blocked",
-    type: "string",
-  });
-
   const pathTools = new Set<string>(STATIC_PATH_TOOLS);
 
   pi.on("session_start", async (_event, ctx) => {
@@ -66,7 +59,13 @@ export default function (pi: ExtensionAPI) {
 
     if (!pathTools.has(event.toolName)) return undefined;
 
-    const root = path.resolve((pi.getFlag("sandbox-root") as string | undefined) || ctx.cwd);
+    let root: string;
+    try {
+      root = path.resolve(getHabitat().scratchRoot);
+    } catch {
+      root = path.resolve(ctx.cwd);
+    }
+
     const input = event.input as Record<string, unknown>;
     const raw = input.path;
     if (raw !== undefined && typeof raw !== "string") return undefined;

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -15,6 +15,8 @@ const SKILLS_DIR = path.join(SANDBOX_ROOT, "skills");
 const PI_BIN = path.join(REPO_ROOT, "node_modules", ".bin", "pi");
 
 const BASELINE_EXTENSIONS = [
+  // Must be first — materialises the Habitat before any rail reads it.
+  "habitat",
   "sandbox",
   "no-startup-help",
   "agent-header",
@@ -282,14 +284,11 @@ const piArgs = [
 ];
 for (const p of extensionPaths) piArgs.push("-e", p);
 for (const p of skillPaths) piArgs.push("--skill", p);
-piArgs.push("--sandbox-root", sandboxRoot);
 
-// Pull --agent-name and --rpc-sock out of passthrough so we can mirror
-// them to env vars. pi.getFlag is scoped to the extension that
-// registered the flag, so cross-extension reads need to bounce through
-// the env (already the case for --agent-name read by agent-bus, and
-// now --rpc-sock read by agent-status-reporter while deferred-confirm
-// owns the flag registration).
+// Pull --agent-name and --rpc-sock out of passthrough.
+// --rpc-sock is kept in passthrough so deferred-confirm still sees it
+// via its own flag registration; it is also carried in the Habitat spec
+// so agent-status-reporter can read it from getHabitat() instead of env.
 let agentName = null;                                     // null → generate
 let rpcSock = "";
 const passthrough = [];
@@ -298,7 +297,6 @@ for (let i = 0; i < args.passthrough.length; i++) {
     agentName = args.passthrough[++i];                    // manual override wins
   } else if (args.passthrough[i] === "--rpc-sock" && i + 1 < args.passthrough.length) {
     rpcSock = args.passthrough[++i];
-    // Keep --rpc-sock in passthrough too so deferred-confirm still sees it.
     passthrough.push("--rpc-sock", rpcSock);
   } else {
     passthrough.push(args.passthrough[i]);
@@ -324,50 +322,45 @@ if (agentName === null) {
   const taken = await probeBusRoot(busRoot);
   agentName = generateInstanceName({ tier, shortName, taken });
 }
-piArgs.push("--agent-name", agentName);
 
-// Only push extension-owned flags when their owning extension is
-// actually loaded; otherwise pi rejects the flag as unknown.
-const usesBus = wired.extensions.includes("agent-bus");
-if (usesBus) piArgs.push("--agent-bus-root", busRoot);
-if (wired.allowed.length > 0) piArgs.push("--allowed-agents", wired.allowed.join(","));
-if (typeof recipe.description === "string" && recipe.description.trim()) {
-  piArgs.push("--agent-description", recipe.description.trim());
-}
-// Recipe filename, prettified by the header into a "type" label rendered
-// before the description on line 2 (e.g. "Deferred Author · Drafts …").
-piArgs.push("--agent-type", args.name);
-if (TIER_VARS.has(recipeModel)) {
-  piArgs.push("--agent-tier", recipeModel);
-}
-if (Array.isArray(recipe.noEditAdd) && recipe.noEditAdd.length > 0) {
-  piArgs.push("--no-edit-add", recipe.noEditAdd.join(","));
-}
-if (Array.isArray(recipe.noEditSkip) && recipe.noEditSkip.length > 0) {
-  piArgs.push("--no-edit-skip", recipe.noEditSkip.join(","));
-}
+const recipeSkills = Array.isArray(recipe.skills) ? recipe.skills.filter((s) => typeof s === "string") : [];
+
+// Serialise the resolved Habitat into one --habitat-spec flag instead of
+// many individual flags + env-var mirrors. The habitat.ts baseline
+// extension materialises this at session_start; all other rails read
+// their axis from getHabitat() rather than re-parsing flags/env.
+// PI_AGENT_DELEGATION_ID is set by agent-spawn in the child's env before
+// calling the runner. Include it in the spec so agent-status-reporter
+// can read it from getHabitat() rather than from env.
+const delegationId = process.env.PI_AGENT_DELEGATION_ID || "";
+
+const habitatSpec = {
+  agentName,
+  scratchRoot: sandboxRoot,
+  busRoot,
+  skills: recipeSkills,
+  agents: wired.allowed,
+  noEditAdd: Array.isArray(recipe.noEditAdd) ? recipe.noEditAdd.filter((s) => typeof s === "string") : [],
+  noEditSkip: Array.isArray(recipe.noEditSkip) ? recipe.noEditSkip.filter((s) => typeof s === "string") : [],
+  ...(typeof recipe.description === "string" && recipe.description.trim()
+    ? { description: recipe.description.trim() }
+    : {}),
+  ...(TIER_VARS.has(recipeModel) ? { tier: recipeModel } : {}),
+  type: args.name,
+  ...(rpcSock ? { rpcSock } : {}),
+  ...(delegationId ? { delegationId } : {}),
+};
+piArgs.push("--habitat-spec", JSON.stringify(habitatSpec));
 piArgs.push(...args.passthrough);
 
 if (!existsSync(PI_BIN)) die(`pi binary missing: ${PI_BIN} (run npm install)`);
 
-const recipeSkills = Array.isArray(recipe.skills) ? recipe.skills.filter((s) => typeof s === "string") : [];
-
 const child = spawn(PI_BIN, piArgs, {
   cwd: sandboxRoot,
   stdio: "inherit",
-  // Mirror the agent name + bus root + rpc sock into env vars so
-  // extensions that can't read the CLI flags via pi.getFlag (which is
-  // scoped per extension) still see them. Skills and allowed-agents
-  // are mirrored too so agent-footer can render them on its third
-  // line without duplicating flag registrations.
-  env: {
-    ...process.env,
-    PI_AGENT_NAME: agentName,
-    PI_AGENT_BUS_ROOT: busRoot,
-    PI_AGENT_SKILLS: recipeSkills.join(","),
-    PI_AGENT_AGENTS: wired.allowed.join(","),
-    ...(rpcSock ? { PI_RPC_SOCK: rpcSock } : {}),
-  },
+  // PI_AGENT_DELEGATION_ID is set by agent-spawn when it spawns a child,
+  // not by the runner. It stays as an env var until Phase 5.
+  env: { ...process.env },
 });
 
 child.on("exit", (code, signal) => {


### PR DESCRIPTION
## Summary

Refactor agent configuration from scattered CLI flags and environment variables into a single `Habitat` interface that is materialized once at session start and shared across all extensions via `getHabitat()`. This eliminates cross-extension flag-reading workarounds and env-var mirroring, making the codebase more maintainable and the data flow explicit.

## Key Changes

- **New `Habitat` interface** (`pi-sandbox/.pi/extensions/_lib/habitat.ts`): Defines the per-instance containment perimeter with identity (agentName, description, tier, type), filesystem (scratchRoot), bus (busRoot), recipe metadata (skills, agents), no-edit rail config (noEditAdd, noEditSkip), and delegation context (rpcSock, delegationId).

- **New `habitat` baseline extension** (`pi-sandbox/.pi/extensions/habitat.ts`): Materializes the Habitat from a `--habitat-spec` JSON flag at session_start (or falls back to env vars for direct `pi` invocations). Stashes it on `globalThis.__pi_habitat__` for all other extensions to read via `getHabitat()`. Must load first in BASELINE_EXTENSIONS.

- **Runner refactoring** (`scripts/run-agent.mjs`): Builds a complete Habitat spec object from recipe metadata, resolved agent name, bus root, and delegation context, then passes it as a single `--habitat-spec` JSON flag instead of multiple individual flags. Removes env-var mirroring (PI_AGENT_NAME, PI_AGENT_BUS_ROOT, PI_AGENT_SKILLS, PI_AGENT_AGENTS, PI_RPC_SOCK).

- **Extension updates**: All extensions that previously read scattered flags or env vars now call `getHabitat()` instead:
  - `agent-header.ts`: Reads agentName, description, tier, type from Habitat
  - `agent-footer.ts`: Reads scratchRoot, skills, agents from Habitat
  - `agent-bus.ts`: Reads agentName, busRoot from Habitat
  - `sandbox.ts`: Reads scratchRoot from Habitat
  - `no-edit.ts`: Reads noEditAdd, noEditSkip from Habitat
  - `agent-status-reporter.ts`: Reads rpcSock, delegationId, agentName from Habitat
  - `agent-spawn.ts`: Reads agents from Habitat

- **Comprehensive test suite** (`pi-sandbox/.pi/extensions/_lib/habitat.test.ts`): 158 lines of vitest coverage for materialiseHabitat, setHabitat, and getHabitat with validation of required fields, optional fields, list filtering, and error cases.

## Implementation Details

- Habitat materialization is defensive: required fields (agentName, scratchRoot, busRoot) throw on missing/non-string values; optional string fields default to undefined; list fields filter to strings only and default to [].
- Extensions gracefully degrade when Habitat is unavailable (e.g., direct `pi` invocations), falling back to ctx.cwd and env vars.
- The fallback path in habitat.ts constructs a minimal Habitat from PI_AGENT_NAME and PI_AGENT_BUS_ROOT env vars, ensuring the session boots cleanly even without the runner.
- All flag registrations for agent-name, agent-description, agent-tier, agent-type, agent-bus-root, allowed-agents, no-edit-add, no-edit-skip, and sandbox-root are removed; these are now read from Habitat instead.

https://claude.ai/code/session_01U9RHNHajXbEbr8rDetEmyC