### PR TITLE
Support optional node names with auto-generation in mesh topology

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -708,6 +708,15 @@ nodes:
 All four peer fields (`supervisor`, `submitTo`, `acceptedFrom`, `peers`) are
 optional. Nodes without them launch with only their recipe's own peer fields.
 
+`name:` is also optional. When omitted, the launcher generates a
+`<breed>-<shortName>` slug from the recipe (using the same breed-pool /
+collision-detection machinery as `npm run agent`). Auto-named nodes can't be
+referenced by name elsewhere in the topology — `entry:`, `supervisor:`,
+`submitTo:`, `acceptedFrom:`, `peers:`, and group memberships all need an
+explicit name. Use it for "anonymous worker" nodes whose roles only flow
+outward (e.g. several workers that all set `supervisor: authority` but are
+never enumerated by the authority).
+
 ### Group references
 
 Any string value in `acceptedFrom`, `peers`, or a `group_bindings` array that

--- a/pi-sandbox/.pi/extensions/_lib/topology.mjs
+++ b/pi-sandbox/.pi/extensions/_lib/topology.mjs
@@ -2,7 +2,7 @@ import { parse as parseYaml } from "yaml";
 
 /**
  * @typedef {{
- *   name: string;
+ *   name?: string;
  *   recipe?: string;
  *   type?: "relay";
  *   sandbox?: string;
@@ -56,11 +56,8 @@ export function parseTopology(yamlText) {
 
   const nodes = raw.nodes.map((n, idx) => {
     if (!n || typeof n !== "object") throw new Error(`topology: node[${idx}] must be a mapping`);
-    if (typeof n.name !== "string" || !n.name) {
-      throw new Error(`topology: node[${idx}] missing 'name'`);
-    }
     return {
-      name: n.name,
+      ...(typeof n.name === "string" && n.name ? { name: n.name } : {}),
       ...(typeof n.recipe === "string" ? { recipe: n.recipe } : {}),
       ...(n.type === "relay" ? { type: /** @type {"relay"} */ ("relay") } : {}),
       ...(typeof n.sandbox === "string" ? { sandbox: n.sandbox } : {}),
@@ -76,9 +73,11 @@ export function parseTopology(yamlText) {
     };
   });
 
-  // Reject duplicate names
+  // Reject duplicate names among the named nodes (unnamed nodes get assigned
+  // names later by the launcher and are checked again post-assignment).
   const seen = new Set();
   for (const node of nodes) {
+    if (!node.name) continue;
     if (seen.has(node.name)) throw new Error(`topology: duplicate node name: '${node.name}'`);
     seen.add(node.name);
   }

--- a/pi-sandbox/.pi/extensions/_lib/topology.test.ts
+++ b/pi-sandbox/.pi/extensions/_lib/topology.test.ts
@@ -75,6 +75,46 @@ nodes:
   it("rejects empty nodes array", () => {
     expect(() => parseTopology("nodes: []\n")).toThrow(/nodes/i);
   });
+
+  it("accepts a node without 'name' (the launcher auto-assigns one)", () => {
+    const yaml = `
+nodes:
+  - recipe: mesh-node
+`;
+    const topo = parseTopology(yaml);
+    expect(topo.nodes).toHaveLength(1);
+    expect(topo.nodes[0].name).toBeUndefined();
+    expect(topo.nodes[0].recipe).toBe("mesh-node");
+  });
+
+  it("accepts a mix of named and unnamed nodes", () => {
+    const yaml = `
+nodes:
+  - name: authority
+    recipe: mesh-authority
+  - recipe: mesh-node
+  - recipe: mesh-node
+    supervisor: authority
+`;
+    const topo = parseTopology(yaml);
+    expect(topo.nodes).toHaveLength(3);
+    expect(topo.nodes[0].name).toBe("authority");
+    expect(topo.nodes[1].name).toBeUndefined();
+    expect(topo.nodes[2].name).toBeUndefined();
+    expect(topo.nodes[2].supervisor).toBe("authority");
+  });
+
+  it("still rejects duplicate names among named nodes when unnamed nodes are also present", () => {
+    const yaml = `
+nodes:
+  - name: worker
+    recipe: mesh-node
+  - recipe: mesh-node
+  - name: worker
+    recipe: mesh-node
+`;
+    expect(() => parseTopology(yaml)).toThrow(/duplicate node name/i);
+  });
 });
 
 // ── resolveNode ──────────────────────────────────────────────────────────────

--- a/pi-sandbox/meshes/authority-mesh.yaml
+++ b/pi-sandbox/meshes/authority-mesh.yaml
@@ -2,11 +2,13 @@
 #
 # Participants:
 #   authority — LLM orchestrator (LEAD_HARE_MODEL); top supervisor; entry peer
-#   analyst   — LLM peer (TASK_RABBIT_MODEL); handles research requests
-#   writer    — LLM peer (TASK_RABBIT_MODEL); handles drafting requests
+#   (auto) — LLM peer (TASK_RABBIT_MODEL); handles research requests
+#   (auto) — LLM peer (TASK_RABBIT_MODEL); handles drafting requests
 #
