### PR TITLE
Migrate agent bus configuration to Habitat spec

### DIFF
--- a/pi-sandbox/.pi/extensions/agent-bus.ts
+++ b/pi-sandbox/.pi/extensions/agent-bus.ts
@@ -5,11 +5,14 @@
 // message on its next turn via pi.sendUserMessage. The same buffer is
 // also pull-readable via the agent_inbox tool.
 //
-// Bus root resolution: --agent-bus-root flag → $PI_AGENT_BUS_ROOT →
-// ~/.pi-agent-bus/<basename(sandbox-root)>. Deliberately lives outside
-// --sandbox-root so the sandbox extension's path rejection doesn't trip.
-// The bus extension only opens sockets, never invokes path-bearing
-// built-in tools, so the sandbox allowlist is unaffected.
+// busRoot and agentName are read from getHabitat() (materialised by the
+// habitat baseline extension before this session_start runs). The
+// resolution chain (--agent-bus → $PI_AGENT_BUS_ROOT → default) happens
+// in scripts/run-agent.mjs and lands as Habitat.busRoot. The bus root
+// deliberately lives outside scratchRoot so the sandbox extension's
+// path rejection doesn't trip on socket paths; the bus extension only
+// opens sockets, never invokes path-bearing tools, so the sandbox
+// allowlist is unaffected.
 //
 // Companion to agent-spawn (blocking delegation). The two are
 // orthogonal: a recipe loads either, both, or neither.

--- a/pi-sandbox/.pi/extensions/deferred-confirm.ts
+++ b/pi-sandbox/.pi/extensions/deferred-confirm.ts
@@ -19,6 +19,7 @@
 
 import net from "node:net";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { getHabitat } from "./_lib/habitat";
 
 export interface DeferredHandler {
   /** Section header in the unified confirm preview ("Writes", "Edits", "Moves", "Deletes"). */
@@ -81,7 +82,8 @@ export async function requestHumanApproval(
   if (ctx.hasUI) {
     return ctx.ui.confirm(req.title, req.preview);
   }
-  const sockPath = pi.getFlag("rpc-sock") as string | undefined;
+  let sockPath: string | undefined;
+  try { sockPath = getHabitat().rpcSock; } catch { sockPath = undefined; }
   if (sockPath) {
     return rpcRequestApproval(sockPath, req);
   }
@@ -151,13 +153,6 @@ function tell(ctx: ExtensionContext, level: "info" | "error", message: string) {
 }
 
 export default function (pi: ExtensionAPI) {
-  pi.registerFlag("rpc-sock", {
-    description:
-      "Unix socket path used to forward end-of-turn approval requests to a parent agent. " +
-      "Set by agent-spawn when launching a child; leave unset for interactive runs.",
-    type: "string",
-  });
-
   pi.on("agent_end", async (_event, ctx) => {
     if (handlers.length === 0) return;
 

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -285,10 +285,9 @@ const piArgs = [
 for (const p of extensionPaths) piArgs.push("-e", p);
 for (const p of skillPaths) piArgs.push("--skill", p);
 
-// Pull --agent-name and --rpc-sock out of passthrough.
-// --rpc-sock is kept in passthrough so deferred-confirm still sees it
-// via its own flag registration; it is also carried in the Habitat spec
-// so agent-status-reporter can read it from getHabitat() instead of env.
+// --agent-name passthrough is parsed only to capture the value into the
+// Habitat spec; pi receives it solely via --habitat-spec. Same for
+// --rpc-sock since deferred-confirm now reads getHabitat().rpcSock.
 let agentName = null;                                     // null → generate
 let rpcSock = "";
 const passthrough = [];
@@ -297,7 +296,7 @@ for (let i = 0; i < args.passthrough.length; i++) {
     agentName = args.passthrough[++i];                    // manual override wins
   } else if (args.passthrough[i] === "--rpc-sock" && i + 1 < args.passthrough.length) {
     rpcSock = args.passthrough[++i];
-    passthrough.push("--rpc-sock", rpcSock);
+    // do not push --rpc-sock into passthrough; pi no longer registers this flag
   } else {
     passthrough.push(args.passthrough[i]);
   }


### PR DESCRIPTION
## Summary
Refactor agent bus and RPC socket configuration to use the Habitat spec instead of command-line flags, reducing flag proliferation and centralizing configuration management.

## Key Changes
- **agent-bus.ts**: Updated documentation to reflect that `busRoot` and `agentName` are now read from `getHabitat()` rather than command-line flags. The resolution chain (--agent-bus → $PI_AGENT_BUS_ROOT → default) now happens in `scripts/run-agent.mjs` and lands in `Habitat.busRoot`.

- **deferred-confirm.ts**: 
  - Removed the `rpc-sock` flag registration from the extension
  - Changed RPC socket resolution to read from `getHabitat().rpcSock` instead of `pi.getFlag("rpc-sock")`
  - Added import of `getHabitat` utility function
  - Added error handling for cases where Habitat is unavailable

- **scripts/run-agent.mjs**:
  - Removed `--rpc-sock` from passthrough arguments to pi (since pi no longer registers this flag)
  - Updated comments to clarify that both `--agent-name` and `--rpc-sock` are parsed only to capture values into the Habitat spec
  - Both values are now passed to pi solely via `--habitat-spec` instead of individual flags

## Implementation Details
This change consolidates configuration that was previously scattered across multiple command-line flags into a single Habitat specification object. The `run-agent.mjs` script continues to parse the original flags for backward compatibility but no longer passes them through to the pi process. Extensions now access this configuration through the `getHabitat()` function, which provides a cleaner, more maintainable approach to sharing configuration across the agent ecosystem.

https://claude.ai/code/session_01PRCvNhtkq2ToJWNVoEP2qa