### PR TITLE
Fix launcher-bridge wiring and mesh-rail state sync race

### DIFF
--- a/pi-sandbox/.pi/extensions/bus-tail-emitter.ts
+++ b/pi-sandbox/.pi/extensions/bus-tail-emitter.ts
@@ -75,7 +75,7 @@ function syncObserver(state: BusTailEmitterState) {
     let makeTailEventEnvelope: ((args: any) => Record<string, unknown>) | undefined;
     try {
       const envMod = _require(
-        path.resolve(__dirname, "../../../../scripts/_lib/launcher-envelope.mjs"),
+        path.resolve(__dirname, "../../../scripts/_lib/launcher-envelope.mjs"),
       ) as { makeTailEventEnvelope?: (args: any) => Record<string, unknown> };
       makeTailEventEnvelope = envMod.makeTailEventEnvelope;
     } catch { /* module not available */ }

--- a/pi-sandbox/.pi/extensions/launcher-bridge.ts
+++ b/pi-sandbox/.pi/extensions/launcher-bridge.ts
@@ -30,6 +30,14 @@ interface BridgeState {
   ready: boolean;
   signalHandlers: Array<(env: any) => void>;
   meshRailUpdateHandlers: Array<(env: any) => void>;
+  // Cache of the most recent mesh-rail-update envelope so a handler that
+  // subscribes after the launcher has already broadcast can replay the latest
+  // snapshot immediately. Without this, the launcher's `client-connected →
+  // broadcastRailUpdate` round-trip races with mesh-rail's `session_start`
+  // (extensions session_start runs sequentially in load order — launcher-bridge
+  // first, mesh-rail last — so the envelope can land in the empty handler
+  // list and be lost).
+  lastMeshRailUpdate: any | null;
 }
 
 function getBridgeState(): BridgeState {
@@ -40,6 +48,7 @@ function getBridgeState(): BridgeState {
     ready: false,
     signalHandlers: [],
     meshRailUpdateHandlers: [],
+    lastMeshRailUpdate: null,
   });
 }
 
@@ -64,10 +73,16 @@ export function onSignal(handler: (env: any) => void): void {
 /**
  * Subscribe to mesh-rail-update envelopes from the launcher.
  * The handler receives the full envelope (peers array + decisionCount).
+ * If the launcher has already broadcast a snapshot before this subscription
+ * landed, the cached envelope is replayed synchronously so the late
+ * subscriber doesn't start out with an empty view.
  */
 export function onMeshRailUpdate(handler: (env: any) => void): void {
   const state = getBridgeState();
   state.meshRailUpdateHandlers.push(handler);
+  if (state.lastMeshRailUpdate) {
+    try { handler(state.lastMeshRailUpdate); } catch { /* ignore handler errors */ }
+  }
 }
 
 /**
@@ -97,7 +112,7 @@ export default function (pi: ExtensionAPI) {
     try {
       // The path is relative to this extension file's location in the repo.
       const sockMod = _require(
-        path.resolve(__dirname, "../../../../scripts/_lib/launcher-socket.mjs"),
+        path.resolve(__dirname, "../../../scripts/_lib/launcher-socket.mjs"),
       );
       createLauncherClient = sockMod.createLauncherClient;
     } catch (e) {
@@ -124,6 +139,10 @@ export default function (pi: ExtensionAPI) {
           break;
         }
         case "mesh-rail-update": {
+          // Cache the latest snapshot so subscribers that register after this
+          // arrival get replayed on subscribe (handles the launcher's
+          // client-connected catch-up vs. mesh-rail session_start race).
+          state.lastMeshRailUpdate = env;
           for (const handler of state.meshRailUpdateHandlers) {
             try { handler(env); } catch { /* ignore handler errors */ }
           }

