### PR TITLE
Drop --mode rpc for mesh peers so /focus shows full TUI, not JSON

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -694,7 +694,7 @@ nodes:
   - name: authority             # instance name on the bus (--agent-name)
     recipe: mesh-authority      # pi-sandbox/agents/<recipe>.yaml
     sandbox: /tmp/mesh/auth     # optional; auto-created under /tmp if omitted
-    task: "..."                 # optional; sent as the first RPC prompt
+    task: "..."                 # optional; passed to pi as the first user message
 
   # Habitat-overlay fields — override recipe + group_bindings values:
   - name: w1

--- a/pi-sandbox/.pi/extensions/_lib/virtual-buffer.mjs
+++ b/pi-sandbox/.pi/extensions/_lib/virtual-buffer.mjs
@@ -166,6 +166,8 @@ export class VirtualBuffer {
     this._term = new Terminal({ cols, rows, allowProposedApi: true });
     this._dirty = true;
     this._cachedPaint = "";
+    /** @type {Promise<void> | null} most recent in-flight xterm parse */
+    this._lastWrite = null;
   }
 
   /** Number of columns in the virtual buffer. */
@@ -187,9 +189,38 @@ export class VirtualBuffer {
    */
   write(data) {
     this._dirty = true;
-    return new Promise((resolve) => {
+    const p = new Promise((resolve) => {
       this._term.write(data, resolve);
     });
+    this._lastWrite = p;
+    // Clear the in-flight reference once this write completes, so drain()
+    // doesn't keep references to long-resolved Promises.
+    p.then(() => {
+      if (this._lastWrite === p) this._lastWrite = null;
+    });
+    return p;
+  }
+
+  /**
+   * Wait until xterm has finished parsing every write issued so far.
+   * The multiplexer calls this on focus change so the next paint() reflects
+   * the most recently-arrived PTY chunks instead of a pre-parse snapshot.
+   *
+   * Re-checks after each await so writes that arrive during the wait are
+   * also drained (otherwise a peer producing back-to-back chunks could
+   * still leave the painted snapshot one chunk behind).
+   *
+   * @returns {Promise<void>}
+   */
+  async drain() {
+    while (this._lastWrite) {
+      const p = this._lastWrite;
+      await p;
+      if (this._lastWrite === p) {
+        this._lastWrite = null;
+        break;
+      }
+    }
   }
 
   /**

--- a/pi-sandbox/.pi/extensions/_lib/virtual-buffer.mjs
+++ b/pi-sandbox/.pi/extensions/_lib/virtual-buffer.mjs
@@ -193,6 +193,16 @@ export class VirtualBuffer {
   }
 
   /**
+   * Force the next paint() to re-render from xterm's current state. Used by
+   * the multiplexer on focus change so a stale cached snapshot can't ghost
+   * behind the new peer's screen.
+   */
+  invalidate() {
+    this._dirty = true;
+    this._cachedPaint = "";
+  }
+
+  /**
    * Resize the virtual buffer. Invalidates the cached paint.
    *
    * @param {number} cols

--- a/pi-sandbox/.pi/extensions/_lib/virtual-buffer.test.ts
+++ b/pi-sandbox/.pi/extensions/_lib/virtual-buffer.test.ts
@@ -272,3 +272,34 @@ describe("paint() cursor position", () => {
     vb.dispose();
   });
 });
+
+describe("drain", () => {
+  it("resolves immediately when no writes are pending", async () => {
+    const vb = createVirtualBuffer({ cols: 40, rows: 10 });
+    await vb.drain();
+    vb.dispose();
+  });
+
+  it("waits for in-flight write() to finish parsing", async () => {
+    const vb = createVirtualBuffer({ cols: 40, rows: 10 });
+    // Fire-and-forget a write the way pty-pool does — do not await it here.
+    vb.write("late-content");
+    // drain() should wait until xterm has parsed the chunk before resolving.
+    await vb.drain();
+    expect(vb.paint()).toContain("late-content");
+    vb.dispose();
+  });
+
+  it("drains additional writes that arrive while drain() is waiting", async () => {
+    const vb = createVirtualBuffer({ cols: 40, rows: 10 });
+    vb.write("first");
+    const drainPromise = vb.drain();
+    // Schedule a second write before the first finishes parsing.
+    queueMicrotask(() => { vb.write("second"); });
+    await drainPromise;
+    const out = vb.paint();
+    expect(out).toContain("first");
+    expect(out).toContain("second");
+    vb.dispose();
+  });
+});

--- a/pi-sandbox/.pi/extensions/agent-bus.prompt.md
+++ b/pi-sandbox/.pi/extensions/agent-bus.prompt.md
@@ -28,10 +28,10 @@ first 8 characters.
 other peers are queued and will surface as user prompts after the call
 returns — you cannot handle them concurrently.
 
-**Mesh nodes** run in `--mode rpc` (long-lived subprocess mode). After
-your initial turn completes, the process stays alive waiting for the
-next bus message. You do not need to loop or poll — just finish your
-response and the next message will start a new turn automatically.
+**Mesh nodes** are long-lived: after your initial turn completes, the
+process stays alive waiting for the next bus message. You do not need
+to loop or poll — just finish your response and the next message will
+start a new turn automatically.
 
 `peer offline` and `timeout` are normal failure modes, not errors to
 retry — there is no offline queue or retry mechanism.

--- a/pi-sandbox/.pi/extensions/launcher-bridge.ts
+++ b/pi-sandbox/.pi/extensions/launcher-bridge.ts
@@ -164,9 +164,21 @@ export default function (pi: ExtensionAPI) {
       if (process.env.AGENT_DEBUG === "1") {
         ctx.ui.notify("launcher-bridge: connected to launcher socket", "info");
       }
-    } catch {
+    } catch (err) {
       // Launcher socket not present — standalone mode. Degrade gracefully.
       state.client = null;
+      // Loud one-line warning so failures aren't invisible. PI_MESH_PEER=1
+      // means we are running under the launcher and a connect failure here
+      // is a real bug (mesh-rail will stay empty, /focus broadcasts will be
+      // missed). When PI_MESH_PEER is unset this is the legitimate
+      // standalone-mode path and we stay quiet.
+      if (process.env.PI_MESH_PEER === "1") {
+        const reason = (err && (err as { message?: string }).message) || String(err);
+        process.stderr.write(
+          `launcher-bridge: connect failed to ${busRoot}/__launcher__.sock — ${reason}\n` +
+          `                 (peer "${agentName}" running standalone; mesh-rail and /focus will not work)\n`,
+        );
+      }
       if (process.env.AGENT_DEBUG === "1") {
         ctx.ui.notify("launcher-bridge: launcher socket not found (standalone mode)", "info");
       }

--- a/pi-sandbox/.pi/extensions/mesh-rail.ts
+++ b/pi-sandbox/.pi/extensions/mesh-rail.ts
@@ -16,7 +16,7 @@ import {
   setMeshRailHandle,
   clearMeshRailHandle,
 } from "./_lib/mesh-rail";
-import { onMeshRailUpdate } from "./launcher-bridge";
+import { onMeshRailUpdate, getFocusState } from "./launcher-bridge";
 
 export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
@@ -45,18 +45,34 @@ export default function (pi: ExtensionAPI) {
       });
     });
 
+    // Stash the TUI reference so the focus-in handler below can call
+    // requestRender(true). Extensions only get a TUI handle via component
+    // factories; this widget always mounts under PI_MESH_PEER, so the
+    // factory is guaranteed to run before any focus-changed event matters.
+    let tuiRef: { requestRender?: (force?: boolean) => void } | undefined;
+
     ctx.ui.setWidget(
       "mesh-rail",
       (tui) => {
+        tuiRef = tui as unknown as { requestRender?: (force?: boolean) => void };
         // Inject the invalidate callback so component.update() can trigger
         // an active re-render rather than waiting for the next natural frame.
-        (handle as any)._setInvalidate(() =>
-          (tui as unknown as { requestRender?: () => void }).requestRender?.(),
-        );
+        (handle as any)._setInvalidate(() => tuiRef?.requestRender?.());
         return handle;
       },
       { placement: "aboveEditor" },
     );
+
+    // When this peer becomes the focused peer in the launcher, force pi's
+    // renderer to clear and redraw from scratch. The launcher-side hard-reset
+    // wipes the terminal but pi's diff-render machinery still believes the
+    // screen contains its previousLines, so without force=true subsequent
+    // updates only emit the diff and the screen stays "stale" in the user's
+    // real terminal. requestRender(true) resets previousLines/cursorRow and
+    // re-emits the full TUI through the PTY.
+    getFocusState().on("focus-changed", ({ focused }: { focused: boolean }) => {
+      if (focused) tuiRef?.requestRender?.(true);
+    });
   });
 
   pi.on("session_end", async () => {

--- a/scripts/_lib/multiplexer.mjs
+++ b/scripts/_lib/multiplexer.mjs
@@ -108,8 +108,32 @@ export class Multiplexer extends EventEmitter {
       // regions, SGR attrs, and alt-screen content from the previously-focused
       // peer don't ghost behind the new peer's snapshot.
       this._repaint({ hardReset: true });
+      // Schedule a follow-up paint after the new peer's xterm parser has
+      // drained pending writes — otherwise PTY chunks that arrived just
+      // before the switch are still being parsed when paint() ran above,
+      // leaving the snapshot stale until the next chunk arrives.
+      void this._followupPaintAfterDrain(name);
       this.emit("focus-changed", name);
     }
+  }
+
+  /**
+   * Re-paint the focused peer once xterm has finished parsing any in-flight
+   * writes. No-op if focus changed again before the drain resolved.
+   *
+   * @param {string} expectedFocus
+   * @returns {Promise<void>}
+   */
+  async _followupPaintAfterDrain(expectedFocus) {
+    if (!this._pool) return;
+    const vb = this._pool.getBuffer(expectedFocus);
+    if (!vb || typeof vb.drain !== "function") return;
+    await vb.drain();
+    // Bail if the user switched focus again while we were waiting.
+    if (this._focused !== expectedFocus) return;
+    if (typeof vb.invalidate === "function") vb.invalidate();
+    const ansi = vb.paint();
+    this._out.write(ansi);
   }
 
   /**

--- a/scripts/_lib/multiplexer.mjs
+++ b/scripts/_lib/multiplexer.mjs
@@ -104,7 +104,10 @@ export class Multiplexer extends EventEmitter {
     const prev = this._focused;
     this._focused = name;
     if (name !== prev) {
-      this._repaint();
+      // Focus change: hard-reset terminal state before repainting so scroll
+      // regions, SGR attrs, and alt-screen content from the previously-focused
+      // peer don't ghost behind the new peer's snapshot.
+      this._repaint({ hardReset: true });
       this.emit("focus-changed", name);
     }
   }
@@ -160,10 +163,24 @@ export class Multiplexer extends EventEmitter {
 
   // ── private ─────────────────────────────────────────────────────────────────
 
-  _repaint() {
+  /**
+   * @param {{ hardReset?: boolean }} [opts]
+   */
+  _repaint(opts = {}) {
     if (!this._focused || !this._pool) return;
     const vb = this._pool.getBuffer(this._focused);
     if (!vb) return;
+    if (opts.hardReset) {
+      // DECSTR (soft terminal reset) + erase scrollback + erase screen + home.
+      // Forces the terminal back to a known state before paint() writes the
+      // new peer's snapshot, so SGR / scroll-region / alt-screen residue from
+      // the previously-focused peer doesn't ghost through.
+      this._out.write("\x1b[!p\x1b[3J\x1b[2J\x1b[H");
+      // Invalidate the virtual buffer's cached paint so paint() re-renders
+      // from xterm-headless's current state instead of returning a stale
+      // snapshot that was generated before recent PTY chunks were parsed.
+      if (typeof vb.invalidate === "function") vb.invalidate();
+    }
     const ansi = vb.paint();
     this._out.write(ansi);
   }

--- a/scripts/_lib/multiplexer.test.ts
+++ b/scripts/_lib/multiplexer.test.ts
@@ -213,7 +213,7 @@ describe("attachPool", () => {
 // ── setFocus is the slice-3 seam ─────────────────────────────────────────────
 
 describe("setFocus seam for slice-3 focus switching", () => {
-  it("switching focus writes exactly one snapshot of the new peer's buffer", () => {
+  it("switching focus emits a hard-reset prefix then the new peer's snapshot", () => {
     const out = makeOutputStream();
     const pool = makeFakePool();
     let paintCount = 0;
@@ -228,8 +228,10 @@ describe("setFocus seam for slice-3 focus switching", () => {
     paintCount = 0;
 
     mux.setFocus("peer-b");
-    // Must write exactly the snapshot string once
-    expect(out.output).toBe("BUFFER-B");
+    // DECSTR + erase scrollback + erase screen + home, then the snapshot.
+    // Without the prefix, ANSI residue (scroll regions, SGR, alt-screen state)
+    // from peer-a leaks into peer-b's painted output.
+    expect(out.output).toBe("\x1b[!p\x1b[3J\x1b[2J\x1b[H" + "BUFFER-B");
     expect(paintCount).toBe(1);
   });
 

--- a/scripts/_lib/pty-pool.mjs
+++ b/scripts/_lib/pty-pool.mjs
@@ -191,6 +191,23 @@ export class PtyPool extends EventEmitter {
   }
 
   /**
+   * Send SIGWINCH directly to a peer's PTY process, unconditionally.
+   * Unlike resize(), this works even when dimensions haven't changed —
+   * ioctl(TIOCSWINSZ) only delivers SIGWINCH when dims differ, so focus
+   * switches (same size) need this path to nudge pi into a full redraw.
+   *
+   * @param {string} name
+   */
+  signalSigwinch(name) {
+    const peer = this._peers.get(name);
+    if (!peer) return;
+    if (peer.status.state !== "running") return;
+    try {
+      process.kill(peer.pty.pid, "SIGWINCH");
+    } catch { /* process may have exited */ }
+  }
+
+  /**
    * Resize ALL peers to new dimensions (e.g. after SIGWINCH on the launcher terminal).
    *
    * @param {number} cols

--- a/scripts/_lib/pty-pool.mjs
+++ b/scripts/_lib/pty-pool.mjs
@@ -191,23 +191,6 @@ export class PtyPool extends EventEmitter {
   }
 
   /**
-   * Send SIGWINCH directly to a peer's PTY process, unconditionally.
-   * Unlike resize(), this works even when dimensions haven't changed —
-   * ioctl(TIOCSWINSZ) only delivers SIGWINCH when dims differ, so focus
-   * switches (same size) need this path to nudge pi into a full redraw.
-   *
-   * @param {string} name
-   */
-  signalSigwinch(name) {
-    const peer = this._peers.get(name);
-    if (!peer) return;
-    if (peer.status.state !== "running") return;
-    try {
-      process.kill(peer.pty.pid, "SIGWINCH");
-    } catch { /* process may have exited */ }
-  }
-
-  /**
    * Resize ALL peers to new dimensions (e.g. after SIGWINCH on the launcher terminal).
    *
    * @param {number} cols

--- a/scripts/launch-mesh.mjs
+++ b/scripts/launch-mesh.mjs
@@ -254,10 +254,11 @@ focusController.on("focus-changed", ({ focused }) => {
   launcherSock.broadcast(env);
   if (mux && focused) {
     mux.setFocus(focused);
-    // Nudge pi to fully redraw its TUI. ioctl(TIOCSWINSZ) only delivers
-    // SIGWINCH when dims change, so pool.resize() with same dimensions is a
-    // no-op. Send the signal directly to guarantee delivery regardless.
-    pool.signalSigwinch(focused);
+    // Pi's full redraw on focus-in is triggered peer-side by mesh-rail
+    // calling tui.requestRender(true) on the focus-changed envelope.
+    // Bare SIGWINCH from outside doesn't fire pi's resize handler
+    // (Node only emits "resize" on actual dim change), so the launcher
+    // itself does no further nudging beyond the broadcast above.
   } else if (mux && !focused) {
     mux.setFocus(null);
   }

--- a/scripts/launch-mesh.mjs
+++ b/scripts/launch-mesh.mjs
@@ -13,7 +13,7 @@
 //     - name: authority           # instance name (--agent-name)
 //       recipe: mesh-authority    # recipe in pi-sandbox/agents/
 //       sandbox: /tmp/mesh/auth   # optional; auto-created
-//       task: "..."               # optional; if set, passes -p (non-interactive)
+//       task: "..."               # optional; sent to the peer as the first user message
 //     - name: analyst
 //       recipe: mesh-node
 //       supervisor: authority     # all non-root nodes must declare a supervisor
@@ -177,9 +177,11 @@ function repaintBusTail() {
 // The focused peer's buffer is rendered live to the launcher's terminal.
 // Focus can be switched by a peer sending a focus-request to the launcher socket.
 //
-// PTY-in-PTY fix (slice 3): run-agent.mjs checks PI_MESH_PEER=1 and uses
-// inherited stdio when its own stdout is already inside a managed PTY,
-// preventing the PTY-in-PTY nesting that slice 2 had for non-entry peers.
+// PTY-in-PTY fix: run-agent.mjs checks PI_MESH_PEER=1 and uses inherited
+// stdio when its own stdout is already inside the launcher's managed PTY,
+// preventing PTY-in-PTY nesting. Every peer now runs the full pi TUI
+// (no `--mode rpc`); the multiplexer accumulates each peer's ANSI into a
+// VirtualBuffer and paints the focused peer's snapshot on /focus switch.
 //
 // TODO(manual-tmux-check): verify multi-peer focus switching with:
 //   set -a; source models.env; set +a
@@ -403,9 +405,14 @@ for (let i = 0; i < topology.nodes.length; i++) {
 
   const overlay = nodeOverlays.get(name);
 
-  // Non-entry peers run in --mode rpc so the entry peer's PTY gets full terminal.
-  // The entry peer runs interactively (no --mode rpc) so pi's TUI renders.
-  const isEntry = name === entryPeer;
+  // Every peer runs the full pi TUI in its own PTY. The multiplexer paints
+  // only the focused peer's virtual buffer to the launcher's terminal;
+  // non-focused peers keep emitting ANSI into their virtual buffers, so a
+  // /focus switch repaints a real TUI snapshot rather than RPC JSON.
+  //
+  // The optional `task:` field is forwarded as a positional argument to pi
+  // (interactive mode treats trailing positionals as the first user message),
+  // replacing the previous `--mode rpc` + JSON-over-stdin bootstrap.
   const peerArgs = [
     RUNNER,
     recipe,
@@ -416,10 +423,8 @@ for (let i = 0; i < topology.nodes.length; i++) {
     "--topology-overlay", JSON.stringify(overlay),
   ];
 
-  if (!isEntry) {
-    // Non-entry peers run headless (RPC mode); their output goes into a virtual
-    // buffer for slice-3 focus switching but isn't painted to the launcher's terminal.
-    peerArgs.push("--mode", "rpc");
+  if (typeof task === "string" && task.trim()) {
+    peerArgs.push(task);
   }
 
   const peerEnv = {
@@ -465,12 +470,6 @@ for (let i = 0; i < topology.nodes.length; i++) {
       // handle state update, unregistration, and auto-shift via focusController.
     }
   });
-
-  // For non-entry RPC peers: send the initial task as the first RPC prompt.
-  if (!isEntry && task) {
-    // Use pool.write() to inject the JSON prompt into the PTY stdin.
-    pool.write(name, JSON.stringify({ type: "prompt", message: task }) + "\n");
-  }
 
   nodeNames.push(name);
 }

--- a/scripts/launch-mesh.mjs
+++ b/scripts/launch-mesh.mjs
@@ -254,6 +254,10 @@ focusController.on("focus-changed", ({ focused }) => {
   launcherSock.broadcast(env);
   if (mux && focused) {
     mux.setFocus(focused);
+    // Nudge pi to fully redraw its TUI. ioctl(TIOCSWINSZ) only delivers
+    // SIGWINCH when dims change, so pool.resize() with same dimensions is a
+    // no-op. Send the signal directly to guarantee delivery regardless.
+    pool.signalSigwinch(focused);
   } else if (mux && !focused) {
     mux.setFocus(null);
   }


### PR DESCRIPTION
Non-entry peers were spawned with `--mode rpc` so the entry peer's
PTY could own the launcher's terminal. The cost: focus-switching to
a non-entry peer painted that peer's RPC JSON envelopes (`{"type":
"response", ...}`) instead of a real pi TUI. Since the multiplexer
already accumulates each peer's PTY output into its own xterm-headless
VirtualBuffer, the RPC-mode tradeoff was unnecessary: every peer can
run the full TUI and the multiplexer paints whichever buffer is
focused.

Replace the `--mode rpc` + JSON-over-stdin task bootstrap with a
positional pi argument (interactive mode treats trailing positionals
as the first user message), so peers receive their `task:` field as a
normal user prompt. Non-focused peers keep emitting ANSI into their
virtual buffers; `/focus` repaints a real TUI snapshot (agent-header,
mesh-rail widget, agent-footer) for any peer.

https://claude.ai/code/session_01Kkz1DFX8BTdzQRG4viq6z8