### PR TITLE
Slice 1: Per-node `groups:` field + group-membership aggregator

### DIFF
--- a/pi-sandbox/.pi/extensions/_lib/group-membership.mjs
+++ b/pi-sandbox/.pi/extensions/_lib/group-membership.mjs
@@ -1,0 +1,87 @@
+/**
+ * group-membership.mjs — unified group-membership aggregator.
+ *
+ * Merges the two forms in which a node can declare group membership:
+ *
+ *   1. Top-level `groups:` block  — classic form; enumerated in the topology root.
+ *   2. Per-node `groups: [...]`   — inline form; each named node declares its own memberships.
+ *
+ * Callers (resolveNode, validateTopology) can use the returned Map in place of
+ * direct reads of `topo.groups` so both forms participate in @group expansion.
+ */
+
+/**
+ * @typedef {{
+ *   name?: string;
+ *   groups?: string[];
+ *   [key: string]: unknown;
+ * }} NodeWithGroups
+ */
+
+/**
+ * @typedef {{
+ *   groups?: Record<string, string[]>;
+ *   nodes: NodeWithGroups[];
+ *   [key: string]: unknown;
+ * }} TopologyLike
+ */
+
+/**
+ * Build a unified group → members map by merging the top-level `groups:` block
+ * with the per-node `groups: [...]` field.
+ *
+ * Resolution order:
+ *   1. Seed from `topo.groups` (top-level), preserving declaration order and
+ *      deduplicating within each group.
+ *   2. For each node (in declaration order) whose `name` is non-empty and whose
+ *      `groups` list is non-empty, append the node name to each declared group,
+ *      creating the group implicitly if it was not in the top-level block.
+ *      Anonymous nodes (no `name`) are silently skipped.
+ *
+ * Deduplication uses first-occurrence order: top-level members always appear
+ * before per-node additions; among per-node additions, declaration order is preserved.
+ *
+ * @param {TopologyLike} topo
+ * @returns {Map<string, string[]>}
+ */
+export function aggregateGroupMembership(topo) {
+  /** @type {Map<string, string[]>} */
+  const result = new Map();
+
+  // Pass 1: seed from the top-level groups block (preserving entry order).
+  if (topo.groups && typeof topo.groups === "object" && !Array.isArray(topo.groups)) {
+    for (const [groupName, members] of Object.entries(topo.groups)) {
+      if (!Array.isArray(members)) continue;
+      const deduped = [];
+      const seen = new Set();
+      for (const m of members) {
+        if (typeof m === "string" && !seen.has(m)) {
+          deduped.push(m);
+          seen.add(m);
+        }
+      }
+      result.set(groupName, deduped);
+    }
+  }
+
+  // Pass 2: append per-node memberships (nodes in declaration order).
+  for (const node of topo.nodes) {
+    const name = node.name;
+    if (!name || typeof name !== "string") continue; // skip anonymous nodes
+    if (!Array.isArray(node.groups) || node.groups.length === 0) continue;
+
+    for (const groupName of node.groups) {
+      if (typeof groupName !== "string") continue;
+
+      if (!result.has(groupName)) {
+        result.set(groupName, []);
+      }
+      const members = /** @type {string[]} */ (result.get(groupName));
+      if (!members.includes(name)) {
+        members.push(name);
+      }
+    }
+  }
+
+  return result;
+}