--- a/pi-sandbox/.pi/extensions/slash-commands.test.ts
+++ b/pi-sandbox/.pi/extensions/slash-commands.test.ts
@@ -1,0 +1,44 @@
+/**
+ * slash-commands.test.ts — regression test for the slash-commands extension's
+ * launcher-bridge wiring.
+ *
+ * The bug being guarded: an earlier revision used
+ *   const _require = createRequire(import.meta.url);
+ *   _require(path.resolve(__dirname, "launcher-bridge"));
+ * to look up sendControl at handler-call time. createRequire is plain Node
+ * CommonJS resolution — it cannot load a `.ts` file. The require always threw
+ * `Cannot find module …/launcher-bridge`, the try/catch swallowed it, and
+ * `/focus`, `/tail`, `/pin`, and the `/decisions` non-UI fallback all reported
+ *   "launcher-bridge not active (standalone mode)".
+ *
+ * The fix is to use a static `import { sendControl } from "./launcher-bridge"`,
+ * which jiti rewrites during transformation. This test reads the extension
+ * source and asserts that the static import is present and the broken
+ * dynamic-require pattern is absent.
+ *
+ * Contract: pure file-content assertions; no jiti, no pi runtime, no I/O
+ * beyond reading the sibling source file.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(path.join(__dirname, "slash-commands.ts"), "utf8");
+
+describe("slash-commands — launcher-bridge wiring", () => {
+  it("statically imports sendControl from ./launcher-bridge", () => {
+    // The transformation jiti applies to .ts handles `./launcher-bridge`
+    // resolution; createRequire cannot. Tolerant regex so renaming the local
+    // alias (e.g. `bridgeSendControl`) doesn't accidentally fail this guard.
+    expect(SRC).toMatch(/import\s*\{[^}]*\bsendControl\b[^}]*\}\s*from\s*['"]\.\/launcher-bridge['"]/);
+  });
+
+  it("does not _require('./launcher-bridge') (broken: createRequire cannot load .ts)", () => {
+    // Match any createRequire-style call that resolves to launcher-bridge —
+    // both `_require("launcher-bridge")` and `_require(path.resolve(__dirname, "launcher-bridge"))`.
+    expect(SRC).not.toMatch(/_require\([^)]*['"]launcher-bridge['"][^)]*\)/);
+  });
+});

--- a/pi-sandbox/.pi/extensions/slash-commands.test.ts
+++ b/pi-sandbox/.pi/extensions/slash-commands.test.ts
@@ -42,3 +42,39 @@ describe("slash-commands — launcher-bridge wiring", () => {
     expect(SRC).not.toMatch(/_require\([^)]*['"]launcher-bridge['"][^)]*\)/);
   });
 });
+
+describe("extensions → scripts/_lib path resolution", () => {
+  // Regression for the silent-no-op bug: extensions live at
+  // pi-sandbox/.pi/extensions/<name>.ts, three levels below the repo root.
+  // path.resolve(__dirname, "../../../scripts/_lib/<file>") lands on the
+  // shared module; "../../../../…" went one level too far up to /home/user
+  // and made createRequire fail with "Cannot find module …", which the
+  // surrounding try/catch swallowed. Net effect: launcher-bridge / slash
+  // commands / supervisor / bus-tail-emitter all silently degraded to
+  // standalone mode, which is exactly the failure mode the user reported.
+  const EXT_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+  it("resolves scripts/_lib/launcher-socket.mjs from launcher-bridge.ts", () => {
+    const fs = require("node:fs") as typeof import("node:fs");
+    const src = fs.readFileSync(path.join(EXT_DIR, "launcher-bridge.ts"), "utf8");
+    const match = src.match(/path\.resolve\(__dirname,\s*['"]([^'"]+launcher-socket\.mjs)['"]\)/);
+    expect(match, "expected one path.resolve(__dirname, '…/launcher-socket.mjs') call").not.toBeNull();
+    const resolved = path.resolve(EXT_DIR, match![1]);
+    expect(fs.existsSync(resolved)).toBe(true);
+  });
+
+  it.each([
+    "slash-commands.ts",
+    "bus-tail-emitter.ts",
+    "supervisor.ts",
+  ])("resolves scripts/_lib/launcher-envelope.mjs from %s", (file) => {
+    const fs = require("node:fs") as typeof import("node:fs");
+    const src = fs.readFileSync(path.join(EXT_DIR, file), "utf8");
+    const matches = [...src.matchAll(/path\.resolve\(__dirname,\s*['"]([^'"]+launcher-envelope\.mjs)['"]\)/g)];
+    expect(matches.length, `${file} should reference launcher-envelope.mjs at least once`).toBeGreaterThan(0);
+    for (const match of matches) {
+      const resolved = path.resolve(EXT_DIR, match[1]);
+      expect(fs.existsSync(resolved), `${file}: ${match[1]} → ${resolved} must exist`).toBe(true);
+    }
+  });
+});

--- a/pi-sandbox/.pi/extensions/slash-commands.ts
+++ b/pi-sandbox/.pi/extensions/slash-commands.ts
@@ -29,9 +29,10 @@ const _require = createRequire(import.meta.url);
 
 // Resolve the launcher-envelope module path relative to this extension file.
 // The extension lives at pi-sandbox/.pi/extensions/slash-commands.ts; the
-// launcher-envelope lives at scripts/_lib/launcher-envelope.mjs (4 levels up).
+// launcher-envelope lives at scripts/_lib/launcher-envelope.mjs — 3 levels
+// up (extensions → .pi → pi-sandbox → repo root), then down into scripts/_lib.
 function getLauncherEnvelopePath(): string {
-  return path.resolve(__dirname, "../../../../scripts/_lib/launcher-envelope.mjs");
+  return path.resolve(__dirname, "../../../scripts/_lib/launcher-envelope.mjs");
 }
 
 // Per-peer tail state, stashed on globalThis so it survives jiti module isolation.

--- a/pi-sandbox/.pi/extensions/slash-commands.ts
+++ b/pi-sandbox/.pi/extensions/slash-commands.ts
@@ -18,6 +18,12 @@ import path from "node:path";
 import { getHabitat } from "./_lib/habitat";
 import { getMeshRailHandle } from "./_lib/mesh-rail";
 import { createDecisionsOverlayComponent } from "./_lib/decisions-overlay";
+// IMPORTANT: this is a static jiti-resolved import, not createRequire().
+// Node's createRequire cannot resolve .ts files, so any attempt to load the
+// bridge dynamically (e.g. _require("./launcher-bridge")) silently throws and
+// the slash commands fall back to "standalone mode". Pulling the helpers in
+// statically lets jiti rewrite the path during transformation.
+import { sendControl as bridgeSendControl } from "./launcher-bridge";
 
 const _require = createRequire(import.meta.url);
 
@@ -55,26 +61,10 @@ export default function (pi: ExtensionAPI) {
       const habitat = getHabitat();
       const agentName = habitat.agentName;
 
-      // Load the launcher-bridge module to send the focus-request.
-      let sendControl: ((env: Record<string, unknown>) => boolean) | undefined;
-      try {
-        // The bridge is loaded by the launcher-bridge extension and stashes its
-        // API on globalThis. Access it via the module exports.
-        const bridge = _require(
-          path.resolve(__dirname, "launcher-bridge"),
-        ) as { sendControl?: (env: Record<string, unknown>) => boolean };
-        sendControl = bridge.sendControl;
-      } catch {
-        // launcher-bridge not loaded or not available.
-      }
-
-      if (!sendControl) {
-        ctx.ui.notify(
-          "/focus: launcher-bridge not active (standalone mode). Cannot switch focus.",
-          "warning",
-        );
-        return;
-      }
+      // bridgeSendControl is the launcher-bridge's exported send helper. It
+      // returns false in standalone mode (no launcher socket), which we map to
+      // a friendly warning further down.
+      const sendControl = bridgeSendControl;
 
       // Build a focus-request envelope.
       let makeFocusRequestEnvelope: ((args: { from: string; target: string }) => Record<string, unknown>) | undefined;
@@ -112,24 +102,8 @@ export default function (pi: ExtensionAPI) {
     handler: async (args: string, ctx) => {
       const filter = args.trim() || undefined;
 
-      // Load the launcher-bridge module to send the tail-toggle envelope.
-      let sendControl: ((env: Record<string, unknown>) => boolean) | undefined;
-      try {
-        const bridge = _require(
-          path.resolve(__dirname, "launcher-bridge"),
-        ) as { sendControl?: (env: Record<string, unknown>) => boolean };
-        sendControl = bridge.sendControl;
-      } catch {
-        // launcher-bridge not loaded or not available.
-      }
-
-      if (!sendControl) {
-        ctx.ui.notify(
-          "/tail: launcher-bridge not active (standalone mode). Cannot toggle bus-tail.",
-          "warning",
-        );
-        return;
-      }
+      // bridgeSendControl is statically imported from launcher-bridge above.
+      const sendControl = bridgeSendControl;
 
       // Build a tail-toggle envelope.
       let makeTailToggleEnvelope:
@@ -192,21 +166,7 @@ export default function (pi: ExtensionAPI) {
         return;
       }
 
-      // Load the launcher-bridge.
-      let sendControl: ((env: Record<string, unknown>) => boolean) | undefined;
-      try {
-        const bridge = _require(
-          path.resolve(__dirname, "launcher-bridge"),
-        ) as { sendControl?: (env: Record<string, unknown>) => boolean };
-        sendControl = bridge.sendControl;
-      } catch {
-        // launcher-bridge not loaded or not available.
-      }
-
-      if (!sendControl) {
-        ctx.ui.notify("/pin: launcher-bridge not active (standalone mode). Cannot pin dialog.", "warning");
-        return;
-      }
+      const sendControl = bridgeSendControl;
 
       // Build a pin-request envelope.
       let makePinRequestEnvelope: ((args: { msg_id: string; peer: string; kind: string; summary: string }) => Record<string, unknown>) | undefined;
@@ -252,20 +212,7 @@ export default function (pi: ExtensionAPI) {
         const habitat = getHabitat();
         const agentName = habitat.agentName;
 
-        let sendControl: ((env: Record<string, unknown>) => boolean) | undefined;
-        try {
-          const bridge = _require(
-            path.resolve(__dirname, "launcher-bridge"),
-          ) as { sendControl?: (env: Record<string, unknown>) => boolean };
-          sendControl = bridge.sendControl;
-        } catch {
-          // launcher-bridge not loaded or not available.
-        }
-
-        if (!sendControl) {
-          ctx.ui.notify("/decisions: no UI and launcher-bridge not active (standalone mode).", "warning");
-          return;
-        }
+        const sendControl = bridgeSendControl;
 
         let makeDecisionsJumpEnvelope: ((args: { from: string }) => Record<string, unknown>) | undefined;
         try {
@@ -307,34 +254,23 @@ export default function (pi: ExtensionAPI) {
       );
 
       // If the user pressed Enter on a decision, emit a focus-request so the
-      // launcher switches to that peer's pane.
+      // launcher switches to that peer's pane. Best-effort: bridgeSendControl
+      // returns false in standalone mode and the user has already gotten what
+      // they wanted from the overlay.
       if (result && result.action === "focus-peer" && result.peer) {
-        // Attempt to send a focus-request via the launcher-bridge (best effort).
-        let sendControl: ((env: Record<string, unknown>) => boolean) | undefined;
+        let makeFocusRequestEnvelope: ((args: { from: string; target: string }) => Record<string, unknown>) | undefined;
         try {
-          const bridge = _require(
-            path.resolve(__dirname, "launcher-bridge"),
-          ) as { sendControl?: (env: Record<string, unknown>) => boolean };
-          sendControl = bridge.sendControl;
+          const envMod = _require(getLauncherEnvelopePath()) as {
+            makeFocusRequestEnvelope: (args: { from: string; target: string }) => Record<string, unknown>;
+          };
+          makeFocusRequestEnvelope = envMod.makeFocusRequestEnvelope;
         } catch {
-          // launcher-bridge not loaded — no focus switch, that is fine.
+          // ignore — launcher-envelope module not resolvable
         }
 
-        if (sendControl) {
-          let makeFocusRequestEnvelope: ((args: { from: string; target: string }) => Record<string, unknown>) | undefined;
-          try {
-            const envMod = _require(getLauncherEnvelopePath()) as {
-              makeFocusRequestEnvelope: (args: { from: string; target: string }) => Record<string, unknown>;
-            };
-            makeFocusRequestEnvelope = envMod.makeFocusRequestEnvelope;
-          } catch {
-            // ignore
-          }
-
-          if (makeFocusRequestEnvelope) {
-            const habitat = getHabitat();
-            sendControl(makeFocusRequestEnvelope({ from: habitat.agentName, target: result.peer }));
-          }
+        if (makeFocusRequestEnvelope) {
+          const habitat = getHabitat();
+          bridgeSendControl(makeFocusRequestEnvelope({ from: habitat.agentName, target: result.peer }));
         }
       }
     },

--- a/pi-sandbox/.pi/extensions/supervisor.ts
+++ b/pi-sandbox/.pi/extensions/supervisor.ts
@@ -83,7 +83,7 @@ function signalDecisionPending(agentName: string, on: boolean): void {
   // relative to the extension, loaded via require at runtime).
   try {
     const { makeDecisionPendingEnvelope } = _require(
-      path.resolve(__dirname, "../../../../scripts/_lib/launcher-envelope.mjs"),
+      path.resolve(__dirname, "../../../scripts/_lib/launcher-envelope.mjs"),
     ) as { makeDecisionPendingEnvelope: (args: { peer: string; on: boolean }) => Record<string, unknown> };
     const env = makeDecisionPendingEnvelope({ peer: agentName, on });
     sendControlToLauncher(env);

--- a/scripts/_lib/focus-controller.mjs
+++ b/scripts/_lib/focus-controller.mjs
@@ -90,6 +90,16 @@ export class FocusController extends EventEmitter {
   }
 
   /**
+   * Re-emit the current `mesh-rail-update` envelope. Used by the launcher to
+   * catch a freshly-connected peer up to the latest state without having to
+   * trigger a state mutation. No-op when no broadcast function has been
+   * injected.
+   */
+  broadcastRailUpdate() {
+    this._broadcastRailUpdate();
+  }
+
+  /**
    * Build and broadcast a `mesh-rail-update` envelope to all connected peers.
    * No-op when no broadcast function has been injected.
    */