-# All participants share the same bus root and discover each other by
-# instance name. Any participant can agent_call or agent_send any other.
+# The two worker nodes omit `name:` and receive auto-generated <breed>-<shortName>
+# slugs at launch time (e.g. "cottontail-node", "rex-writer"). Only `authority`
+# needs an explicit name because it is referenced by `entry:` and by the workers'
+# `supervisor:` fields. Workers discover each other at runtime via agent_list.
 #
 # Human interaction is provided by the launcher TUI (see ADR-0004).
 # The former `type: relay` human node has been removed.
@@ -25,34 +27,30 @@ nodes:
     recipe: mesh-authority
     sandbox: /tmp/pi-mesh-authority/authority
     task: |
-      You are the authority in this mesh. Your peers are: analyst, writer.
-      Start by calling agent_list to see who is already online.
-      Then wait — messages from peers arrive as [from <peer>] prompts.
+      You are the authority in this mesh. Two worker peers will join.
+      Start by calling agent_list to see who is already online, then wait.
+      Messages from peers arrive as [from <peer>] prompts.
       When a peer sends you a request, handle it using your tools and reply
       with agent_send({to: "<peer>", body: "<answer>", in_reply_to: "<msg_id>"}).
-      You can also proactively spawn or delegate to nodes with mesh_spawn or delegate.
 
-  - name: analyst
-    recipe: mesh-node
+  - recipe: mesh-node
     sandbox: /tmp/pi-mesh-authority/analyst
     supervisor: authority
     task: |
-      You are the analyst peer in a mesh. Your name is "analyst".
-      Wait for requests from other peers. When a request arrives as
-      [from <peer> re:<id>] <body>, research or analyse it using your
-      tools, then reply with:
+      You are a research worker in a mesh. Start by calling agent_list to
+      discover the authority and other peers. Wait for requests from peers.
+      When a request arrives as [from <peer> re:<id>] <body>, research or
+      analyse it using your tools, then reply with:
         agent_send({to: "<peer>", body: "<findings>", in_reply_to: "<full_msg_id>"})
-      You can also use agent_call to ask the writer or authority for help.
 
-  - name: writer
-    recipe: mesh-writer
+  - recipe: mesh-writer
     sandbox: /tmp/pi-mesh-authority/writer
     supervisor: authority
     task: |
-      You are the writer peer in a mesh. Your name is "writer".
-      Wait for drafting requests from other peers. When a request arrives as
-      [from <peer> re:<id>] <body>, draft the requested content, SAVE IT TO A
-      FILE using the write tool, then reply with the file path and a summary:
+      You are a drafting worker in a mesh. Start by calling agent_list to
+      discover the authority and other peers. Wait for drafting requests.
+      When a request arrives as [from <peer> re:<id>] <body>, draft the
+      requested content, SAVE IT TO A FILE using the write tool, then reply
+      with the file path and a summary:
         agent_send({to: "<peer>", body: "Saved to <path>: <summary>", in_reply_to: "<full_msg_id>"})
-      You can use agent_call to ask the analyst for background information.
       Always write the file before replying — do not just return the text inline.

--- a/pi-sandbox/meshes/grouped-mesh.yaml
+++ b/pi-sandbox/meshes/grouped-mesh.yaml
@@ -18,6 +18,10 @@
 # Human interaction is provided by the launcher TUI (see ADR-0004).
 # The former `type: relay` human node has been removed.
 #
+# Note: all nodes in this mesh require explicit names because they are referenced
+# by structural fields — groups list them, submitTo/acceptedFrom name them directly.
+# See authority-mesh.yaml for an example that uses auto-generated names for workers.
+#
 # Launch:
 #   set -a; source models.env; set +a
 #   npm run mesh -- pi-sandbox/meshes/grouped-mesh.yaml

--- a/scripts/launch-mesh.mjs
+++ b/scripts/launch-mesh.mjs
@@ -65,8 +65,6 @@ if (topology.nodes.length < 2) {
   die("topology must have at least 2 nodes");
 }
 
