### PR TITLE
Add phase planning docs for 4a, 4b, and 6a

### DIFF
--- a/docs/phases/phase-4a-worker-emit.md
+++ b/docs/phases/phase-4a-worker-emit.md
@@ -1,0 +1,215 @@
+# Phase 4a — worker-side submission emit
+
+**Goal.** When `getHabitat().submitTo` is set on a worker peer, the `deferred-*` extensions' end-of-turn flow ships a `submission` envelope to the `submitTo` peer instead of locally rendering an approval dialog. Worker waits for the reply (`approval-result`); on approve, no local apply (supervisor handles it); on reject, log and discard. Revision handling lands in a separate phase (4c) — for 4a, treat `revision-requested` as `reject + log`.
+
+**Behaviour after this phase:**
+- Recipes that set `submitTo` get the new bus-routed submission flow.
+- Recipes that don't set `submitTo` keep today's local-or-rpc-sock flow exactly.
+- Workers that emit submissions don't write to disk in their own scratch — only the supervisor's apply path (Phase 4b) writes to canonical.
+
+This file is deleted in the PR that ships Phase 4a.
+
+---
+
+## Prerequisite
+
+Phases 3a / 3b / 3c merged to main. Phase 4b *not* required — 4a's tests use synthetic supervisor receivers via mocked sockets.
+
+**This phase is parallelisable with Phase 4b and Phase 6a.** Coordinate at the artifact contract (locked in `_lib/bus-envelope.ts`'s `Artifact` type) and the wire protocol; otherwise touch separate files.
+
+## Required reading
+
+- `docs/adr/0001-mesh-subsumes-delegation.md` and `0003-supervisor-llm-in-review-loop.md`.
+- `docs/phases/_notes-for-phase-3.md` and `_notes-for-phase-4.md` (if present) — inherited observations.
+- `pi-sandbox/.pi/extensions/_lib/bus-envelope.ts` — the `Artifact` and `Payload` shapes you're constructing.
+- `pi-sandbox/.pi/extensions/deferred-confirm.ts` — the agent_end coordinator you're forking.
+- All four `deferred-*.ts` extensions (write/edit/move/delete) — read the existing `prepare()` results to understand what each carries.
+- `pi-sandbox/.pi/extensions/agent-bus.ts` — how typed dispatch routes inbound envelopes; you'll add a sibling hook for worker-side submission replies.
+
+## Skill to invoke
+
+`/tdd`. Submission emit is testable in isolation with mocked socket transports.
+
+## Branch strategy
+
+Off latest `main`. Suggested: **`claude/phase-4a-worker-emit`**.
+
+```sh
+git fetch origin main
+git checkout -b claude/phase-4a-worker-emit origin/main
+npm test   # confirm baseline
+```
+
+## Scope — what's in (TDD order)
+
+### Step 1 — `_lib/submission-emit.ts` (testable core)
+
+**Tests first** in `pi-sandbox/.pi/extensions/_lib/submission-emit.test.ts`:
+
+- `buildWriteArtifact({relPath, content})` returns `{kind: "write", relPath, content, sha256}` with the correct SHA-256 of content.
+- `buildEditArtifact({relPath, originalContent, edits})` returns the edit artifact with `sha256OfOriginal` correctly computed.
+- `buildMoveArtifact({src, dst, sourceContent})` returns `{kind: "move", src, dst, sha256OfSource}`.
+- `buildDeleteArtifact({relPath, content})` returns `{kind: "delete", relPath, sha256}`.
+- `shipSubmission` builds a `submission` envelope, sends it via the injected sender callback, registers a pending entry keyed by `msg_id`, and returns a Promise that resolves when a matching reply is dispatched.
+- The dispatch callback (called when an `approval-result` or `revision-requested` envelope arrives with a matching `in_reply_to`) resolves the pending Promise with the reply's typed payload.
+- Timeout (default 5 minutes; injectable for tests): rejects the pending Promise.
+
+**Then implementation:**
+
+```ts
+export function buildWriteArtifact(args: { relPath: string; content: string }): Artifact;
+export function buildEditArtifact(args: {
+  relPath: string;
+  originalContent: string;
+  edits: Array<{ oldString: string; newString: string }>;
+}): Artifact;
+export function buildMoveArtifact(args: { src: string; dst: string; sourceContent: string }): Artifact;
+export function buildDeleteArtifact(args: { relPath: string; content: string }): Artifact;
+
+export interface PendingSubmission {
+  resolve: (reply: { approved: boolean; note?: string; revisionNote?: string }) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+export function getPendingSubmissions(): Map<string, PendingSubmission>;
+
+export interface ShipContext {
+  busRoot: string;
+  agentName: string;
+  submitTo: string;
+  sendEnvelope: (env: Envelope) => Promise<{ delivered: boolean; reason?: string }>;
+  timeoutMs?: number;
+}
+
+export async function shipSubmission(
+  ctx: ShipContext,
+  artifacts: Artifact[],
+  summary?: string,
+): Promise<{ approved: boolean; note?: string; revisionNote?: string }>;
+```
+
+The pending-submissions Map is stashed on globalThis (mirroring `agent-bus`'s `pendingCalls`) so `agent-bus.ts` can dispatch replies into it from a different module.
+
+### Step 2 — agent-bus dispatch hook for submission replies
+
+In `pi-sandbox/.pi/extensions/agent-bus.ts`'s `handleIncoming`, after the existing `pendingCalls` check (which now correctly rejects non-message replies per Phase 3c) but **before** the `acceptedFrom`-gated supervisor dispatch:
+
+- If `env.in_reply_to` is set AND the envelope kind is `approval-result` or `revision-requested`:
+  - Look up `getPendingSubmissions().get(env.in_reply_to)`.
+  - If found: clear the timer, delete the pending entry, resolve the promise with the typed payload.
+  - If not found: fall through (envelope continues to supervisor dispatch / inbox).
+
+This is an additive change — it doesn't break existing behavior. Add a single test to `agent-bus`'s test file (or a new one) that exercises the hook with a mocked pending submission.
+
+### Step 3 — extend `PrepareResult` to carry artifacts
+
+In `pi-sandbox/.pi/extensions/deferred-confirm.ts`, extend the `ok` variant of `PrepareResult`:
+
+```ts
+export type PrepareResult =
+  | { status: "empty" }
+  | { status: "error"; messages: string[] }
+  | {
+      status: "ok";
+      summary: string;
+      preview: string;
+      apply: () => Promise<{ wrote: string[]; failed: string[] }>;
+      artifacts?: Artifact[];   // NEW: when set, supervisor-routed flow uses these
+    };
+```
+
+Existing handlers that don't populate `artifacts` continue to work (the field is optional).
+
+### Step 4 — each `deferred-*` handler populates artifacts
+
+Update the four `deferred-*.ts` extensions to populate `result.artifacts` in their `prepare()` ok results:
+
+- `deferred-write.ts`: each draft → `buildWriteArtifact({relPath, content})`.
+- `deferred-edit.ts`: each edit-target file → `buildEditArtifact({relPath, originalContent, edits})` using the original content the handler reads anyway for re-validation.
+- `deferred-move.ts`: each move → `buildMoveArtifact({src, dst, sourceContent})` (read source content for the SHA).
+- `deferred-delete.ts`: each delete → `buildDeleteArtifact({relPath, content})` (read content for the SHA).
+
+The existing `apply()` method on each handler stays — it's the local-flow fallback when `submitTo` is unset.
+
+### Step 5 — fork `deferred-confirm.ts`'s `agent_end`
+
+Add a branch in the agent_end coordinator:
+
+- If `getHabitat().submitTo` is set:
+  - Aggregate all handlers' `result.artifacts` from the prepared `ok` results.
+  - Build a summary (e.g. count + per-handler labels).
+  - Ship via `shipSubmission`.
+  - On `{approved: true}`: `tell(ctx, "info", "submission applied by supervisor")` (no local apply).
+  - On `{approved: false}`: `tell(ctx, "info", "submission rejected: ${note ?? "(no reason)"}")`. Don't apply locally.
+  - On `revision-requested`: for 4a, treat as reject (log it, discard the queue). 4c handles the actual revision flow.
+- If `submitTo` is unset: existing local-or-rpc-sock flow, **unchanged**.
+
+The `submitTo` read uses the same try/catch pattern as other rails:
+
+```ts
+let submitTo: string | undefined;
+try { submitTo = getHabitat().submitTo; } catch { submitTo = undefined; }
+```
+
+### Step 6 — docs
+
+In `docs/agents.md`, append a paragraph under the recipe-shape section: when `submitTo` is set on a recipe, deferred-* drafts are shipped to that peer's supervisor rail at end-of-turn instead of being locally applied. Recipes that don't set `submitTo` keep today's local flow.
+
+## Scope — what's NOT in
+
+- **No supervisor-side apply logic.** Phase 4b builds that. For 4a, tests use mocked supervisor receivers.
+- **No revision threading.** Phase 4c. For 4a, treat `revision-requested` reply as `reject + log`.
+- **No agent-spawn deletion.** Phase 5.
+- **No bundle / workspace seeding.** Phase 5 (atomic delegate spawn flow).
+- **No new tools.** Workers continue to call `deferred_write` / `deferred_edit` / etc. as today.
+- **No habitat field changes.** `submitTo` already exists from Phase 3b.
+
+## Step-by-step checklist
+
+```
+[ ]  1. Read prereqs + ADRs + notes.
+[ ]  2. /tdd.
+[ ]  3. Branch claude/phase-4a-worker-emit from main.
+
+  RED:
+[ ]  4. _lib/submission-emit.test.ts — all 4 builders + shipSubmission +
+        timeout + dispatch resolution.
+
+  GREEN:
+[ ]  5. _lib/submission-emit.ts — implementations.
+
+  INTEGRATION:
+[ ]  6. agent-bus.ts — add submission-reply dispatch hook before
+        supervisor dispatch.
+[ ]  7. PrepareResult type — add optional artifacts field.
+[ ]  8. Each deferred-*.ts — populate result.artifacts in prepare().
+[ ]  9. deferred-confirm.ts — fork agent_end on getHabitat().submitTo.
+[ ] 10. docs/agents.md — append the submitTo flow paragraph.
+
+[ ] 11. npm test — green.
+[ ] 12. Tmux smoke (with synthetic supervisor or pair-test with 4b):
+        a worker recipe with submitTo set queues a draft, ships
+        submission, gets approve reply, logs success.
+[ ] 13. Tmux smoke regression: deferred-writer (no submitTo) still
+        renders local confirm dialog and applies on approval.
+[ ] 14. Commit per logical step (one commit per file group).
+[ ] 15. Push; delete this plan file.
+```
+
+## Acceptance criteria
+
+- `_lib/submission-emit.ts` exists with the artifact builders and ship/dispatch logic.
+- `agent-bus.ts` correctly forwards approval-result/revision-requested replies to pending submissions.
+- All four `deferred-*` handlers populate `result.artifacts` in their `prepare()` ok results.
+- `deferred-confirm.ts` correctly forks on `submitTo`.
+- `npm test` passes (existing + new).
+- Tmux smoke regression: deferred-writer (no `submitTo`) unchanged.
+- Tmux smoke new: a worker with `submitTo` set ships submission and logs the supervisor's reply.
+- This plan file deleted.
+
+## Hand-back
+
+Push to `origin/claude/phase-4a-worker-emit`. Report SHAs (one per logical step), npm test output, both tmux test results, and any contract issues you discovered with Phase 4b's supervisor-side work.
+
+Don't open a PR.

--- a/docs/phases/phase-4b-supervisor-apply.md
+++ b/docs/phases/phase-4b-supervisor-apply.md
@@ -1,0 +1,158 @@
+# Phase 4b — supervisor-side submission apply
+
+**Goal.** Supervisor's `respond_to_request({action: "approve"})` on an inbound `submission` actually *applies* the artifacts to the supervisor's canonical sandbox. Verifies SHA-256 receipts before applying; aborts on mismatch (drift detection). Replies `approval-result {approved: true}` on success, `{approved: false, note: "<error>"}` on failure.
+
+**Behaviour after this phase:**
+- A supervisor receiving a submission and approving it actually performs the writes/edits/moves/deletes on its canonical filesystem.
+- SHA-256 receipts on each artifact are verified against the canonical filesystem before the artifact is applied; any mismatch aborts the entire batch (atomic).
+- The `respond_to_request` tool's existing reject/revise/escalate paths are unchanged.
+- Reject/revise/escalate on a submission do not write anything to the canonical filesystem.
+
+This file is deleted in the PR that ships Phase 4b.
+
+---
+
+## Prerequisite
+
+Phases 3a / 3b / 3c merged to main. Phase 4a *not* required — 4b's tests use synthetic submission envelopes (the unit tests already do).
+
+**Parallelisable with Phase 4a and 6a.** Contract with 4a is the `Artifact` type from `_lib/bus-envelope.ts` (already locked).
+
+## Required reading
+
+- `docs/adr/0001-mesh-subsumes-delegation.md` and `0003-supervisor-llm-in-review-loop.md`.
+- `docs/phases/_notes-for-phase-3.md` and `_notes-for-phase-4.md` (if present).
+- `pi-sandbox/.pi/extensions/_lib/bus-envelope.ts` — `Artifact` shape.
+- `pi-sandbox/.pi/extensions/_lib/supervisor-inbox.ts` — the `approve` action you're extending.
+- The four `deferred-*.ts` extensions' existing `apply()` paths — they're the reference implementation for "given an operation, do it on the filesystem." Mirror their logic for the supervisor's apply path, but operating on the supervisor's canonical sandbox (until Phase 6 splits scratch vs canonical, the supervisor's `getHabitat().scratchRoot` doubles as canonical).
+
+## Skill to invoke
+
+`/tdd`. Apply logic is pure I/O over a small filesystem; testable with vitest using `fs.mkdtempSync` for an isolated apply target.
+
+## Branch strategy
+
+Off latest `main`. Suggested: **`claude/phase-4b-supervisor-apply`**.
+
+```sh
+git fetch origin main
+git checkout -b claude/phase-4b-supervisor-apply origin/main
+npm test   # confirm baseline
+```
+
+## Scope — what's in (TDD order)
+
+### Step 1 — `_lib/submission-apply.ts` (testable core)
+
+**Tests first** in `pi-sandbox/.pi/extensions/_lib/submission-apply.test.ts`. For each artifact kind, cover:
+
+- **Happy path:** apply succeeds, file state matches expectation.
+- **SHA mismatch:** rejected before apply, no fs change.
+- **Missing file** (for edit/move/delete): rejected, no fs change.
+- **Existing-file overwrite** for write: succeeds (no-edit rail's job to enforce create-only when applicable; the apply path itself does not gate on existence).
+- **Atomic batch:** if any artifact in a list fails verification, *none* are applied — the entire batch is rejected with a list of error reasons.
+- **Apply order:** writes → edits → moves → deletes (mirrors the existing `deferred-confirm` priority order, so the same compositions that work today continue to work).
+
+**Then implementation:**
+
+```ts
+export interface ApplyResult {
+  ok: boolean;
+  applied: string[];   // relPaths successfully applied
+  errors: string[];    // human-readable errors (empty when ok)
+}
+
+export async function applyArtifacts(
+  canonicalRoot: string,
+  artifacts: Artifact[],
+): Promise<ApplyResult>;
+```
+
+Two-pass apply:
+
+1. **Verify pass:** for each artifact, check the SHA-256 against the current file contents (where applicable):
+   - `write`: no verify (creates new content; SHA is informational).
+   - `edit`: read current content, hash, must equal `sha256OfOriginal`.
+   - `move`: read source, hash, must equal `sha256OfSource`. Destination must not exist.
+   - `delete`: read current content, hash, must equal `sha256`.
+   Build an error list. If any errors, return `{ok: false, errors}` without touching the fs.
+2. **Apply pass:** apply each artifact in order (writes → edits → moves → deletes). Each successful apply appends to `applied`; failures append to `errors`. Returns `{ok: errors.length === 0, applied, errors}`.
+
+### Step 2 — extend supervisor's `approve` action
+
+In `pi-sandbox/.pi/extensions/_lib/supervisor-inbox.ts`'s `respondToRequest`'s `approve` branch:
+
+- If the pending entry's envelope is a `submission` (not an `approval-request`):
+  - Resolve `canonicalRoot` from `getHabitat().scratchRoot` (until Phase 6 introduces a separate `canonicalRoot` field, the supervisor's scratchRoot doubles as canonical — its filesystem *is* its source of truth).
+  - Call `applyArtifacts(canonicalRoot, payload.artifacts)`.
+  - On `{ok: true}`: send `approval-result {approved: true}` reply.
+  - On `{ok: false}`: send `approval-result {approved: false, note: "apply failed: ${errors.join("; ")}"}`.
+- If the pending entry is an `approval-request` (not a submission): existing behavior — just send `approval-result {approved: true}` (no apply, since approval-requests don't carry artifacts).
+
+### Step 3 — `supervisor.ts` wires the apply path
+
+The extension's `respond_to_request` tool implementation (where it calls `state.inbox.respondToRequest`) needs to make `applyArtifacts` available to the inbox. Cleanest path: `_lib/supervisor-inbox.ts` imports `applyArtifacts` directly from `_lib/submission-apply.ts`. No changes to `supervisor.ts`'s tool wiring required.
+
+If you find a test-ergonomics reason to inject the apply function via callback instead, do so — but the direct-import path is simpler for v1.
+
+### Step 4 — docs
+
+- `docs/agents.md`: extend the supervisor section to describe what `approve` does for `submission` envelopes (apply to canonical) vs `approval-request` (just acknowledge).
+- `pi-sandbox/.pi/extensions/supervisor.prompt.md`: add a paragraph: "approve on a submission applies the artifacts to your canonical sandbox; SHA mismatches abort the entire batch and the reply will indicate failure."
+
+## Scope — what's NOT in
+
+- **No worker-side emit.** Phase 4a. For 4b, tests construct synthetic `submission` envelopes directly.
+- **No revision threading.** Phase 4c.
+- **No `canonicalRoot` Habitat field.** Phase 6 might add one. For 4b, `scratchRoot` doubles as the supervisor's canonical (the supervisor's directory *is* its source of truth).
+- **No changes to `respond_to_request`'s tool schema.** Just the implementation.
+- **No new envelope kinds.** All in 3a.
+- **No worker-side handling of approval-result.** Phase 4a's territory; on 4b's branch, tests use synthetic envelopes and assert on the reply envelope's payload directly.
+
+## Step-by-step checklist
+
+```
+[ ]  1. Read prereqs.
+[ ]  2. /tdd.
+[ ]  3. Branch claude/phase-4b-supervisor-apply from main.
+
+  RED:
+[ ]  4. _lib/submission-apply.test.ts — happy paths + SHA mismatches +
+        atomic batch failure for each artifact kind + apply-order.
+
+  GREEN:
+[ ]  5. _lib/submission-apply.ts — verify pass + apply pass.
+
+  INTEGRATION:
+[ ]  6. _lib/supervisor-inbox.ts — extend approve action to call
+        applyArtifacts when envelope is a submission.
+[ ]  7. supervisor.ts — verify no wiring changes needed (imports
+        flow through the inbox lib).
+[ ]  8. docs/agents.md — supervisor section update.
+[ ]  9. supervisor.prompt.md — apply note for the model.
+
+[ ] 10. npm test — green.
+[ ] 11. Tmux smoke (synthetic submission envelope from a Node script
+        targeting a supervisor recipe, exercising approve / reject /
+        revise / escalate). The unit tests already cover the action
+        graph; this is the integration confirmation.
+
+[ ] 12. Commit per logical step.
+[ ] 13. Push; delete this plan file.
+```
+
+## Acceptance criteria
+
+- `_lib/submission-apply.ts` exists with `applyArtifacts` implementing two-pass verify-then-apply.
+- Supervisor's `approve` action invokes the apply path for `submission` envelopes; reply contains success/failure.
+- SHA-mismatch test passes (file unchanged after rejected verify; reply has `approved: false` with error note).
+- Atomic-batch test passes (one bad SHA in a list → none applied).
+- Tmux smoke: synthetic submission → approve → file applied to canonical.
+- Tmux smoke: synthetic submission with bad SHA → approve → no file change, reply contains error.
+- This plan file deleted.
+
+## Hand-back
+
+Push to `origin/claude/phase-4b-supervisor-apply`. Report SHAs, npm test output, tmux smoke results (both happy and bad-SHA cases), and any contract issues with Phase 4a.
+
+Don't open a PR.

--- a/docs/phases/phase-6a-topology-yaml.md
+++ b/docs/phases/phase-6a-topology-yaml.md
@@ -1,0 +1,182 @@
+# Phase 6a — topology YAML schema + launcher integration
+
+**Goal.** The existing `scripts/launch-mesh.mjs` (carried over from the original mesh deployment branch before the deepening began) needs to know about the post-Phase-3b Habitat fields. Topology YAMLs gain `supervisor`, `submitTo`, `acceptedFrom`, `peers` per node + a `groups` section for named groups + per-group bindings. Launcher resolves these, expands group references, and passes the resulting fields to each peer's `run-agent.mjs` invocation (which writes them into the Habitat spec).
+
+**Behaviour after this phase:**
+- A topology YAML can declare per-node peer relationships and named groups.
+- `peers: ["@workers"]` in a node's entry resolves to the concrete peer list at launch time (sender-side expansion; the bus sees only concrete names).
+- Group bindings (`group_bindings.workers.supervisor: authority`) flow into each member's effective fields, with per-node overrides winning.
+- Existing topology YAMLs (no peer fields) continue to launch unchanged.
+
+This file is deleted in the PR that ships Phase 6a.
+
+---
+
+## Prerequisite
+
+Phase 3b on main (Habitat carries the four peer fields and the runner serialises them). 3c not strictly needed — but if 3c is merged (it is), supervisors launched via topology will actually have a working inbound rail.
+
+**Parallelisable with Phase 4a and 4b.** Touches the launcher and topology parsing, not the rails or workers. Zero file overlap with 4a/4b.
+
+## Required reading
+
+- `scripts/launch-mesh.mjs` — current state (read end-to-end).
+- `pi-sandbox/meshes/authority-mesh.yaml` — example topology that exists today (no peer fields yet).
+- `scripts/run-agent.mjs` — how a single peer's Habitat spec is constructed from a recipe + flags. Topology fields need to flow through to here.
+- `docs/adr/0001-mesh-subsumes-delegation.md` and `0002-habitat-materialises-once.md` — the topology and habitat concepts.
+- `docs/phases/_notes-for-phase-3.md` and `_notes-for-phase-4.md` (if present) for context.
+
+## Skill to invoke
+
+`/tdd`. Topology parsing + group expansion is pure data transformation; perfect for unit tests.
+
+## Branch strategy
+
+Off latest `main`. Suggested: **`claude/phase-6a-topology-yaml`**.
+
+```sh
+git fetch origin main
+git checkout -b claude/phase-6a-topology-yaml origin/main
+npm test   # confirm baseline
+```
+
+## Scope — what's in (TDD order)
+
+### Step 1 — `_lib/topology.ts` (testable parser)
+
+Note: `_lib/topology.ts` is a **node-side** library (used by `launch-mesh.mjs`, which runs in Node, not inside pi). The existing `_lib/` directory under `pi-sandbox/.pi/extensions/_lib/` is for pi-extension code. **Place this new file** at `pi-sandbox/.pi/extensions/_lib/topology.ts` for consistency with the other libs (it can still be imported from a `.mjs` script — vitest handles the TS), or at `scripts/_lib/topology.ts` if you'd rather keep node-side and pi-side libs separate. **Recommend: `pi-sandbox/.pi/extensions/_lib/topology.ts`** — single library tree, reuses existing test infrastructure.
+
+**Tests first** in `_lib/topology.test.ts`:
+
+- Parse a minimal topology with one node — produces correct per-node Habitat overlay.
+- Parse with `groups` defined — expand `@<group>` references in `peers`/`acceptedFrom` to concrete peer names.
+- Parse with `group_bindings` — apply the binding to each member node, but per-node overrides win.
+- Reject `@<group>` references to undefined groups.
+- Reject duplicate node names.
+- Reject `acceptedFrom`/`peers` that reference non-existent nodes (after group expansion).
+
+**Then implementation:**
+
+```ts
+export interface TopologyNode {
+  name: string;
+  recipe?: string;        // omitted for type: relay
+  type?: "relay";
+  sandbox?: string;
+  task?: string;
+  // Habitat-overlay fields (post-3b):
+  supervisor?: string;
+  submitTo?: string;
+  acceptedFrom?: string[];  // may contain @group refs
+  peers?: string[];         // may contain @group refs
+}
+
+export interface GroupBinding {
+  supervisor?: string;
+  submitTo?: string;
+  acceptedFrom?: string[];
+  peers?: string[];
+}
+
+export interface Topology {
+  bus_root?: string;
+  groups?: Record<string, string[]>;
+  group_bindings?: Record<string, GroupBinding>;
+  nodes: TopologyNode[];
+}
+
+export interface ResolvedNode {
+  supervisor?: string;
+  submitTo?: string;
+  acceptedFrom: string[];   // concrete peer names; groups expanded
+  peers: string[];           // concrete peer names; groups expanded
+}
+
+export function parseTopology(yamlText: string): Topology;
+
+// Returns the effective Habitat-overlay fields for one node.
+// Resolution order: recipe defaults → group_bindings (per group) → per-node overrides.
+// (Recipe defaults aren't visible from topology alone; the runner merges them.)
+// Group expansion happens here and resolves @<group> refs to concrete names.
+export function resolveNode(topo: Topology, nodeName: string): ResolvedNode;
+```
+
+### Step 2 — `launch-mesh.mjs` integration
+
+Use `parseTopology` to validate the YAML at launch start. For each node, compute `resolveNode` and pass the resulting overlay to that node's `run-agent.mjs` invocation.
+
+**Recommend: a single `--topology-overlay <json>` flag** added to passthrough, mirroring how `--habitat-spec` already works at the runner level. The launcher serializes the overlay JSON; the runner unpacks and merges it into `habitatSpec`.
+
+### Step 3 — runner consumes the overlay
+
+In `scripts/run-agent.mjs`, after constructing `habitatSpec` from the recipe, parse `--topology-overlay` (if present) and overlay fields onto `habitatSpec`. Per-overlay-field overrides recipe values.
+
+Specifically:
+- If overlay has `supervisor`, replace `habitatSpec.supervisor` (recipe value lost).
+- If overlay has `submitTo`, replace.
+- If overlay has `acceptedFrom`, **replace** (not merge) — the topology's view of allowlists is authoritative for that deployment.
+- If overlay has `peers`, replace.
+
+### Step 4 — docs
+
+Update `docs/agents.md` with a new section "Topology YAML" documenting the schema, group syntax, and binding rules. Reference `pi-sandbox/meshes/authority-mesh.yaml` as the existing example (which doesn't yet use the new fields).
+
+If you want, write a new example topology that exercises the new fields — but **don't break the existing one**. Add a new file (e.g. `pi-sandbox/meshes/grouped-mesh.yaml`) or add the fields to `authority-mesh.yaml` in a way that's still launchable (the new fields are all optional).
+
+## Scope — what's NOT in
+
+- **No worker-side submission emit** (Phase 4a).
+- **No supervisor-side apply** (Phase 4b).
+- **No bus-level group fanout.** Group expansion is sender-side at topology resolve time. The bus continues to see only concrete peer names.
+- **No new envelope kinds** or **status reporting**. Status reporting (the `status` envelope kind for `delegation-boxes` to consume) is Phase 6c.
+- **No deletion of `agent-spawn.ts` or `agent-status-reporter.ts`.** Phase 5.
+- **No changes to `mesh-authority.ts`** beyond what `run-agent.mjs` brings indirectly.
+- **No CLI ergonomics changes** to `launch-mesh.mjs` (e.g. dry-run mode, validation-only mode, etc.). Out of scope; can land later.
+
+## Step-by-step checklist
+
+```
+[ ]  1. Read prereqs.
+[ ]  2. /tdd.
+[ ]  3. Branch claude/phase-6a-topology-yaml from main.
+
+  RED:
+[ ]  4. _lib/topology.test.ts — parse + group expansion + bindings +
+        rejection cases.
+
+  GREEN:
+[ ]  5. _lib/topology.ts — parser + resolveNode.
+
+  INTEGRATION:
+[ ]  6. scripts/launch-mesh.mjs — use parseTopology; pass per-node
+        overlay via --topology-overlay flag in passthrough.
+[ ]  7. scripts/run-agent.mjs — consume --topology-overlay; merge into
+        habitatSpec.
+
+[ ]  8. docs/agents.md — Topology YAML section.
+[ ]  9. Optional: extend pi-sandbox/meshes/authority-mesh.yaml or add
+        a new pi-sandbox/meshes/grouped-mesh.yaml exercising the new
+        fields. Ensure the existing authority-mesh launches unchanged.
+
+[ ] 10. npm test — green.
+[ ] 11. Smoke test: launch authority-mesh; confirm each node's
+        [AGENT_DEBUG] habitat: dump shows correctly resolved fields.
+[ ] 12. Smoke test: a topology with @groups; confirm expansion.
+[ ] 13. Commit per logical step; push; delete this plan file.
+```
+
+## Acceptance criteria
+
+- `_lib/topology.ts` exists; parses, expands groups, applies bindings.
+- `launch-mesh.mjs` uses `parseTopology` and passes resolved overlays.
+- `run-agent.mjs` consumes `--topology-overlay` and merges into `habitatSpec`.
+- A topology with `@groups` launches; resolved fields appear in each peer's `[AGENT_DEBUG] habitat:` dump.
+- Existing topology files (without new fields) launch unchanged.
+- `docs/agents.md` documents the schema.
+- This plan file deleted.
+
+## Hand-back
+
+Push to `origin/claude/phase-6a-topology-yaml`. Report SHAs, npm test output, smoke test outputs (one with groups, one without), any conflicts you found with `mesh-authority.ts`'s existing behavior.
+
+Don't open a PR.


### PR DESCRIPTION
## Summary

This commit adds three comprehensive phase planning documents that detail the implementation roadmap for worker-side submission emit (Phase 4a), supervisor-side submission apply (Phase 4b), and topology YAML schema integration (Phase 6a). These documents serve as detailed specifications and checklists for implementing the mesh delegation workflow.

## Changes

- **`docs/phases/phase-4a-worker-emit.md`** — Specification for worker-side submission emit flow. Defines how workers with `submitTo` set will ship submission envelopes to supervisors instead of rendering local approval dialogs. Includes TDD-ordered implementation steps covering:
  - Core `_lib/submission-emit.ts` with artifact builders and submission shipping logic
  - Agent-bus dispatch hook for approval-result/revision-requested replies
  - Extension of `PrepareResult` to carry artifacts
  - Updates to all four `deferred-*` handlers to populate artifacts
  - Fork of `deferred-confirm.ts`'s agent_end coordinator for submitTo flow
  - Documentation updates

- **`docs/phases/phase-4b-supervisor-apply.md`** — Specification for supervisor-side submission apply logic. Defines how supervisors process and apply artifacts from worker submissions with SHA-256 verification. Includes:
  - Core `_lib/submission-apply.ts` with two-pass verify-then-apply logic
  - Extension of supervisor's `approve` action to handle submission envelopes
  - Atomic batch failure semantics (all-or-nothing apply)
  - Documentation updates for supervisor behavior

- **`docs/phases/phase-6a-topology-yaml.md`** — Specification for topology YAML schema and launcher integration. Defines how topology files declare peer relationships and named groups. Includes:
  - `_lib/topology.ts` parser with group expansion and binding resolution
  - Integration with `launch-mesh.mjs` to resolve and pass topology overlays
  - Runner-side consumption of topology overlays in `run-agent.mjs`
  - Documentation of the topology YAML schema

## Implementation Details

Each document follows a consistent structure:
- Clear goal statement and post-phase behavior
- Prerequisite phases and parallelization notes
- Required reading list
- TDD-ordered implementation steps with code signatures
- Detailed scope (what's in/out)
- Step-by-step checklist
- Acceptance criteria
- Hand-back instructions

The documents are marked as temporary (deleted when the phase ships) and serve as both specification and implementation guide for the assigned developer.

https://claude.ai/code/session_01V3NTYkF6Z9QuK1zFm7eNGs