--- a/pi-sandbox/.pi/extensions/_lib/group-membership.test.ts
+++ b/pi-sandbox/.pi/extensions/_lib/group-membership.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { aggregateGroupMembership } from "./group-membership.mjs";
+
+// Minimal shim types for test readability.
+type NodeLike = { name?: string; groups?: string[]; [key: string]: unknown };
+type TopoLike = { groups?: Record<string, string[]>; nodes: NodeLike[] };
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function topoOf(nodes: NodeLike[], groups?: Record<string, string[]>): TopoLike {
+  return { nodes, ...(groups ? { groups } : {}) };
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("aggregateGroupMembership", () => {
+  // 1. Top-level groups only, no per-node groups
+  it("returns top-level groups unchanged when no per-node groups are present", () => {
+    const topo = topoOf(
+      [
+        { name: "w1", recipe: "mesh-node" },
+        { name: "w2", recipe: "mesh-node" },
+      ],
+      { workers: ["w1", "w2"] },
+    );
+    const result = aggregateGroupMembership(topo);
+    expect(result.get("workers")).toEqual(["w1", "w2"]);
+    expect(result.size).toBe(1);
+  });
+
+  // 2. Per-node groups only, no top-level groups block
+  it("builds groups entirely from per-node declarations when no top-level block", () => {
+    const topo = topoOf([
+      { name: "w1", groups: ["workers"] },
+      { name: "w2", groups: ["workers"] },
+    ]);
+    const result = aggregateGroupMembership(topo);
+    expect(result.get("workers")).toEqual(["w1", "w2"]);
+  });
+
+  // 3. Both forms for the same group — top-level first, then per-node order, no duplicates
+  it("unions both forms for the same group with top-level members appearing first", () => {
+    const topo = topoOf(
+      [
+        { name: "w3", groups: ["team"] },
+        { name: "w1", groups: ["team"] }, // w1 is in top-level AND per-node
+      ],
+      { team: ["w1", "w2"] },
+    );
+    const result = aggregateGroupMembership(topo);
+    // w1 and w2 from top-level, then w3 from per-node; w1 per-node is deduped
+    expect(result.get("team")).toEqual(["w1", "w2", "w3"]);
+  });
+
+  // 4. Node belonging to multiple groups
+  it("adds the node to every group it declares membership in", () => {
+    const topo = topoOf([{ name: "multi", groups: ["alpha", "beta", "gamma"] }]);
+    const result = aggregateGroupMembership(topo);
+    expect(result.get("alpha")).toEqual(["multi"]);
+    expect(result.get("beta")).toEqual(["multi"]);
+    expect(result.get("gamma")).toEqual(["multi"]);
+  });
+
+  // 5. Empty group declared at top level but never joined
+  it("preserves an empty top-level group entry", () => {
+    const topo = topoOf([{ name: "w1" }], { empty: [] });
+    const result = aggregateGroupMembership(topo);
+    expect(result.has("empty")).toBe(true);
+    expect(result.get("empty")).toEqual([]);
+  });
+
+  // 6. Per-node group referencing a group not declared at top-level is allowed (implicit)
+  it("allows per-node groups to reference groups not declared in top-level block", () => {
+    const topo = topoOf([{ name: "w1", groups: ["implicit-group"] }]);
+    const result = aggregateGroupMembership(topo);
+    expect(result.get("implicit-group")).toEqual(["w1"]);
+  });
+
+  // 7. Order preservation
+  it("preserves declaration order within a group", () => {
+    const topo = topoOf(
+      [
+        { name: "c", groups: ["ordered"] },
+        { name: "b", groups: ["ordered"] },
+        { name: "a", groups: ["ordered"] },
+      ],
+    );
+    const result = aggregateGroupMembership(topo);
+    expect(result.get("ordered")).toEqual(["c", "b", "a"]);
+  });
+
+  it("top-level declaration order is preserved before per-node additions", () => {
+    const topo = topoOf(
+      [{ name: "z", groups: ["letters"] }],
+      { letters: ["a", "b", "c"] },
+    );
+    const result = aggregateGroupMembership(topo);
+    expect(result.get("letters")).toEqual(["a", "b", "c", "z"]);
+  });
+
+  // 8. Anonymous nodes (no `name`) are silently skipped
+  it("skips anonymous nodes (no name field) without error", () => {
+    const topo = topoOf([
+      { groups: ["workers"] }, // no name — should be ignored
+      { name: "w1", groups: ["workers"] },
+    ]);
+    const result = aggregateGroupMembership(topo);
+    expect(result.get("workers")).toEqual(["w1"]);
+  });
+
+  it("skips nodes with empty-string name", () => {
+    const topo = topoOf([
+      { name: "", groups: ["workers"] }, // empty string name — should be ignored
+      { name: "w1", groups: ["workers"] },
+    ]);
+    const result = aggregateGroupMembership(topo);
+    expect(result.get("workers")).toEqual(["w1"]);
+  });
+
+  // No-op edge cases
+  it("returns an empty Map for a topology with no groups and no per-node groups", () => {
+    const topo = topoOf([{ name: "solo" }]);
+    const result = aggregateGroupMembership(topo);
+    expect(result.size).toBe(0);
+  });
+
+  it("deduplicates members within a top-level group", () => {
+    // Defensive: top-level block with a dup (shouldn't happen in normal parsing but be safe)
+    const topo: TopoLike = {
+      groups: { workers: ["w1", "w2", "w1"] } as Record<string, string[]>,
+      nodes: [],
+    };
+    const result = aggregateGroupMembership(topo);
+    expect(result.get("workers")).toEqual(["w1", "w2"]);
+  });
+
+  it("does not add a node to a group twice even if it appears in top-level and per-node", () => {
+    const topo = topoOf(
+      [{ name: "w1", groups: ["workers"] }],
+      { workers: ["w1"] },
+    );
+    const result = aggregateGroupMembership(topo);
+    expect(result.get("workers")).toEqual(["w1"]); // not ["w1", "w1"]
+  });
+});

--- a/pi-sandbox/.pi/extensions/_lib/topology-validator.mjs
+++ b/pi-sandbox/.pi/extensions/_lib/topology-validator.mjs
@@ -18,6 +18,8 @@
  * caller passes via recipeLoader).
  */
 