-// ── Validate topology (entry:, relay deprecation, top supervisor, peer refs) ──
-
 /** @param {string} recipeName */
 function loadRecipeModel(recipeName) {
   const recipeFile = path.join(REPO_ROOT, "pi-sandbox", "agents", `${recipeName}.yaml`);
@@ -77,33 +75,19 @@ function loadRecipeModel(recipeName) {
   return undefined;
 }
 
-const { errors: topoErrors, warnings: topoWarnings } = validateTopology(topology, loadRecipeModel);
+// ── Resolve bus root ──────────────────────────────────────────────────────────
 
-for (const warning of topoWarnings) {
-  process.stderr.write(`launch-mesh: ${warning}\n`);
-}
-
-if (topoErrors.length > 0) {
-  for (const error of topoErrors) {
-    process.stderr.write(`launch-mesh: validation error: ${error}\n`);
-  }
-  process.exit(1);
-}
-
-// Resolve entry peer (for launcher TUI focus — informational for now).
-const { entryPeer } = resolveEntry(topology);
-if (entryPeer) {
-  process.stderr.write(`launch-mesh: entry peer: ${entryPeer}\n`);
-}
-
-// Resolve bus root
 const busRoot = topology.bus_root
   ? path.resolve(topology.bus_root)
   : path.join(os.homedir(), ".pi-agent-bus", `mesh-${path.basename(meshPath, ".yaml")}`);
 
 mkdirSync(busRoot, { recursive: true });
 
-// Assign names: explicit `name:` wins; missing name auto-generates <breed>-<shortName>
+// ── Assign names ──────────────────────────────────────────────────────────────
+// Explicit `name:` wins; missing name auto-generates <breed>-<shortName> using
+// the recipe's optional shortName (or filename stem) plus a breed pool. Runs
+// BEFORE validation so validateTopology / resolveEntry see fully-named nodes.
+
 const taken = await probeBusRoot(busRoot);
 for (const node of topology.nodes) {
   if (node.name) {
@@ -124,10 +108,34 @@ for (const node of topology.nodes) {
   taken.add(node.name);
 }
 
-// Validate unique names after assignment
+// Validate unique names after assignment (defence in depth — parseTopology
+// already rejects dups among declared names, but auto-naming might collide
+// with a pre-bound bus socket; generateInstanceName handles that, but a
+// user-declared name that matches an auto-generated slug would slip through).
 const names = topology.nodes.map((n) => n.name);
 const dupes = names.filter((n, i) => names.indexOf(n) !== i);
 if (dupes.length > 0) die(`duplicate node names: ${dupes.join(", ")}`);
+
+// ── Validate topology (entry:, relay deprecation, top supervisor, peer refs) ──
+
+const { errors: topoErrors, warnings: topoWarnings } = validateTopology(topology, loadRecipeModel);
+
+for (const warning of topoWarnings) {
+  process.stderr.write(`launch-mesh: ${warning}\n`);
+}
+
+if (topoErrors.length > 0) {
+  for (const error of topoErrors) {
+    process.stderr.write(`launch-mesh: validation error: ${error}\n`);
+  }
+  process.exit(1);
+}
+
+// Resolve entry peer (for launcher TUI focus — informational for now).
+const { entryPeer } = resolveEntry(topology);
+if (entryPeer) {
+  process.stderr.write(`launch-mesh: entry peer: ${entryPeer}\n`);
+}
 
 // Pre-compute per-node overlays (validates @group refs and peer references early).
 const nodeOverlays = new Map();


### PR DESCRIPTION
## Summary
This change makes the `name:` field optional in mesh topology node definitions. When omitted, the launcher automatically generates a `<breed>-<shortName>` slug for the node at launch time, similar to the `npm run agent` naming machinery. This enables cleaner topology definitions for "anonymous worker" nodes that don't need to be referenced by name elsewhere.

## Key Changes

- **Topology parsing** (`topology.mjs`): Modified `parseTopology()` to accept nodes without a `name` field. The `name` property is now optional in the Node typedef and only included in the parsed object when explicitly provided.

- **Duplicate name validation** (`topology.mjs`): Updated duplicate-name checking to only validate among explicitly-named nodes during parsing. Auto-named nodes are validated again post-assignment in the launcher to catch collisions with pre-bound bus sockets.

- **Launcher reordering** (`launch-mesh.mjs`): Reorganized the initialization sequence to:
  1. Assign names (explicit or auto-generated) to all nodes first
  2. Validate unique names post-assignment
  3. Then run topology validation (which now sees fully-named nodes)
  4. Finally resolve the entry peer
  
  This ensures `validateTopology()` and `resolveEntry()` always work with complete node names.

- **Documentation** (`agents.md`): Added explanation that `name:` is optional, how auto-naming works, and the constraint that auto-named nodes cannot be referenced by name in structural fields (`entry:`, `supervisor:`, `submitTo:`, `acceptedFrom:`, `peers:`, group memberships).

- **Test coverage** (`topology.test.ts`): Added three new test cases covering unnamed nodes, mixed named/unnamed nodes, and duplicate-name detection with unnamed nodes present.

- **Example mesh** (`authority-mesh.yaml`): Updated to demonstrate the feature with two worker nodes that omit `name:` and receive auto-generated slugs, while the `authority` node retains an explicit name (required because it's referenced by `entry:` and `supervisor:` fields).

- **Grouped mesh note** (`grouped-mesh.yaml`): Added clarifying comment that all nodes in this mesh require explicit names due to structural references.

## Implementation Details

The auto-naming happens in the launcher after probing the bus root for existing sockets, ensuring collision detection with pre-bound instances. The name assignment runs before topology validation so that validation functions see complete node names. Duplicate-name checking is performed twice: once during parsing (for explicitly-named nodes only) and again post-assignment (for all nodes) to catch collisions from auto-generation.

https://claude.ai/code/session_01P3i9vTxQpnBmFw9g8cbWCS