### PR TITLE
fix: deliver mesh task: as system-prompt context, not first user message

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -683,7 +683,7 @@ nodes:
   - name: authority             # instance name on the bus (--agent-name)
     recipe: mesh-authority      # pi-sandbox/agents/<recipe>.yaml
     sandbox: /tmp/mesh/auth     # optional; auto-created under /tmp if omitted
-    task: "..."                 # optional; passed to pi as the first user message
+    task: "..."                 # optional; appended to system prompt as per-instance role context
 
   # Habitat-overlay fields — override recipe + group_bindings values:
   - name: w1

--- a/pi-sandbox/meshes/authority-mesh.yaml
+++ b/pi-sandbox/meshes/authority-mesh.yaml
@@ -38,18 +38,16 @@ nodes:
     recipe: mesh-authority
     sandbox: /tmp/pi-mesh-authority/authority
     task: |
-      You are the authority in this mesh. Two worker peers will join.
-      Start by calling agent_list to see who is already online, then wait.
-      Messages from peers arrive as [from <peer>] prompts.
-      When a peer sends you a request, handle it using your tools and reply
-      with agent_send({to: "<peer>", body: "<answer>", in_reply_to: "<msg_id>"}).
+      You are the authority in this mesh. Two worker peers (an analyst and a writer)
+      are part of this topology. Peer messages arrive as [from <peer>] prompts.
+      When a peer sends a request, handle it with your tools and reply via
+      agent_send({to: "<peer>", body: "<answer>", in_reply_to: "<msg_id>"}).
 
   - recipe: mesh-node
     sandbox: /tmp/pi-mesh-authority/analyst
     supervisor: "@authority"
     task: |
-      You are a research worker in a mesh. Start by calling agent_list to
-      discover the authority and other peers. Wait for requests from peers.
+      You are the research analyst in this mesh. Your supervisor is authority.
       When a request arrives as [from <peer> re:<id>] <body>, research or
       analyse it using your tools, then reply with:
         agent_send({to: "<peer>", body: "<findings>", in_reply_to: "<full_msg_id>"})
@@ -58,10 +56,9 @@ nodes:
     sandbox: /tmp/pi-mesh-authority/writer
     supervisor: "@authority"
     task: |
-      You are a drafting worker in a mesh. Start by calling agent_list to
-      discover the authority and other peers. Wait for drafting requests.
-      When a request arrives as [from <peer> re:<id>] <body>, draft the
-      requested content, SAVE IT TO A FILE using the write tool, then reply
-      with the file path and a summary:
+      You are the drafting writer in this mesh. Your supervisor is authority.
+      When a drafting request arrives as [from <peer> re:<id>] <body>, draft the
+      content, SAVE IT TO A FILE using the write tool, then reply with the file
+      path and a summary:
         agent_send({to: "<peer>", body: "Saved to <path>: <summary>", in_reply_to: "<full_msg_id>"})
-      Always write the file before replying — do not just return the text inline.
+      Always write the file before replying — do not return content inline.

--- a/pi-sandbox/meshes/grouped-mesh.yaml
+++ b/pi-sandbox/meshes/grouped-mesh.yaml
@@ -52,15 +52,15 @@ nodes:
     acceptedFrom: ["@workers"]
     task: |
       You are the authority in this mesh. Your peers are: analyst, writer, reviewer.
-      Start by calling agent_list to see who is online. Then wait for messages from workers.
-      When a worker sends you a request, coordinate with your peers and reply.
+      Worker messages arrive as [from <peer>] prompts. When one does, coordinate
+      with your peers as needed and reply via agent_send.
 
   - name: analyst
     recipe: mesh-node
     sandbox: /tmp/pi-mesh-grouped/analyst
     task: |
-      You are the analyst worker in a mesh. Your name is "analyst".
-      Wait for research requests. When a request arrives as [from <peer>] <body>,
+      You are the analyst in this mesh. Your supervisor is authority.
+      When a research request arrives as [from <peer>] <body>,
       research it using your tools and reply with agent_send.
 
   - name: writer
@@ -69,8 +69,8 @@ nodes:
     # Per-node override: writer submits drafts to reviewer, not authority.
     submitTo: reviewer
     task: |
-      You are the writer worker in a mesh. Your name is "writer".
-      Wait for drafting requests. When a request arrives, draft the content,
+      You are the writer in this mesh. Your supervisor is authority; you submit
+      drafts to reviewer. When a drafting request arrives, draft the content,
       save it to a file, then reply with the file path and a summary.
 
   - name: reviewer
@@ -79,6 +79,6 @@ nodes:
     supervisor: authority
     acceptedFrom: [writer]
     task: |
