### PR TITLE
Add mesh-rail status overlay extension for launcher peer mode

### DIFF
--- a/pi-sandbox/.pi/extensions/_lib/mesh-rail.test.ts
+++ b/pi-sandbox/.pi/extensions/_lib/mesh-rail.test.ts
@@ -1,0 +1,124 @@
+/**
+ * mesh-rail.test.ts — hermetic unit tests for mesh-rail overlay state, render, and handle.
+ *
+ * Contract: no I/O, no network, no env from models.env, no real pi runtime.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getMeshRailHandle,
+  setMeshRailHandle,
+  clearMeshRailHandle,
+  createMeshRailComponent,
+  meshRailOverlayOptions,
+} from "./mesh-rail";
+
+describe("mesh-rail handle stash (globalThis)", () => {
+  beforeEach(() => {
+    clearMeshRailHandle();
+  });
+
+  it("getMeshRailHandle() returns undefined before any handle is registered", () => {
+    expect(getMeshRailHandle()).toBeUndefined();
+  });
+
+  it("setMeshRailHandle(h) makes getMeshRailHandle() return that handle", () => {
+    const fakeHandle = {
+      hide: () => {},
+      setHidden: (_: boolean) => {},
+      isHidden: () => false,
+      focus: () => {},
+      unfocus: () => {},
+      isFocused: () => false,
+    };
+    setMeshRailHandle(fakeHandle);
+    expect(getMeshRailHandle()).toBe(fakeHandle);
+  });
+
+  it("clearMeshRailHandle() resets the stash", () => {
+    const fakeHandle = {
+      hide: () => {},
+      setHidden: (_: boolean) => {},
+      isHidden: () => false,
+      focus: () => {},
+      unfocus: () => {},
+      isFocused: () => false,
+    };
+    setMeshRailHandle(fakeHandle);
+    clearMeshRailHandle();
+    expect(getMeshRailHandle()).toBeUndefined();
+  });
+});
+
+describe("createMeshRailComponent — placeholder content", () => {
+  it("renders a header line containing the peer name", () => {
+    const component = createMeshRailComponent({ peerName: "cottontail-writer" });
+    const lines = component.render(40);
+    const all = lines.join("\n");
+    expect(all).toContain("cottontail-writer");
+  });
+
+  it("renders a line containing '0 peers'", () => {
+    const component = createMeshRailComponent({ peerName: "any-peer" });
+    const lines = component.render(40);
+    const all = lines.join("\n");
+    expect(all).toContain("0 peers");
+  });
+
+  it("renders a line containing '0 decisions'", () => {
+    const component = createMeshRailComponent({ peerName: "any-peer" });
+    const lines = component.render(40);
+    const all = lines.join("\n");
+    expect(all).toContain("0 decisions");
+  });
+
+  it("returned component implements the pi-tui Component interface (render + invalidate)", () => {
+    const component = createMeshRailComponent({ peerName: "any-peer" });
+    expect(typeof component.render).toBe("function");
+    expect(typeof component.invalidate).toBe("function");
+    // Sanity: render returns an array of strings.
+    const lines = component.render(40);
+    expect(Array.isArray(lines)).toBe(true);
+    for (const line of lines) expect(typeof line).toBe("string");
+  });
+});
+
+describe("meshRailOverlayOptions", () => {
+  it("anchors the overlay to top-right", () => {
+    expect(meshRailOverlayOptions().anchor).toBe("top-right");
+  });
+
+  it("sets width to '30%'", () => {
+    expect(meshRailOverlayOptions().width).toBe("30%");
+  });
+
+  it("is non-capturing so the editor keeps focus", () => {
+    expect(meshRailOverlayOptions().nonCapturing).toBe(true);
+  });
+
+  it("sets a top margin of 1 to clear the agent header", () => {
+    const opts = meshRailOverlayOptions();
+    const margin = opts.margin;
+    if (typeof margin === "number") {
+      expect(margin).toBeGreaterThanOrEqual(1);
+    } else {
+      expect(margin?.top).toBe(1);
+    }
+  });
+
+  it("sets a bounded maxHeight (caps growth so chat below is not obscured)", () => {
+    const { maxHeight } = meshRailOverlayOptions();
+    expect(maxHeight).toBeDefined();
+    // Bounded: either a small absolute number of rows or a percentage cap.
+    if (typeof maxHeight === "number") {
+      expect(maxHeight).toBeGreaterThan(0);
+      expect(maxHeight).toBeLessThanOrEqual(20);
+    } else {
+      // Percentage like "30%": parse and assert it's a real cap (< 100%).
+      expect(maxHeight).toMatch(/^\d+%$/);
+      const pct = Number((maxHeight as string).slice(0, -1));
+      expect(pct).toBeGreaterThan(0);
+      expect(pct).toBeLessThan(100);
+    }
+  });
+});

--- a/pi-sandbox/.pi/extensions/_lib/mesh-rail.ts
+++ b/pi-sandbox/.pi/extensions/_lib/mesh-rail.ts
@@ -1,0 +1,56 @@
+// mesh-rail.ts — pure helpers for the mesh-rail overlay (state, component factory,
+// overlay options, globalThis handle stash). The extension default export in
+// ../mesh-rail.ts is a thin wrapper that wires session_start to ctx.ui.custom.
+
+import type { Component, OverlayHandle, OverlayOptions } from "@mariozechner/pi-tui";
+
+export interface MeshRailComponentOptions {
+  peerName: string;
+}
+
+export function createMeshRailComponent(opts: MeshRailComponentOptions): Component {
+  return {
+    render(_width: number): string[] {
+      return [
+        opts.peerName,
+        "0 peers",
+        "0 decisions",
+      ];
+    },
+    invalidate(): void {
+      // Static placeholder content; nothing to invalidate yet.
+      // Real signal-driven re-renders land in the follow-up slice (#91).
+    },
+  };
+}
+
+interface MeshRailState {
+  handle?: OverlayHandle;
+}
+
+function getState(): MeshRailState {
+  const g = globalThis as { __pi_mesh_rail__?: MeshRailState };
+  return (g.__pi_mesh_rail__ ??= {});
+}
+
+export function getMeshRailHandle(): OverlayHandle | undefined {
+  return getState().handle;
+}
+
+export function setMeshRailHandle(handle: OverlayHandle): void {
+  getState().handle = handle;
+}
+
+export function clearMeshRailHandle(): void {
+  delete getState().handle;
+}
+
+export function meshRailOverlayOptions(): OverlayOptions {
+  return {
+    anchor: "top-right",
+    width: "30%",
+    maxHeight: 6,
+    margin: { top: 1 },
+    nonCapturing: true,
+  };
+}

--- a/pi-sandbox/.pi/extensions/mesh-rail.prompt.md
+++ b/pi-sandbox/.pi/extensions/mesh-rail.prompt.md
@@ -1,0 +1,9 @@
+## Mesh rail (status overlay)
+
+When you are running under the mesh launcher, a small status overlay is
+rendered in the top-right of your terminal showing your peer name and the
+current peer/decision counts in the mesh.
+
+The overlay is informational only — it captures no keyboard input and exposes
+no model-facing tools. You do not need to do anything with it; treat it as
+chrome from the launcher.

--- a/pi-sandbox/.pi/extensions/mesh-rail.ts
+++ b/pi-sandbox/.pi/extensions/mesh-rail.ts
@@ -1,0 +1,57 @@
+// mesh-rail.ts — in-peer baseline extension that renders a top-right overlay
+// summarising mesh state (peer name, peer count, decisions count). Auto-loaded
+// by run-agent.mjs only when PI_MESH_PEER=1 (i.e. the peer is running under
+// the launcher); raw `npm run pi` and standalone `npm run agent` do not load
+// it. The overlay is `nonCapturing` so the editor keeps focus.
+//
+// This slice (#90) ships static placeholder content. Real signals from the
+// launcher (peer-state, decisions count) land in #91.
+//
+// Slash-command handlers (e.g. /decisions in #93) reach the OverlayHandle via
+// the named export `getMeshRailHandle()`, which reads from a globalThis stash
+// to survive jiti's per-extension module isolation (same pattern as
+// deferred-confirm).
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { getHabitat } from "./_lib/habitat";
+import {
+  createMeshRailComponent,
+  meshRailOverlayOptions,
+  setMeshRailHandle,
+} from "./_lib/mesh-rail";
+
+export {
+  getMeshRailHandle,
+  setMeshRailHandle,
+  clearMeshRailHandle,
+} from "./_lib/mesh-rail";
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    if (!ctx.hasUI) return;
+
+    let peerName: string;
+    try {
+      peerName = getHabitat().agentName;
+    } catch {
+      // Habitat not materialised — degrade silently (defensive; the runner
+      // always loads habitat first, so this branch should not normally hit).
+      return;
+    }
+
+    const component = createMeshRailComponent({ peerName });
+
+    // Fire-and-forget: ctx.ui.custom returns a Promise that resolves when the
+    // overlay is dismissed via `done(...)`. The mesh-rail overlay is permanent
+    // for the lifetime of the session, so we never call done(); the promise
+    // never resolves and that's fine.
+    void ctx.ui.custom(
+      () => component,
+      {
+        overlay: true,
+        overlayOptions: meshRailOverlayOptions(),
+        onHandle: (handle) => setMeshRailHandle(handle),
+      },
+    );
+  });
+}

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -35,10 +35,15 @@ const BASELINE_EXTENSIONS = [
 // When launched under the mesh launcher (PI_MESH_PEER=1), load the launcher
 // bridge, focus-state, and slash-commands extensions as additional baselines.
 // These are silent no-ops when the launcher socket is absent (standalone mode).
+//
+// mesh-rail renders the top-right mesh-status overlay; only meaningful under
+// the launcher. Like the others, it degrades silently if hasUI is false
+// (print mode / no TUI).
 const MESH_PEER_EXTENSIONS = [
   "launcher-bridge",
   "slash-commands",
   "bus-tail-emitter",
+  "mesh-rail",
 ];
 const TIER_VARS = new Set(["RABBIT_SAGE_MODEL", "LEAD_HARE_MODEL", "TASK_RABBIT_MODEL"]);
 


### PR DESCRIPTION
## Summary
Introduces the mesh-rail extension, a non-capturing status overlay that displays mesh peer information in the top-right corner of the terminal when running under the mesh launcher (PI_MESH_PEER=1).

## Key Changes
- **New extension module** (`mesh-rail.ts`): Wires the overlay to the `session_start` event and manages the overlay lifecycle via `ctx.ui.custom()`
- **Pure helper library** (`_lib/mesh-rail.ts`): Provides:
  - `createMeshRailComponent()`: Factory for the overlay component with static placeholder content (peer name, peer count, decision count)
  - `meshRailOverlayOptions()`: Configures the overlay as top-right anchored, 30% width, non-capturing, with bounded height to avoid obscuring chat below
  - Handle stash functions (`getMeshRailHandle`, `setMeshRailHandle`, `clearMeshRailHandle`): Uses globalThis to persist the OverlayHandle across module boundaries, enabling slash-command handlers to interact with the overlay
- **Comprehensive test suite** (`mesh-rail.test.ts`): Hermetic unit tests covering handle stash lifecycle, component rendering, and overlay configuration
- **Documentation** (`mesh-rail.prompt.md`): User-facing description of the overlay as informational chrome
- **Integration** (`run-agent.mjs`): Registers mesh-rail as a baseline extension when running under the launcher

## Implementation Details
- The overlay is **non-capturing** so keyboard focus remains in the editor
- **Fire-and-forget** promise pattern: the overlay is permanent for the session lifetime and never dismissed
- **Graceful degradation**: silently skips initialization if habitat is unavailable or hasUI is false (print mode)
- **Static placeholder content** in this slice; real signal-driven updates (peer state, decision counts) are deferred to follow-up work (#91)
- Uses the same globalThis stash pattern as deferred-confirm to survive jiti's per-extension module isolation

https://claude.ai/code/session_01QVJ4LLpdfkFinUHpCbZ4nK