--- a/scripts/_lib/focus-controller.test.ts
+++ b/scripts/_lib/focus-controller.test.ts
@@ -456,4 +456,29 @@ describe("FocusController — setBroadcast / _broadcastRailUpdate", () => {
     expect(peer).toBeDefined();
     expect(peer.decisionPending).toBe(true);
   });
+
+  // Regression for "mesh-rail stuck at 0 peers" — peers connect to the
+  // launcher socket asynchronously, after registerPeer() has already
+  // broadcast. The launcher uses broadcastRailUpdate() on each
+  // client-connected to catch the late arrival up to the current state.
+  it("broadcastRailUpdate() re-emits the current snapshot on demand", () => {
+    const fc = createFocusController();
+    fc.registerPeer("peer-a");
+    fc.registerPeer("peer-b");
+    const emitted: any[] = [];
+    fc.setBroadcast((env) => emitted.push(env));
+
+    fc.broadcastRailUpdate();
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].kind).toBe("mesh-rail-update");
+    expect(emitted[0].peers.map((p: any) => p.name)).toEqual(["peer-a", "peer-b"]);
+  });
+
+  it("broadcastRailUpdate() is a no-op when no broadcast function is wired", () => {
+    const fc = createFocusController();
+    fc.registerPeer("peer-a");
+    // No setBroadcast call — must not throw.
+    expect(() => fc.broadcastRailUpdate()).not.toThrow();
+  });
 });

