### PR TITLE
Move mesh status into pi TUI overlay, remove launcher chrome

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -69,7 +69,7 @@ A peer's submission target; the peer that receives and applies the worker's arti
 ### Human Surface
 
 **TUI**:
-Launcher-level interactive surface; the human's only interface to a running **Mesh**. Each peer runs in its own PTY with a full pi TUI alive; the launcher multiplexes — the **Focused Peer**'s PTY is rendered live in the main pane, off-screen peers render to virtual buffers. Launcher chrome (peers list, **Decisions Queue**) lives in a right rail. Slash commands (`/focus`, `/pin`, `/tail`, …) registered by a baseline `launcher-bridge` extension on every peer are the human's command channel; they emit control envelopes to a launcher-bound socket. The human is *not* a peer — there is no `human-relay` peer in this model.
+Launcher-level interactive surface; the human's only interface to a running **Mesh**. Each peer runs in its own PTY with a full pi TUI alive; the launcher multiplexes via PTY pass-through — the **Focused Peer**'s output streams directly to the launcher's stdout, off-screen peers accumulate in virtual buffers, and a focus change paints the destination's accumulated state once before resuming pass-through. Mesh status (peers list, **Decisions Queue**) renders inside each peer's pi TUI as a `nonCapturing` overlay anchored top-right, populated by the `mesh-rail` baseline extension; the launcher emits no chrome of its own. Slash commands (`/focus`, `/pin`, `/tail`, `/decisions`, …) registered by a baseline `launcher-bridge` extension on every peer are the human's command channel; they emit control envelopes to a launcher-bound socket. The human is *not* a peer — there is no `human-relay` peer in this model. See [ADR-0004](docs/adr/0004-launcher-multiplexed-tui.md) including its 2026-05-01 amendment.
 
 **Focused Peer**:
 The peer whose pi session the **TUI** is currently bound to. Human keystrokes inject as user-messages into this peer's pi process via stdin. Movable at runtime; the topology may declare an initial default focus.