+import { aggregateGroupMembership } from "./group-membership.mjs";
+
 /**
  * @typedef {{
  *   name: string;
@@ -67,7 +69,7 @@
  * Returns the expanded list; pushes to errors when a group is missing.
  *
  * @param {string[]} list
- * @param {Record<string, string[]> | undefined} groups
+ * @param {Map<string, string[]>} groups
  * @param {string} context
  * @param {string[]} errors
  * @returns {string[]}
@@ -77,7 +79,7 @@ function expandRefs(list, groups, context, errors) {
   for (const item of list) {
     if (item.startsWith("@")) {
       const groupName = item.slice(1);
-      const members = groups?.[groupName];
+      const members = groups.get(groupName);
       if (!members) {
         errors.push(
           `unknown @group reference '@${groupName}' in ${context} — group is not defined`,
@@ -104,6 +106,11 @@ export function validateTopology(topo, recipeModelLoader) {
   const warnings = [];
 
   const nodeNames = new Set(topo.nodes.map((n) => n.name));
+
+  // Build the unified group-membership map (merges top-level groups block + per-node
+  // groups: fields). All @group expansions below use this Map so per-node declarations
+  // participate in ref resolution.
+  const groups = aggregateGroupMembership(topo);
 
   // ── Rule 1: required `entry:` field ────────────────────────────────────────
   if (!topo.entry) {
@@ -133,9 +140,10 @@ export function validateTopology(topo, recipeModelLoader) {
 
     let effectiveSupervisor;
 
-    // Group_bindings first (last group wins per topology.mjs semantics)
-    if (topo.groups && topo.group_bindings) {
-      for (const [groupName, members] of Object.entries(topo.groups)) {
+    // Group_bindings first (last group wins per topology.mjs semantics).
+    // Use the aggregated groups Map so per-node group declarations are included.
+    if (topo.group_bindings) {
+      for (const [groupName, members] of groups) {
         if (members.includes(node.name)) {
           const binding = topo.group_bindings[groupName];
           if (binding?.supervisor !== undefined) {
@@ -172,7 +180,7 @@ export function validateTopology(topo, recipeModelLoader) {
     if (node.acceptedFrom) {
       const expanded = expandRefs(
         node.acceptedFrom,
-        topo.groups,
+        groups,
         `node '${node.name}'.acceptedFrom`,
         errors,
       );
@@ -187,7 +195,7 @@ export function validateTopology(topo, recipeModelLoader) {
     if (node.peers) {
       const expanded = expandRefs(
         node.peers,
-        topo.groups,
+        groups,
         `node '${node.name}'.peers`,
         errors,
       );
@@ -207,7 +215,7 @@ export function validateTopology(topo, recipeModelLoader) {
       if (binding.acceptedFrom) {
         expandRefs(
           binding.acceptedFrom,
-          topo.groups,
+          groups,
           `group_bindings.${bindingName}.acceptedFrom`,
           errors,
         );
@@ -215,7 +223,7 @@ export function validateTopology(topo, recipeModelLoader) {
       if (binding.peers) {
         expandRefs(
           binding.peers,
-          topo.groups,
+          groups,
           `group_bindings.${bindingName}.peers`,
           errors,
         );

--- a/pi-sandbox/.pi/extensions/_lib/topology-validator.test.ts
+++ b/pi-sandbox/.pi/extensions/_lib/topology-validator.test.ts
@@ -22,6 +22,7 @@ type TopologyNode = {
   supervisor?: string;
   acceptedFrom?: string[];
   peers?: string[];
+  groups?: string[];
 };
 
 type Topology = {
@@ -365,5 +366,67 @@ describe("TASK_RABBIT_MODEL warning", () => {
     };
     const result = validateTopology(topo, literalModelLoader);
     expect(result.warnings).toHaveLength(0);
+  });
+});
+
+// ── per-node groups: field ────────────────────────────────────────────────────
+
+describe("per-node groups field", () => {
+  it("passes when a node uses per-node groups to declare membership in an implicit group, and another node @refs it", () => {
+    // No top-level groups block — the group exists only because a node declares it.
+    const topo: Topology = {
+      entry: "authority",
+      nodes: [
+        { name: "authority", recipe: "mesh-authority", acceptedFrom: ["@workers"] },
+        { name: "w1", recipe: "mesh-node", supervisor: "authority", groups: ["workers"] },
+        { name: "w2", recipe: "mesh-node", supervisor: "authority", groups: ["workers"] },
+      ],
+    };
+    const result = validateTopology(topo);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("rejects @group ref to a group name not declared by either top-level or per-node form", () => {
+    const topo: Topology = {
+      entry: "authority",
+      nodes: [
+        { name: "authority", recipe: "mesh-authority", acceptedFrom: ["@totally-unknown"] },
+        { name: "w1", recipe: "mesh-node", supervisor: "authority" },
+      ],
+    };
+    const result = validateTopology(topo);
+    expect(result.errors.some((e) => /totally-unknown/i.test(e))).toBe(true);
+  });
+
+  it("counts per-node group_binding supervisor as effectively set (not a top candidate)", () => {
+    // Node w1 declares groups: [workers] and group_bindings has workers.supervisor.
+    // So w1 should NOT be a top candidate (it has an effective supervisor via binding).
+    const topo: Topology = {
+      entry: "authority",
+      groups: undefined,
+      group_bindings: { workers: { supervisor: "authority" } },
+      nodes: [
+        { name: "authority", recipe: "mesh-authority" },
+        { name: "w1", recipe: "mesh-node", groups: ["workers"] },
+      ],
+    };
+    const result = validateTopology(topo);
+    // Only authority should be top candidate; no duplicate-supervisor error.
+    expect(result.errors.filter((e) => /supervisor/i.test(e))).toHaveLength(0);
+  });
+
+  it("passes a mixed topology with both top-level groups and per-node groups for the same group", () => {
+    const topo: Topology = {
+      entry: "authority",
+      groups: { workers: ["w1"] },
+      group_bindings: { workers: { supervisor: "authority" } },
+      nodes: [
+        { name: "authority", recipe: "mesh-authority", acceptedFrom: ["@workers"] },
+        { name: "w1", recipe: "mesh-node" },
+        { name: "w2", recipe: "mesh-node", groups: ["workers"] },
+      ],
+    };
+    const result = validateTopology(topo);
+    expect(result.errors).toHaveLength(0);
   });
 });

--- a/pi-sandbox/.pi/extensions/_lib/topology.mjs
+++ b/pi-sandbox/.pi/extensions/_lib/topology.mjs
@@ -1,4 +1,5 @@
 import { parse as parseYaml } from "yaml";
+import { aggregateGroupMembership } from "./group-membership.mjs";
 
 /**
  * @typedef {{
@@ -11,6 +12,7 @@ import { parse as parseYaml } from "yaml";
  *   submitTo?: string;
  *   acceptedFrom?: string[];
  *   peers?: string[];
+ *   groups?: string[];
  * }} TopologyNode
  */
 