--- a/scripts/launch-mesh.mjs
+++ b/scripts/launch-mesh.mjs
@@ -227,6 +227,24 @@ pool.on("error", (peer, err) => {
 const launcherSock = createLauncherSocket();
 await launcherSock.bind(busRoot);
 
+// Wire focusController → launcher broadcast. Without this, every state-mutating
+// call (registerPeer, setFocus, setPeerState, …) silently no-ops its
+// mesh-rail-update broadcast and each peer's mesh-rail widget stays stuck at
+// "0 peers". The decisions-count getter pulls live from decisionsQueue so the
+// envelope reflects the current pin queue size.
+focusController.setBroadcast(
+  (env) => launcherSock.broadcast(env),
+  () => decisionsQueue.count(),
+);
+
+// Each peer's launcher-bridge connects asynchronously after spawn. By the time
+// it lands on the socket, all the registerPeer() broadcasts have already
+// fired, so the late arrival would never see them. Re-emit a snapshot on every
+// client-connected so the newcomer's mesh-rail catches up.
+launcherSock.on("client-connected", () => {
+  focusController.broadcastRailUpdate();
+});
+
 // When the focus controller changes focus, broadcast focus-changed to all
 // connected peers and repaint the multiplexer. mesh-rail handles peer-status display.
 focusController.on("focus-changed", ({ focused }) => {


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs that caused the launcher and mesh-rail to silently degrade to standalone mode:

1. **Broken launcher-bridge imports**: The slash-commands extension (and related extensions) were using `createRequire()` to dynamically load `launcher-bridge.ts` at runtime, which fails because Node's CommonJS resolver cannot load `.ts` files. The require always threw silently, causing `/focus`, `/tail`, `/pin`, and `/decisions` commands to report "launcher-bridge not active (standalone mode)".

2. **Mesh-rail state sync race**: Peers connect to the launcher socket asynchronously after `registerPeer()` broadcasts have already fired, causing newly-connected peers to see an empty mesh-rail widget ("0 peers"). The launcher wasn't re-emitting state snapshots to catch late arrivals up to the current state.

## Key Changes

- **Static import of launcher-bridge**: Changed from dynamic `_require(path.resolve(__dirname, "launcher-bridge"))` to static `import { sendControl as bridgeSendControl } from "./launcher-bridge"`. This allows jiti to rewrite the path during transformation, enabling `.ts` file resolution.

- **Fixed path resolution**: Corrected relative paths from `../../../../scripts/_lib/` to `../../../scripts/_lib/` in launcher-bridge, slash-commands, bus-tail-emitter, and supervisor extensions. The extensions live 3 levels below the repo root (extensions → .pi → pi-sandbox → root), not 4.

- **Mesh-rail update caching**: Added `lastMeshRailUpdate` cache to launcher-bridge's BridgeState. When a handler subscribes to `onMeshRailUpdate()` after the launcher has already broadcast, the cached envelope is replayed synchronously so late subscribers don't start with an empty view.

- **Broadcast on client-connected**: Added `focusController.broadcastRailUpdate()` call in launch-mesh.mjs when a client connects, ensuring newly-connected peers receive the current state snapshot immediately.

- **New public API**: Added `broadcastRailUpdate()` method to FocusController to re-emit the current mesh-rail-update envelope on demand.

- **Regression tests**: Added comprehensive test suite (slash-commands.test.ts) that validates the static import pattern and path resolution, guarding against future regressions of the createRequire bug.

- **FocusController tests**: Added tests for `broadcastRailUpdate()` behavior, including the no-op case when no broadcast function is wired.

## Implementation Details

The fix leverages jiti's transformation pipeline: static imports of `.ts` files are rewritten during module transformation, whereas dynamic `createRequire()` calls use plain Node resolution and fail silently. By moving to static imports, the launcher-bridge API is now reliably available to all slash commands.

The mesh-rail race is solved by treating the launcher socket's `client-connected` event as a trigger to re-broadcast the current state, combined with caching the latest envelope in launcher-bridge so even out-of-order subscriptions get the snapshot they need.

https://claude.ai/code/session_01N5Xs8Yr3sZ4nQ8qYfU8Z58