### PR TITLE
Add Phase 3 planning documents for supervisor rail & habitat

### DIFF
--- a/docs/phases/_notes-for-phase-3.md
+++ b/docs/phases/_notes-for-phase-3.md
@@ -1,0 +1,52 @@
+# Notes for Phase 3 plan
+
+Scratch file — a place to stash forward-looking observations from earlier phases that Phase 3's planner needs to see. Delete this file when Phase 3 plan is written (its contents fold into the plan's "Inherited state" / "Required reading" / "Out of scope" sections as appropriate).
+
+This file is **not a plan**. It's a memo for the plan author.
+
+---
+
+## What's already done re: `deferred-confirm`
+
+Phase 2 + a follow-up cleanup commit (PR #54) slimmed `deferred-confirm.ts` along with the seven other rails: it now reads `rpcSock` from `getHabitat()` via the same try/catch pattern as `sandbox.ts` and friends. The `--rpc-sock` pi flag is gone. `requestHumanApproval`'s logic — UI → rpc-sock → loud-fail — is unchanged in shape, just sourcing differently.
+
+Phase 3 therefore inherits a `deferred-confirm` that is already Habitat-aware. When Phase 3 builds the supervisor inbound rail and `respond_to_request` tool, it can:
+
+- Move `requestHumanApproval` and the `rpcRequestApproval` helper out of `deferred-confirm.ts` into the new shared module that owns the inbound/outbound envelope handling. `deferred-confirm` becomes a *user* of that module, not the owner of the escalation primitive (which it accidentally became in main; see ADR-0001's "homeless primitive" framing).
+- Drop `Habitat.rpcSock` once the bus has subsumed approval forwarding (escalation goes via `agent_call({to: supervisor, kind: "approval-request"})` instead of via the per-call Unix socket). At that point `--rpc-sock` and `agent-spawn`'s per-call sockets disappear together — but that's late-Phase-3 / Phase-5, not the opening move.
+
+What Phase 3 does **not** need to do: re-slim `deferred-confirm` (already done), introduce a `getHabitat().rpcSock` read anywhere new (existing readers cover the use cases), or untangle the deferred-confirm-as-escalation-primitive mixup (Phase 3's new shared module is what untangles it).
+
+## `agent_call`'s silent-empty-string for non-message replies
+
+Phase 1 spot-check observation. In `agent-bus.ts`'s `handleIncoming`:
+
+```ts
+if (env.in_reply_to) {
+  const pending = state.pendingCalls.get(env.in_reply_to);
+  if (pending) {
+    clearTimeout(pending.timer);
+    state.pendingCalls.delete(env.in_reply_to);
+    pending.resolve(env.payload.kind === "message" ? env.payload.text : "");
+    return;
+  }
+}
+```
+
+The `env.payload.kind === "message" ? env.payload.text : ""` branch was forward-compat for Phase 3+ when new payload kinds arrive. **Phase 3 will hit this:** when an `approval-result` or `submission` envelope arrives as a reply to a pending `agent_call`, this code silently resolves with `""`.
+
+Phase 3 needs to decide:
+
+- **(a)** Reject the pending promise with a typed-mismatch error: *"agent_call expected a message-kind reply, got submission"*. Forces callers to know what kind of reply they expect (which they typically do at the call site).
+- **(b)** Extend `agent_call` to accept and return typed replies: e.g., `agent_call` resolves with the whole `Payload` object, callers destructure on `kind`. More disciplined; bigger API change.
+- **(c)** Add a separate `agent_call_typed({to, body, expect_kind})` that returns the typed payload, leaving `agent_call` as the message-only convenience.
+
+Recommendation: **(a)** for v1. Lowest API churn. The supervisor-handler pattern Phase 3 is building doesn't *use* `agent_call` for approval/submission round-trips anyway — those flow through the dedicated inbound rail. So `agent_call` stays a message-only convenience, and a non-message reply is simply a programming error worth surfacing loudly.
+
+## Stale comments in `agent-bus.ts` deferred to Phase 5
+
+The file-header comment block in `agent-bus.ts` calls itself a "Companion to agent-spawn (blocking delegation). The two are orthogonal." That sentence becomes wrong only when `agent-spawn` is deleted (Phase 5). Phase 3 should leave the comment alone; Phase 5's `agent-spawn`-deletion commit updates it.
+
+## Dead env-var fallback in `agent-status-reporter.ts`
+
+After Phase 2, the env-var fallback (`PI_RPC_SOCK`, `PI_AGENT_NAME`) is unreachable because the runner no longer sets those vars. The Phase 2 spot-check explicitly chose to leave it for uniformity with the try/catch pattern in other rails. Phase 3 doesn't need to touch this. It tidies naturally when Phase 5 deletes `agent-spawn` (which is what made `PI_AGENT_DELEGATION_ID` exist) — at that point the whole try/catch block can be removed.

--- a/docs/phases/phase-3a-envelope-kinds.md
+++ b/docs/phases/phase-3a-envelope-kinds.md
@@ -1,0 +1,139 @@
+# Phase 3a — extend `_lib/bus-envelope.ts` with new payload kinds
+
+**Goal.** Add `approval-request`, `approval-result`, `revision-requested`, and `submission` to the `Payload` discriminated union, plus the `Artifact` type the submission payload carries. Add constructors for each, extend `tryDecodeEnvelope` to validate the new kinds, extend `renderInboundForUser` to give them sensible fallbacks. Tests for everything.
+
+**Behaviour after this phase: identical to before.** Nothing emits or consumes the new kinds yet — they're encodable but no rail produces or routes them. Phase 3b/3c/4 wire them up. This is types + tests only.
+
+This file is deleted in the PR that ships Phase 3a.
+
+---
+
+## Prerequisite
+
+Phases 0.5, 0.6, 1, 2 (incl. cleanup) merged to main. `_lib/bus-envelope.ts` exists; `npm test` works.
+
+## Required reading
+
+- `pi-sandbox/.pi/extensions/_lib/bus-envelope.ts` and `bus-envelope.test.ts` — current state.
+- `docs/adr/0003-supervisor-llm-in-review-loop.md` — the four supervisor actions and the envelope kinds they imply.
+- `docs/adr/0001-mesh-subsumes-delegation.md` — the migration shape.
+- `docs/phases/_notes-for-phase-3.md` — inherited observations.
+
+## Skill to invoke
+
+`/tdd`. Tests first; the new kinds are pure data with discriminated-union shape — exactly the test-friendly territory.
+
+## Branch strategy
+
+Branch from latest `main`. Suggested: `claude/phase-3a-envelope-kinds`.
+
+```sh
+git fetch origin main
+git checkout -b claude/phase-3a-envelope-kinds origin/main
+npm test   # confirm vitest works
+```
+
+## Scope — what's in (TDD order)
+
+### Step 1 — tests first (red)
+
+In `pi-sandbox/.pi/extensions/_lib/bus-envelope.test.ts`, add:
+
+- `makeApprovalRequestEnvelope({from, to, title, summary, preview, in_reply_to?})` builds an envelope with `payload.kind === "approval-request"` and the three string fields.
+- `makeApprovalResultEnvelope({from, to, in_reply_to, approved, note?})` — `approved: boolean` required, `note: string` optional.
+- `makeRevisionRequestedEnvelope({from, to, in_reply_to, note})` — `note` required.
+- `makeSubmissionEnvelope({from, to, summary?, artifacts, in_reply_to?})` — `artifacts: Artifact[]`.
+- `tryDecodeEnvelope` accepts each new kind with valid fields; rejects each with type-mismatched / missing required fields. One assertion per malformed input.
+- `renderInboundForUser` produces:
+  - `[approval request from <peer>] <title>` for approval-request.
+  - `[approval result from <peer>: approved|rejected]` for approval-result.
+  - `[revise from <peer>] <note>` for revision-requested.
+  - `[submission from <peer>] <N> artifacts: <summary>` for submission.
+
+Run `npm test` — every new test fails (red). Confirms the harness sees them.
+
+### Step 2 — implementation (green)
+
+In `pi-sandbox/.pi/extensions/_lib/bus-envelope.ts`:
+
+```ts
+export type Artifact =
+  | { kind: "write"; relPath: string; content: string; sha256: string }
+  | { kind: "edit"; relPath: string; sha256OfOriginal: string;
+      edits: Array<{ oldString: string; newString: string }> }
+  | { kind: "move"; src: string; dst: string; sha256OfSource: string }
+  | { kind: "delete"; relPath: string; sha256: string };
+
+export type Payload =
+  | { kind: "message"; text: string }
+  | { kind: "approval-request"; title: string; summary: string; preview: string }
+  | { kind: "approval-result"; approved: boolean; note?: string }
+  | { kind: "revision-requested"; note: string }
+  | { kind: "submission"; artifacts: Artifact[]; summary?: string };
+```
+
+Constructors and decoder updates follow the existing pattern in the file. The decoder validates `Artifact[]` shape inside `submission` (each entry has a valid `kind` and the kind-specific required fields).
+
+### Step 3 — refactor
+
+Tighten naming, JSDoc, deduplicate validation helpers if useful. Tests stay green.
+
+## Scope — what's NOT in
+
+- **No `agent-bus.ts` changes.** `handleIncoming` already routes only `message` kind to inbox/pushToModel; non-message kinds get the existing `(${kind})` fallback in inbox rendering. Don't change `handleIncoming` in 3a — it gets its supervisor-routing dispatch in 3c.
+- **No new tools.** No `respond_to_request` (Phase 3c).
+- **No new rails.** No supervisor extension (Phase 3c).
+- **No Habitat changes.** New `supervisor`/`submitTo`/`acceptedFrom`/`peers` fields are Phase 3b.
+- **No actual sending of new-kind envelopes from anywhere.** Nothing in main code emits them yet.
+- **No `agent_call` typed-reply changes.** The pending-call resolution still resolves with `""` for non-message replies (forward-compat fallback). The fix lands in Phase 3c when there's an actual rail consuming the new kinds.
+
+## Step-by-step checklist
+
+```
+[ ]  1. Read prereqs + ADR-0003 + notes file.
+[ ]  2. Invoke /tdd.
+[ ]  3. Branch claude/phase-3a-envelope-kinds from main.
+
+  RED:
+[ ]  4. Add tests for the four constructors.
+[ ]  5. Add tests for tryDecodeEnvelope's new-kind validation
+        (happy path + per-field type mismatches + missing required fields).
+[ ]  6. Add tests for renderInboundForUser's new-kind output.
+        Confirm `npm test` shows them all failing.
+
+  GREEN:
+[ ]  7. Add Artifact type.
+[ ]  8. Extend Payload union.
+[ ]  9. Add four constructors.
+[ ] 10. Extend tryDecodeEnvelope's validation (including Artifact[] shape).
+[ ] 11. Extend renderInboundForUser to handle each kind.
+
+  REFACTOR:
+[ ] 12. Tighten naming, JSDoc; dedupe validation helpers.
+
+[ ] 13. npm test — all green.
+[ ] 14. Commit, push, delete this file in same PR.
+```
+
+## Testing
+
+Unit only. `npm test`. No tmux needed — nothing observably changes outside the test suite.
+
+## Acceptance criteria
+
+- All four constructors + Artifact type + extended decoder/renderer.
+- Tests cover happy paths + every malformed-input mode for new kinds.
+- Test count grows by roughly 25–35 assertions (4 constructors × 2-3 happy-path checks + 4 kinds × 3-5 malformed-input checks + 4 render cases).
+- `npm test` passes.
+- `agent-bus.ts`, all rails, all recipes — unchanged.
+- This file (`docs/phases/phase-3a-envelope-kinds.md`) deleted in the same commit/PR.
+
+## Hand-back
+
+Push to `origin/claude/phase-3a-envelope-kinds`. Report:
+
+- Commit SHA.
+- Output of `npm test` (assertion count delta).
+- Anything you found in the existing decoder/renderer code that needed cleanup along the way.
+
+Don't open a PR. The user reviews the branch directly.

--- a/docs/phases/phase-3b-habitat-peer-fields.md
+++ b/docs/phases/phase-3b-habitat-peer-fields.md
@@ -1,0 +1,150 @@
+# Phase 3b — extend Habitat with supervisor / submitTo / acceptedFrom / peers
+
+**Goal.** Add four optional fields to `Habitat` covering peer relationships, parse them in the materialiser, surface them through the runner from new optional recipe fields. No rail reads them yet.
+
+**Behaviour after this phase: identical to before.** Recipes can declare new fields without effect; existing recipes continue to work unchanged. The fields are *declarable* and *materialised* but inert until Phase 3c wires the rails that read them.
+
+This file is deleted in the PR that ships Phase 3b.
+
+---
+
+## Prerequisite
+
+Phase 3a merged to main. `npm test` works.
+
+## Required reading
+
+- `pi-sandbox/.pi/extensions/_lib/habitat.ts` and `habitat.test.ts` — current shape.
+- `scripts/run-agent.mjs` — recipe parsing + spec construction.
+- `docs/adr/0001-mesh-subsumes-delegation.md` — the four field meanings.
+- `CONTEXT.md` — `Supervisor`, `submitTo`, `acceptedFrom`, `peers` definitions.
+- `docs/phases/_notes-for-phase-3.md`.
+
+## Skill to invoke
+
+`/tdd`. Habitat extension follows the same pattern as 3a — pure data with discriminator-friendly tests.
+
+## Branch strategy
+
+Branch from latest `main`. Suggested: `claude/phase-3b-habitat-peer-fields`.
+
+```sh
+git fetch origin main
+git checkout -b claude/phase-3b-habitat-peer-fields origin/main
+npm test   # confirm 3a's tests pass on the new base
+```
+
+## Scope — what's in (TDD order)
+
+### Step 1 — tests first (red)
+
+In `pi-sandbox/.pi/extensions/_lib/habitat.test.ts`:
+
+- `materialiseHabitat` accepts the four new optional fields and preserves them.
+- Defaults: `acceptedFrom` and `peers` default to `[]` when absent (list fields, like existing `agents`/`skills`); `supervisor` and `submitTo` default to `undefined` (optional strings).
+- Type-mismatched values for any of the four → rejected (consistent with existing field validation).
+
+Run `npm test` — new tests fail.
+
+### Step 2 — implementation (green)
+
+Extend the type:
+
+```ts
+export interface Habitat {
+  // ... existing fields ...
+
+  // Phase 3b: peer relationships
+  supervisor?: string;       // peer name to escalate approvals to
+  submitTo?: string;         // peer name to ship submissions to
+  acceptedFrom: string[];    // peers allowed to send to this one
+  peers: string[];           // peers this one may address
+}
+```
+
+Extend `materialiseHabitat` to parse the new fields using the existing `optionalString` / `stringList` helpers. Tests pass.
+
+### Step 3 — runner serialisation
+
+In `scripts/run-agent.mjs`:
+
+- Read `recipe.supervisor`, `recipe.submitTo`, `recipe.acceptedFrom`, `recipe.peers` (all optional, all may be missing).
+- Validate types: strings for the first two, arrays-of-strings for the last two; reject malformed recipes loudly with `die()`.
+- Add to `habitatSpec`. Use the same `...(value ? { field: value } : {})` pattern the runner already uses for other optional fields.
+
+### Step 4 — recipe schema docs
+
+In `docs/agents.md`, append a small note (under the recipe-shape section) describing the four new fields:
+
+- `supervisor: <peer name>` — peer to escalate approvals to.
+- `submitTo: <peer name>` — peer to ship submissions to.
+- `acceptedFrom: [peer, …]` — incoming peer allowlist.
+- `peers: [peer, …]` — outgoing peer allowlist.
+
+Note that the fields are declarable now but no rail enforces them until Phase 3c.
+
+## Scope — what's NOT in
+
+- **No rail changes.** `sandbox.ts`, `agent-bus.ts`, etc. don't yet enforce these fields.
+- **No new tools.** `respond_to_request` is Phase 3c.
+- **No supervisor extension.** Phase 3c.
+- **No new envelope kinds.** Phase 3a covered those.
+- **No topology YAML support.** Phase 6.
+- **No group references like `@workers`.** Phase 6.
+- **No `agent_call` typed-reply changes.** Phase 3c.
+
+## Step-by-step checklist
+
+```
+[ ]  1. Read prereqs.
+[ ]  2. /tdd.
+[ ]  3. Branch claude/phase-3b-habitat-peer-fields from main.
+
+  RED:
+[ ]  4. Add tests: materialiseHabitat preserves the four new fields.
+[ ]  5. Add tests: defaults for absent fields ([] for lists, undefined
+        for strings).
+[ ]  6. Add tests: type mismatches are rejected.
+        Confirm npm test shows them all failing.
+
+  GREEN:
+[ ]  7. Extend Habitat interface.
+[ ]  8. Extend materialiseHabitat parsing.
+
+  INTEGRATION:
+[ ]  9. Update run-agent.mjs to read recipe fields, validate types,
+        add to habitatSpec.
+[ ] 10. Update docs/agents.md recipe-shape notes.
+
+[ ] 11. npm test — green.
+[ ] 12. Tmux smoke: deferred-writer + peer-chatter + writer-foreman
+        all still pass (no behavior change expected).
+[ ] 13. Optional: launch a recipe with the new fields set; confirm
+        [AGENT_DEBUG] habitat dump shows them.
+[ ] 14. Commit, push, delete this file.
+```
+
+## Testing
+
+Unit (vitest) + tmux for regression confirmation. No new behavior to exercise — just verify nothing broke.
+
+## Acceptance criteria
+
+- Habitat type + materialiser + runner serialisation handle the four new fields.
+- Tests cover preservation, defaults, and rejection.
+- A recipe declaring the new fields launches and `[AGENT_DEBUG] habitat:` shows them when set (extend the debug dump if needed).
+- A recipe NOT declaring them launches as before; `[AGENT_DEBUG]` shows the existing fields unchanged.
+- All three tmux smoke tests still pass (deferred-writer, peer-chatter, writer-foreman).
+- `docs/agents.md` has the new field documentation.
+- This file (`docs/phases/phase-3b-habitat-peer-fields.md`) deleted in the same commit/PR.
+
+## Hand-back
+
+Push to `origin/claude/phase-3b-habitat-peer-fields`. Report:
+
+- Commit SHA.
+- Output of `npm test`.
+- Output of each tmux smoke test (the captures that confirm no regression).
+- A sample `[AGENT_DEBUG]` line for a recipe that declares the new fields, showing them present.
+
+Don't open a PR.

--- a/docs/phases/phase-3c-supervisor-rail.md
+++ b/docs/phases/phase-3c-supervisor-rail.md
@@ -1,0 +1,202 @@
+# Phase 3c — supervisor inbound rail + `respond_to_request` + relocate `requestHumanApproval`
+
+**Goal.** Build the supervisor-side machinery. New rail extension catches inbound `submission` and `approval-request` envelopes from the bus, surfaces them to the supervisor's LLM, exposes a `respond_to_request({msg_id, action, note?})` tool with four actions (approve / reject / revise / escalate), routes the chosen action back over the bus. Move `requestHumanApproval` and `rpcRequestApproval` out of `deferred-confirm.ts` into a new shared module that owns the recursive escalation primitive.
+
+**Behaviour after this phase: nothing currently emits `submission` or `approval-request` envelopes yet** (Phase 4 wires the worker side, Phase 5 wires atomic-delegate). So end-to-end exercise of this rail through real work doesn't happen until Phase 4. **3c is testable in isolation via synthetic envelopes** — vitest exercises the full request → respond → reply round-trip with mocked bus connections.
+
+This file is deleted in the PR that ships Phase 3c.
+
+---
+
+## Prerequisite
+
+Phase 3a + 3b merged to main. `npm test` works; `_lib/bus-envelope.ts` has the four new payload kinds; `_lib/habitat.ts` has `supervisor` / `submitTo` / `acceptedFrom` / `peers` fields.
+
+## Required reading
+
+- `docs/adr/0003-supervisor-llm-in-review-loop.md` — the **whole** rail design. Re-read until the four-action flow is clear.
+- `docs/adr/0001-mesh-subsumes-delegation.md` — the migration plan.
+- `docs/adr/0002-habitat-materialises-once.md` — the rail-reads-from-Habitat pattern.
+- `docs/phases/_notes-for-phase-3.md` — **especially** the `agent_call` non-message-reply observation; this phase will hit it.
+- `pi-sandbox/.pi/extensions/deferred-confirm.ts` — the file you're moving code *out of*.
+- `pi-sandbox/.pi/extensions/agent-bus.ts` — the file you're modifying to dispatch new kinds.
+- `pi-sandbox/.pi/extensions/_lib/bus-envelope.ts` (post-3a) and `_lib/habitat.ts` (post-3b) — what you're building on.
+
+## Skill to invoke
+
+`/tdd`. The escalation primitive and the action-routing logic are testable in isolation with mocked sockets/peers. Tests-first protects the move of `requestHumanApproval` (the most regression-prone part).
+
+## Branch strategy
+
+Branch from latest `main` (post-3a, post-3b). Suggested: `claude/phase-3c-supervisor-rail`.
+
+```sh
+git fetch origin main
+git checkout -b claude/phase-3c-supervisor-rail origin/main
+npm test   # confirm all prior phases' tests pass
+```
+
+## Scope — what's in (TDD order, per logical step)
+
+### Step 1 — extract escalation primitive into `_lib/escalation.ts`
+
+**Tests first** in `pi-sandbox/.pi/extensions/_lib/escalation.test.ts`:
+
+- `requestHumanApproval(ctx, pi, req)` returns `ctx.ui.confirm(...)` result when `ctx.hasUI` is true.
+- Returns `false` and writes loud-fail to stderr when `!ctx.hasUI` and `getHabitat().rpcSock` is unset / `getHabitat()` throws.
+- When `getHabitat().rpcSock` is set, opens the socket, writes `{type: "request-approval", ...}` line, awaits `{type: "approval-result", approved}` reply. Mock the socket via `net.createServer` in the test.
+
+**Then implementation:** copy the existing `requestHumanApproval` and `rpcRequestApproval` from `deferred-confirm.ts` into `_lib/escalation.ts` exactly. Update `deferred-confirm.ts` to import from there. The `_lib/escalation.ts` module becomes the canonical home for the recursive escalation primitive (per ADR-0001's "homeless primitive" framing).
+
+### Step 2 — supervisor inbound rail
+
+**Tests first** in `_lib/supervisor-inbox.test.ts` (or similar; the dispatcher logic may live in `_lib/` for testability):
+
+- Inbound `approval-request` envelope from a peer in `getHabitat().acceptedFrom` is queued for handling.
+- Inbound `approval-request` from a peer **not** in `acceptedFrom` is dropped silently (with stderr log under AGENT_DEBUG).
+- Inbound `submission` from any peer is queued for handling. (`submitTo` is for the *outbound* direction; supervisors don't have a single allowed-submitter — they accept submissions from anyone in `acceptedFrom`.)
+- After queue, the inbox handler calls `pi.sendUserMessage` with the rendered envelope.
+- Per-action behavior (test each):
+  - `approve` builds an `approval-result` envelope (`approved: true`) and sends to the original sender.
+  - `reject` builds an `approval-result` (`approved: false`) and sends.
+  - `revise` builds a `revision-requested` envelope (note required) and sends.
+  - `escalate` builds a fresh `approval-request` for `getHabitat().supervisor` via `agent_call`. When that resolves, builds an `approval-result` mirroring the upstream answer back to the original sender.
+- Loop guardrail: cap revision-cycle depth at 3 per `msg_id` chain; on cap, the rail forces approve / reject (no more revise allowed).
+
+**Then implementation** in `pi-sandbox/.pi/extensions/supervisor.ts`:
+
+- Registers the `respond_to_request` tool with schema:
+  ```ts
+  Type.Object({
+    msg_id: Type.String(),
+    action: Type.Union([
+      Type.Literal("approve"),
+      Type.Literal("reject"),
+      Type.Literal("revise"),
+      Type.Literal("escalate"),
+    ]),
+    note: Type.Optional(Type.String()),
+  })
+  ```
+- Maintains a globalThis registry of pending inbound envelopes (mirrors the `__pi_*` idiom in `agent-bus.ts` / `deferred-confirm.ts`).
+- Hooks `agent-bus`'s incoming dispatch (see Step 3) to queue envelopes by `msg_id`.
+- On tool invocation, routes the action; the four actions delegate to internal handlers that build the appropriate reply envelope and `agent_send` it.
+
+### Step 3 — agent-bus dispatch update
+
+In `pi-sandbox/.pi/extensions/agent-bus.ts`'s `handleIncoming`:
+
+- Add a typed dispatch on `env.payload.kind`:
+  - `message` → existing inbox + pushToModel logic, unchanged.
+  - `approval-request`, `submission` → forward to the supervisor rail's queue (via the globalThis registration the rail performs at session_start, mirroring the `__pi_*` idiom).
+  - `approval-result`, `revision-requested` → if `env.in_reply_to` matches a `pendingCalls` entry, **resolve with the typed payload** (not just text). This is where the Phase 1 spot-check observation lands — the empty-string fallback gets replaced. **Recommended: reject the pending call's promise with a typed-mismatch error** if the caller used `agent_call` (which expects message-kind replies); the supervisor rail's escalation path uses its own internal correlation, not `agent_call`.
+- Add `acceptedFrom` enforcement: before any non-message envelope is dispatched, check `env.from` against `getHabitat().acceptedFrom`. Drop with stderr log if not in the list. Message-kind envelopes still flow freely (existing peer chat is unrestricted by `acceptedFrom` for v1; tightening that is a separate decision).
+
+### Step 4 — recipe schema + implicit-wire rule
+
+In `scripts/run-agent.mjs`:
+
+- When `recipe.acceptedFrom` is non-empty *or* `recipe.supervisor` / `recipe.submitTo` are set, auto-load the `supervisor` extension (similar to how `agents:` triggers `agent-spawn`).
+- Auto-add `respond_to_request` to `tools` when the `supervisor` extension is loaded.
+- Inverse rejection: if `recipe.extensions` explicitly includes `supervisor` but no relevant fields are set, `die()` with a clear message.
+
+### Step 5 — documentation
+
+- `docs/agents.md`: add a section describing the supervisor inbound rail, the `respond_to_request` tool, and the four-action flow. Reference ADR-0003.
+- `pi-sandbox/.pi/extensions/supervisor.prompt.md`: model-facing tool documentation for `respond_to_request` (what each action does, when to use which).
+
+## Scope — what's NOT in
+
+- **No worker-side `submission` shipping.** Phase 4 builds that. Workers continue to apply their own drafts via `deferred-confirm` until Phase 4.
+- **No atomic `delegate` rewrite.** Phase 5.
+- **No topology YAML support.** Phase 6.
+- **No deletion of `agent-spawn.ts` / `agent-status-reporter.ts`.** Phase 5.
+- **No deletion of `Habitat.rpcSock`.** Bus path coexists with rpc-sock path until Phase 5 finishes the cutover.
+- **No `acceptedFrom` enforcement on `message`-kind envelopes.** The peer-chat tightening is a separate decision; for now, only typed (non-message) inbound envelopes are gated by `acceptedFrom`. Pin as a follow-up question.
+
+## Step-by-step checklist
+
+```
+[ ]  1. Read prereqs (especially ADR-0003 + notes file).
+[ ]  2. /tdd.
+[ ]  3. Branch claude/phase-3c-supervisor-rail from main.
+
+  STEP 1 — escalation primitive:
+[ ]  4. _lib/escalation.test.ts: tests for requestHumanApproval + rpc round-trip.
+[ ]  5. _lib/escalation.ts: extract the two functions from deferred-confirm.
+[ ]  6. deferred-confirm.ts: import from _lib/escalation.ts; drop inline.
+[ ]  7. npm test — green.
+
+  STEP 2 — supervisor rail:
+[ ]  8. _lib/supervisor-inbox.test.ts: tests for queue + four-action routing.
+[ ]  9. supervisor.ts extension: tool registration + action handlers + cap.
+[ ] 10. npm test — green.
+
+  STEP 3 — agent-bus dispatch:
+[ ] 11. agent-bus.ts: typed handleIncoming dispatch + acceptedFrom check.
+[ ] 12. agent-bus.ts pendingCalls: reject-on-typed-mismatch (resolves the
+        Phase 1 forward-compat observation).
+[ ] 13. npm test — green.
+
+  STEP 4 — wiring:
+[ ] 14. run-agent.mjs: implicit-wire rule + respond_to_request auto-tool +
+        inverse rejection.
+
+  STEP 5 — docs:
+[ ] 15. docs/agents.md: append supervisor rail + respond_to_request docs.
+[ ] 16. pi-sandbox/.pi/extensions/supervisor.prompt.md: model-facing tool docs.
+
+  TESTING:
+[ ] 17. npm test — all green (synthetic-envelope round-trips).
+[ ] 18. Tmux smoke: existing three tests still pass (no observable
+        behavior change yet — this rail is dormant until Phase 4 ships
+        worker submissions).
+[ ] 19. Tmux smoke (new): synthetic-submission test using a hand-crafted
+        envelope sent from a test script to a supervisor-recipe agent.
+        Verify the rail catches it, the model sees the prompt, the
+        respond_to_request tool round-trips correctly. Document the
+        test recipe in the PR.
+
+[ ] 20. Commit per logical step (5 commits keeps reviewing tractable).
+[ ] 21. Push.
+[ ] 22. Delete this file in same PR.
+```
+
+## Testing
+
+**Unit (vitest)** is the primary correctness proof since the worker side doesn't ship submissions yet. Aim for full coverage of the four-action routing, escalation chain, and `acceptedFrom` enforcement.
+
+**Tmux integration** has two parts:
+- Existing three tests (deferred-writer, peer-chatter, writer-foreman) must still pass — this phase shouldn't change observable behavior of any pre-3c flow.
+- New synthetic-submission test: write a small recipe (e.g. `supervisor-test`) that loads `supervisor`, sets `acceptedFrom: [test-sender]`, and a small standalone Node script that sends a hand-crafted `submission` or `approval-request` envelope to the recipe's bus socket. Drive end-to-end through tmux to verify the rail catches it, surfaces it to the model, and routes the four actions correctly.
+
+## Acceptance criteria
+
+- `_lib/escalation.ts` exists; `deferred-confirm.ts` imports from it; behavior identical to pre-phase.
+- `pi-sandbox/.pi/extensions/supervisor.ts` exists; registers `respond_to_request`; routes the four actions correctly; enforces the revision cap.
+- `agent-bus.ts`'s `handleIncoming` dispatches by kind and enforces `acceptedFrom` for non-message envelopes.
+- Pending `agent_call` entries reject with a typed-mismatch error when a non-message reply arrives (Phase 1 forward-compat observation now resolved).
+- Implicit-wire rule fires when supervisor-related recipe fields are set; inverse rejection works.
+- All three existing tmux tests still pass.
+- New synthetic-submission tmux test exercises the four actions end-to-end.
+- `docs/agents.md` and `supervisor.prompt.md` updated.
+- This file (`docs/phases/phase-3c-supervisor-rail.md`) deleted in the same commit/PR.
+
+## What to do if you hit something unexpected
+
+- **`requestHumanApproval` has subtle behavior I didn't notice in the move.** That's why tests-first matters. If the move breaks the writer-foreman tmux test, the test you wrote in Step 1 was incomplete — extend it to cover the regression, fix the implementation, re-run.
+- **Synthetic test recipe is hard to write because the supervisor rail expects an LLM response to its `respond_to_request` prompt.** Use a small mocked-LLM mode if pi supports it, or design the test to exit after the rail's queue is hit (verify the queue state, not the tool round-trip). Document the limitation.
+- **`agent-bus.ts`'s `pendingCalls` reject-on-typed-mismatch breaks something.** That's a real possibility — current code resolves with `""` for any non-message reply. If anything depends on that empty-string behavior, the dependency is itself a bug; fix the dependency and continue.
+- **The `acceptedFrom` enforcement breaks `peer-chatter`.** Shouldn't, since peer-chatter uses message-kind only. If it does, the `kind === "message"` carve-out in the enforcement check needs strengthening — every peer-chat code path should be unaffected.
+
+## Hand-back
+
+When the checklist is complete, push to `origin/claude/phase-3c-supervisor-rail` and report:
+
+- Commit SHAs (one per logical step keeps reviewing tractable).
+- Output of `npm test` (assertion count delta).
+- Output of each tmux smoke test (existing three + new synthetic-submission).
+- Anything noteworthy about the move of `requestHumanApproval` (e.g. discovered subtle invariants, edge cases in the escalation chain).
+- Whether the synthetic-submission test had to mock the LLM response or whether you found a way to drive a real model end-to-end.
+
+Don't open a PR.


### PR DESCRIPTION
## Summary

This PR adds comprehensive planning documentation for Phase 3 of the supervisor-in-the-loop architecture, breaking down the work into three sub-phases (3a, 3b, 3c) with detailed step-by-step implementation guides.

## Changes

- **`docs/phases/phase-3a-envelope-kinds.md`**: Planning document for extending `bus-envelope.ts` with four new payload kinds (`approval-request`, `approval-result`, `revision-requested`, `submission`) and the `Artifact` type. Includes TDD-first approach with test specifications, implementation checklist, and acceptance criteria.

- **`docs/phases/phase-3b-habitat-peer-fields.md`**: Planning document for extending the `Habitat` type with four new optional fields (`supervisor`, `submitTo`, `acceptedFrom`, `peers`) to declare peer relationships. Covers materialization, recipe parsing, and validation with no behavioral changes until Phase 3c wires the rails.

- **`docs/phases/phase-3c-supervisor-rail.md`**: Planning document for building the supervisor-side inbound rail machinery, including:
  - Extraction of the escalation primitive (`requestHumanApproval`) into a shared module
  - Supervisor inbound rail with `respond_to_request` tool supporting four actions (approve/reject/revise/escalate)
  - Agent-bus dispatch updates to route new envelope kinds and enforce `acceptedFrom` allowlisting
  - Implicit wiring rules and documentation

- **`docs/phases/_notes-for-phase-3.md`**: Scratch notes capturing forward-looking observations from earlier phases that inform the Phase 3 plan, including:
  - Status of `deferred-confirm` refactoring from Phase 2
  - `agent_call` silent-empty-string behavior for non-message replies (Phase 1 forward-compat observation)
  - Stale comments and dead code deferred to Phase 5

## Notable Details

- All three phase documents follow a consistent structure: prerequisites, required reading, TDD-first approach, detailed step-by-step checklists, testing strategy, and acceptance criteria
- Phase 3a is types-only (no behavioral change); Phase 3b adds inert fields; Phase 3c wires the rails
- Each phase is designed to be testable in isolation with synthetic envelopes before worker-side submission shipping (Phase 4)
- Documents explicitly call out what's NOT in scope to prevent scope creep
- Includes troubleshooting guidance and hand-back reporting requirements for the implementation phase

https://claude.ai/code/session_01V3NTYkF6Z9QuK1zFm7eNGs