@@ -70,6 +72,9 @@ export function parseTopology(yamlText) {
       ...(Array.isArray(n.peers)
         ? { peers: n.peers.filter((s) => typeof s === "string") }
         : {}),
+      ...(Array.isArray(n.groups)
+        ? { groups: n.groups.filter((s) => typeof s === "string") }
+        : {}),
     };
   });
 
@@ -128,7 +133,7 @@ export function parseTopology(yamlText) {
 /**
  * Expand a list that may contain @<group> references into concrete peer names.
  * @param {string[]} list
- * @param {Record<string, string[]> | undefined} groups
+ * @param {Map<string, string[]> | undefined} groups
  * @param {string} context
  * @returns {string[]}
  */
@@ -137,7 +142,7 @@ function expandRefs(list, groups, context) {
   for (const item of list) {
     if (item.startsWith("@")) {
       const groupName = item.slice(1);
-      const members = groups?.[groupName];
+      const members = groups?.get(groupName);
       if (!members) throw new Error(`topology: unknown group reference '@${groupName}' in ${context}`);
       result.push(...members);
     } else {
@@ -159,14 +164,13 @@ export function resolveNode(topo, nodeName) {
   if (!node) throw new Error(`topology: node '${nodeName}' not found in topology`);
 
   const nodeNames = new Set(topo.nodes.map((n) => n.name));
-  const groups = topo.groups;
+  // Use the aggregator so per-node groups: declarations participate in @group expansion.
+  const groups = aggregateGroupMembership(topo);
 
   // Collect all groups this node belongs to (order: groups in declaration order)
   const memberGroups = [];
-  if (groups) {
-    for (const [groupName, members] of Object.entries(groups)) {
-      if (members.includes(nodeName)) memberGroups.push(groupName);
-    }
+  for (const [groupName, members] of groups) {
+    if (members.includes(nodeName)) memberGroups.push(groupName);
   }
 
   // Apply group_bindings in declaration order; later groups overwrite earlier

--- a/pi-sandbox/.pi/extensions/_lib/topology.test.ts
+++ b/pi-sandbox/.pi/extensions/_lib/topology.test.ts
@@ -115,6 +115,45 @@ nodes:
 `;
     expect(() => parseTopology(yaml)).toThrow(/duplicate node name/i);
   });
+
+  it("accepts per-node groups field as an array of strings", () => {
+    const yaml = `
+nodes:
+  - name: worker
+    recipe: mesh-node
+    groups: [workers, submitters]
+`;
+    const topo = parseTopology(yaml);
+    expect(topo.nodes[0].groups).toEqual(["workers", "submitters"]);
+  });
+
+  it("omits groups field when not supplied on a node", () => {
+    const yaml = `
+nodes:
+  - name: worker
+    recipe: mesh-node
+`;
+    const topo = parseTopology(yaml);
+    expect(topo.nodes[0].groups).toBeUndefined();
+  });
+
+  it("accepts a mix of named nodes with and without per-node groups", () => {
+    const yaml = `
+nodes:
+  - name: authority
+    recipe: mesh-authority
+  - name: worker-a
+    recipe: mesh-node
+    groups: [workers]
+  - name: worker-b
+    recipe: mesh-node
+    groups: [workers]
+`;
+    const topo = parseTopology(yaml);
+    expect(topo.nodes[0].groups).toBeUndefined();
+    expect(topo.nodes[1].groups).toEqual(["workers"]);
+    expect(topo.nodes[2].groups).toEqual(["workers"]);
+  });
 });
 
 // ── resolveNode ──────────────────────────────────────────────────────────────
@@ -398,5 +437,112 @@ nodes:
 `;
     const topo = parseTopology(yaml);
     expect(() => resolveNode(topo, "nobody")).toThrow(/nobody/i);
+  });
+
+  // ── Per-node groups: field ───────────────────────────────────────────────
+
+  it("per-node groups causes @group ref to expand to that node's name", () => {
+    const yaml = `
+nodes:
+  - name: authority
+    recipe: mesh-authority
+    acceptedFrom: ["@workers"]
+  - name: w1
+    recipe: mesh-node
+    groups: [workers]
+  - name: w2
+    recipe: mesh-node
+    groups: [workers]
+`;
+    const topo = parseTopology(yaml);
+    const resolved = resolveNode(topo, "authority");
+    expect(resolved.acceptedFrom).toEqual(["w1", "w2"]);
+  });
+
+  it("per-node groups can reference a group not declared at top level (implicit group)", () => {
+    const yaml = `
+nodes:
+  - name: authority
+    recipe: mesh-authority
+    peers: ["@implicit"]
+  - name: anon-worker
+    recipe: mesh-node
+    groups: [implicit]
+`;
+    const topo = parseTopology(yaml);
+    const resolved = resolveNode(topo, "authority");
+    expect(resolved.peers).toEqual(["anon-worker"]);
+  });
+
+  it("mixes top-level and per-node groups for the same group name", () => {
+    const yaml = `
+groups:
+  workers: [w1]
+nodes:
+  - name: authority
+    recipe: mesh-authority
+    acceptedFrom: ["@workers"]
+  - name: w1
+    recipe: mesh-node
+  - name: w2
+    recipe: mesh-node
+    groups: [workers]
+`;
+    const topo = parseTopology(yaml);
+    const resolved = resolveNode(topo, "authority");
+    // top-level w1 first, then per-node w2
+    expect(resolved.acceptedFrom).toEqual(["w1", "w2"]);
+  });
+
+  it("per-node groups triggers group_binding for that node", () => {
+    const yaml = `
+group_bindings:
+  workers:
+    supervisor: authority
+nodes:
+  - name: authority
+    recipe: mesh-authority
+  - name: w1
+    recipe: mesh-node
+    groups: [workers]
+`;
+    const topo = parseTopology(yaml);
+    const resolved = resolveNode(topo, "w1");
+    expect(resolved.supervisor).toBe("authority");
+  });
+
+  it("anonymous node with groups field does not expand into @group refs (skipped)", () => {
+    // After auto-naming the anonymous node gets a name; before that, it's skipped.
+    // We test with the raw (pre-auto-naming) topology where the node has no name.
+    const yaml = `
+nodes:
+  - name: authority
+    recipe: mesh-authority
+    acceptedFrom: ["@workers"]
+  - recipe: mesh-node
+    supervisor: authority
+`;
+    // The anonymous node has no `groups:` field; @workers ref should fail.
+    const topo = parseTopology(yaml);
+    expect(() => resolveNode(topo, "authority")).toThrow(/group.*workers/i);
+  });
+
+  it("anonymous node stamped with a name + groups participates in @group expansion", () => {
+    // Simulate the launcher's auto-naming step: assign a name to the unnamed node
+    // before calling resolveNode so the aggregator picks it up.
+    const yaml = `
+nodes:
+  - name: authority
+    recipe: mesh-authority
+    acceptedFrom: ["@workers"]
+  - recipe: mesh-node
+    supervisor: authority
+    groups: [workers]
+`;
+    const topo = parseTopology(yaml);
+    // Simulate launcher auto-naming
+    topo.nodes[1].name = "cottontail-worker";
+    const resolved = resolveNode(topo, "authority");
+    expect(resolved.acceptedFrom).toEqual(["cottontail-worker"]);
   });
 });

--- a/pi-sandbox/meshes/anon-grouped-mesh.yaml
+++ b/pi-sandbox/meshes/anon-grouped-mesh.yaml
@@ -1,0 +1,24 @@
+# anon-grouped-mesh.yaml — fixture exercising the per-node `groups:` field
+# with an anonymous worker node (no explicit `name:`).
+#
+# The anonymous worker declares `groups: [workers]`; once the launcher
+# auto-assigns it a breed slug, the aggregator picks it up and expands
+# `@workers` in authority.acceptedFrom to include the assigned slug.
+#
+# Launch (after auto-naming the anonymous node — see topology.test.ts for
+# the simulated version):
+#   set -a; source models.env; set +a
+#   npm run mesh -- pi-sandbox/meshes/anon-grouped-mesh.yaml
+
+bus_root: /tmp/pi-mesh-anon-grouped
+
+entry: authority
+
+nodes:
+  - name: authority
+    recipe: mesh-authority
+    acceptedFrom: ["@workers"]
+
+  - recipe: mesh-node
+    supervisor: authority
+    groups: [workers]

--- a/scripts/launch-mesh.mjs
+++ b/scripts/launch-mesh.mjs
@@ -117,6 +117,9 @@ const dupes = names.filter((n, i) => names.indexOf(n) !== i);
 if (dupes.length > 0) die(`duplicate node names: ${dupes.join(", ")}`);
 
 // ── Validate topology (entry:, relay deprecation, top supervisor, peer refs) ──
+// Ordering invariant: validateTopology is called AFTER auto-naming (above) so that
+// per-node `groups:` fields on formerly-anonymous nodes are resolved with their
+// assigned slugs by aggregateGroupMembership inside the validator.
 
 const { errors: topoErrors, warnings: topoWarnings } = validateTopology(topology, loadRecipeModel);
 


### PR DESCRIPTION
## What this fixes

Slice 1 of PRD #103 (Groups as author-only convenience for anonymous mesh peers). Anonymous Peers — nodes with no `name:` field — could not previously join a Group, because the only declaration form (the top-level `groups: { <name>: [peer1, peer2] }` block) requires a symbol the topology has no way to write. This change adds a per-node `groups: [<name>, ...]` field as a second declaration form and a pure-function aggregator (`aggregateGroupMembership` in `pi-sandbox/.pi/extensions/_lib/group-membership.mjs`) that unifies the two forms into a single `Map<groupName, string[]>` at launch.

`topology.mjs:resolveNode` and `topology-validator.mjs:validateTopology` now consult the aggregator (rather than reading `topo.groups` directly) when expanding `@group` references in `acceptedFrom:` and `peers:`. The aggregator runs after `launch-mesh.mjs`'s auto-naming pass, so an anonymous worker's auto-assigned `<breed>-<short>` slug is the value contributed to `@workers`. A supervisor declaring `acceptedFrom: ["@workers"]` automatically accepts envelopes from such workers without any further wiring. Per-node membership in an undeclared group implicitly creates the group; top-level entries appear first in the resolved member list, then per-node in node-declaration order, with cross-form duplicates removed.

Out of scope for this slice and untouched: `supervisor:`, `submitTo:`, and `entry:` semantics (slices 2 and 3), recipe-level peer fields (recipes remain name-only), and `Habitat` schema (rails continue to see only concrete instance names).

## QA steps for the human

None — fully covered by the automated test suite and the live integration smoke. The smoke exercised the headline anon-worker path end-to-end (parse → auto-name → validate → resolve → assert authority's resolved `acceptedFrom` contains the worker's auto-assigned slug) and confirmed the existing `grouped-mesh.yaml` and `authority-mesh.yaml` resolve identically, plus probed adjacent regressions (malformed `groups:` input, undefined `@group` refs, empty-topology aggregator).

## Automated coverage

`npm test` — 605/605 vitest tests pass (27 files; 13 new tests in `group-membership.test.ts`, plus integration cases added to `topology.test.ts` and `topology-validator.test.ts`).

Closes #105


---
_Generated by [Claude Code](https://claude.ai/code/session_011qcjY9wuPWJmBHxJ3SbKuK)_