-      You are the reviewer in a mesh. Your name is "reviewer".
-      Wait for submissions from the writer. When a submission arrives, review it
-      for quality and completeness, then send feedback back to the writer.
+      You are the reviewer in this mesh. Your supervisor is authority.
+      When a submission arrives from writer, review it for quality and completeness,
+      then send feedback back via agent_send.

--- a/scripts/launch-mesh.mjs
+++ b/scripts/launch-mesh.mjs
@@ -13,11 +13,11 @@
 //     - name: authority           # instance name (--agent-name)
 //       recipe: mesh-authority    # recipe in pi-sandbox/agents/
 //       sandbox: /tmp/mesh/auth   # optional; auto-created
-//       task: "..."               # optional; sent to the peer as the first user message
+//       task: "..."               # optional; appended to system prompt as per-instance role context
 //     - name: analyst
 //       recipe: mesh-node
 //       supervisor: authority     # all non-root nodes must declare a supervisor
-//       task: "wait for requests"
+//       task: "you are the analyst; handle research requests from authority"
 // NOTE: type:relay nodes are no longer supported (see ADR-0004); the validator
 //       will reject any topology that still declares them.
 
@@ -438,9 +438,11 @@ for (let i = 0; i < topology.nodes.length; i++) {
   // non-focused peers keep emitting ANSI into their virtual buffers, so a
   // /focus switch repaints a real TUI snapshot rather than RPC JSON.
   //
-  // The optional `task:` field is forwarded as a positional argument to pi
-  // (interactive mode treats trailing positionals as the first user message),
-  // replacing the previous `--mode rpc` + JSON-over-stdin bootstrap.
+  // The optional `task:` field is forwarded as --task so run-agent.mjs can
+  // append it to the system prompt as per-instance role context. Delivering
+  // it as system-prompt context (not a positional first-user-message) keeps
+  // peers idle until a real inbound event arrives rather than firing an LLM
+  // turn immediately at mesh start.
   const peerArgs = [
     RUNNER,
     recipe,
@@ -452,7 +454,7 @@ for (let i = 0; i < topology.nodes.length; i++) {
   ];
 
   if (typeof task === "string" && task.trim()) {
-    peerArgs.push(task);
+    peerArgs.push("--task", task);
   }
 
   const peerEnv = {

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -286,6 +286,7 @@ const skillPaths = resolveSkillPaths(Array.isArray(recipe.skills) ? recipe.skill
 // supervisor/intercept prompt fragments (Step 6).
 let agentName = null;                                     // null → generate
 let topologyOverlayJson = "";
+let taskText = "";                                        // appended to system prompt
 const passthrough = [];
 for (let i = 0; i < args.passthrough.length; i++) {
   if (args.passthrough[i] === "--agent-name" && i + 1 < args.passthrough.length) {
@@ -293,6 +294,9 @@ for (let i = 0; i < args.passthrough.length; i++) {
   } else if (args.passthrough[i] === "--topology-overlay" && i + 1 < args.passthrough.length) {
     topologyOverlayJson = args.passthrough[++i];
     // do not push --topology-overlay into passthrough; pi doesn't know this flag
+  } else if (args.passthrough[i] === "--task" && i + 1 < args.passthrough.length) {
+    taskText = args.passthrough[++i];
+    // do not push --task into passthrough; it's consumed here as system-prompt context
   } else {
     passthrough.push(args.passthrough[i]);
   }
@@ -386,7 +390,9 @@ const mergedExtensions = [
   ...wired.extensions.filter((n) => !effectiveBaseline.includes(n)),
 ];
 const promptFragments = loadPromptFragments(mergedExtensions, hasSupervisoryHabitat);
-const systemPrompt = [...promptFragments, recipe.prompt.trim()].join("\n\n");
+const promptParts = [...promptFragments, recipe.prompt.trim()];
+if (taskText.trim()) promptParts.push(taskText.trim());
+const systemPrompt = promptParts.join("\n\n");
 
 const piArgs = [
   "--no-context-files",


### PR DESCRIPTION
## Summary

- `launch-mesh.mjs` now passes `task:` as `--task <text>` instead of a trailing positional, so pi no longer treats it as the first user message
- `run-agent.mjs` parses `--task` and appends it to the system prompt as the final segment — peers boot idle and wait for real inbound bus events
- Rewrote the example mesh YAML `task:` strings from imperative ("Start by calling agent_list…") to declarative role context

`atomic-delegate` is untouched — its one-shot `-p <task>` workers still generate immediately on first turn.

## Test plan

- [x] 661 unit tests pass (`npm test`)
- [ ] Manual: launch `authority-mesh.yaml` under tmux, confirm no peer fires an LLM turn at startup

https://claude.ai/code/session_014TMzWoUBbaFu2tTeV4RNJS

---
_Generated by [Claude Code](https://claude.ai/code/session_014TMzWoUBbaFu2tTeV4RNJS)_