@@ -80,7 +80,7 @@ When the **TUI** is the **Focused Peer** for X and X is about to invoke `respond
 A focus change from X→Y is a **hard cancel** on X: any in-flight `ctx.ui.confirm` on X is dismissed and the original prompt is re-injected to X's LLM as a fresh `respond_to_request` turn. The exception is **pin** — a pinned decision survives focus shifts and is never returned to the LLM.
 
 **Decisions Queue**:
-Side-panel of pending human decisions surfaced by **Intercept** or by `escalate` from the **Top Supervisor**. Default lifecycle is **fluid**: shifting focus away from a transient intercept dialog re-injects the original prompt to the peer's LLM (fresh turn). The human can **pin** a decision to make it sticky — it stays in the queue across focus changes and the LLM does not resume.
+Pending human decisions surfaced by **Intercept** or by `escalate` from the **Top Supervisor**, summarized as a count badge in the `mesh-rail` overlay and expanded via `/decisions` into a focus-capturing overlay with pin/dismiss affordances. Default lifecycle is **fluid**: shifting focus away from a transient intercept dialog re-injects the original prompt to the peer's LLM (fresh turn). The human can **pin** a decision to make it sticky — it stays in the queue across focus changes and the LLM does not resume.
 
 ### Patterns
 

--- a/docs/adr/0004-launcher-multiplexed-tui.md
+++ b/docs/adr/0004-launcher-multiplexed-tui.md
@@ -56,3 +56,33 @@ The new infrastructure follows the same per-axis split that ADR-0002 established
 | `entry-resolver` | Resolves the topology `entry:` field; integrates with `focus-controller` for crash auto-shift. |
 
 The discipline is not free — more files, more interface boundaries, slightly more ceremony per change. The trade-off is "if a future you wants to replace exactly one behavior, can you do it without touching anything else?" The repo's existing rail pattern says yes; this infrastructure inherits that contract.
+
+## Amendment (2026-05-01) — Mesh status surfaces inside pi's TUI (issue #88)
+
+The original *Consequences* described *"Launcher chrome (peers list, Decisions Queue) lives in a right rail"* rendered by the launcher to stderr alongside the focused peer's stdout. Slice 2's first attempt — buffer-paint the focused peer on every PTY chunk — produced unusable rendering: full-screen reprint per keystroke, stripped SGR, wrong cursor (issue #88). Refactoring slice 2 to "paint-once-on-focus-change with pass-through between" (the literal reading of *"swaps which buffer paints the focused pane on focus change"*) re-opens a different problem the original ADR didn't address: chrome's stderr writes interleaving with pi's stdout would strand the cursor mid-keystroke during pi's live editing.
+
+This amendment relocates the rail into pi rather than continuing to fight the interleaving. The same logic that argued *"Intercept reuses pi's own UI ... no double-render of the same prompt across launcher chrome and pi's own surface"* applies to mesh status.
+
+### Rendering pipeline
+
+- **Focused peer**: PTY output passes through verbatim to the launcher's stdout. The peer's `xterm-headless` virtual buffer continues to accumulate so focus changes have something to paint.
+- **Off-screen peers**: write only to their virtual buffer (unchanged from slice 3).
+- **Focus change**: the multiplexer paints the destination peer's accumulated buffer once (with SGR reconstruction and cursor restore), then resumes pass-through. The snapshot's role is narrow — make the few hundred ms before pi's next render look right; the bar for SGR fidelity is bounded.
+
+### Mesh status surface
+
+- A new in-peer baseline extension `mesh-rail` (auto-loaded under the launcher) renders mesh status as a `nonCapturing` overlay anchored `top-right`, sized `width: "30%"` with bounded `maxHeight`, via `ctx.ui.custom({ overlay: true, overlayOptions: { ... nonCapturing: true } })`. Pi's overlay system composites the rail into the focused peer's TUI; the launcher emits no chrome of its own.
+- Slash command `/decisions` opens a rich centered overlay (focus-capturing) for full peer detail and pin/dismiss affordances. The `mesh-rail` overlay hides while it is open via `OverlayHandle.setHidden(true)` and reappears on close. Other overlays (intercept's `ctx.ui.confirm`, future `/peers`) leave the rail stacked — the rail's ambient mesh-state context remains useful while the human picks an intercept action.
+- `mesh-rail` subscribes to launcher signals via the existing `launcher-bridge` extension. The launcher's `decisions-queue.mjs` and `focus-controller.mjs` modules continue to own state but stop holding render code; they broadcast renderable summaries to peers instead.
+- `scripts/_lib/chrome.mjs` and its tests are removed. `launch-mesh.mjs` stops writing peer-state chrome to stderr.
+
+### Decomposition diff
+
+- **Add to in-peer baseline extensions:** `mesh-rail` — *Renders the mesh-status overlay (peers list, decisions count) and exposes a hide/show handle for slash-command handlers. Subscribes to launcher signals via `launcher-bridge`.*
+- **Remove from launcher modules:** `chrome` (deleted).
+- **Amend `decisions-queue` row:** *Pending-decisions state; pin/dismiss; broadcasts renderable summaries to `mesh-rail` peers* (no longer renders into `chrome`).
+
+### Trade-offs accepted
+
+- **Chat lines wider than `termWidth - rail_width` clip in the rail's row range** (top-right corner only). Pi's overlay compositor floats; it does not reflow base content (`pi-tui/dist/tui.js:611` — `compositeLineAt` splices the overlay column-range into the base line). The editor and footer sit outside the rail's row range (rail's `maxHeight` is bounded so it never extends down into them) and are unaffected. The latest visible chat (where the human is looking) sits below the rail; only the oldest visible lines on the right are at risk.
+- A follow-up tracks an upstream pi-tui PR for `TUI.setReservedRight(cols)` which would let base components render at `(termWidth - reservedRight)` while overlays still composite in full-`termWidth` coordinates. When that lands, clipping disappears with no other change in this repo. Until then this is acknowledged-cosmetic.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@mariozechner/pi-coding-agent": "^0.70.2",
         "@xterm/headless": "^6.0.0",
         "node-pty": "^1.1.0",
-        "xterm-headless": "^5.3.0",
         "yaml": "^2.8.3"
       },
       "devDependencies": {
@@ -5598,13 +5597,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/xterm-headless": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/xterm-headless/-/xterm-headless-5.3.0.tgz",
-      "integrity": "sha512-HjKkEgvjlyXfZvI0LdQChOqGL5nDiXge6X2IvoQbOn+oavAKUCX9hKHtDxmWVwxgNCCvXDnfQCYL+3wyHQ9PXA==",
-      "deprecated": "This package is now deprecated. Move to @xterm/headless instead.",
-      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",


### PR DESCRIPTION
## Summary

This PR relocates mesh status rendering (peers list, decisions queue) from launcher-level chrome into each peer's pi TUI as a non-capturing overlay. The launcher no longer renders its own chrome to stderr, eliminating cursor interleaving issues that arose during PTY pass-through multiplexing.

## Key Changes

- **ADR-0004 Amendment (2026-05-01)**: Documents the shift from launcher chrome to in-peer overlay rendering, including rationale for the change and rendering pipeline details
- **New `mesh-rail` baseline extension**: Renders mesh status as a `nonCapturing` overlay anchored top-right inside pi's TUI, subscribed to launcher signals via `launcher-bridge`
- **Removed launcher chrome**: `scripts/_lib/chrome.mjs` and related tests deleted; `launch-mesh.mjs` no longer writes peer-state chrome to stderr
- **Refactored state ownership**: `decisions-queue.mjs` and `focus-controller.mjs` now broadcast renderable summaries to peers instead of holding render code
- **New `/decisions` slash command**: Opens a focus-capturing overlay for full peer detail and pin/dismiss affordances; hides the `mesh-rail` while open
- **Updated CONTEXT.md**: Clarified TUI architecture, PTY pass-through behavior, and mesh status rendering location

## Implementation Details

- **Rendering pipeline**: Focused peer's PTY output passes through verbatim to launcher stdout; off-screen peers write only to virtual buffers; focus changes paint the destination's accumulated buffer once with SGR reconstruction before resuming pass-through
- **Overlay composition**: Pi's overlay compositor floats the rail without reflowing base content; chat lines wider than `termWidth - rail_width` may clip in the rail's row range (top-right corner only), with a follow-up planned for upstream pi-tui support to eliminate this
- **Overlay stacking**: The `mesh-rail` hides during `/decisions` and other focus-capturing overlays but remains visible during ambient overlays like intercept confirmations, maintaining mesh-state context

https://claude.ai/code/session_01HH1TU9RrRY2sN5C8Nn1UEs