### PR TITLE
Slice 1: peer.yaml template artifact + template loader (deep module + hermetic tests)

### DIFF
--- a/pi-sandbox/templates/peer.yaml
+++ b/pi-sandbox/templates/peer.yaml
@@ -1,0 +1,25 @@
+# Universal-rail bundle for mesh peers.
+#
+# This template is the canonical source for the rails every peer agent
+# inherits — the union of BASELINE_EXTENSIONS and MESH_PEER_EXTENSIONS in
+# scripts/run-agent.mjs, in their load order. Recipes will eventually
+# `extends: peer` to pick up these rails and append per-role rails on top.
+#
+# NOTE: Slice 1 only ships this artifact and a hermetic loader. The runner
+# still drives runtime behaviour from the JS arrays in run-agent.mjs.
+# Editing this file does NOT change runtime behaviour yet.
+extensions:
+  - habitat
+  - sandbox
+  - no-startup-help
+  - agent-header
+  - agent-footer
+  - hide-extensions-list
+  - deferred-confirm
+  - supervisor
+  - intercept
+  - agent-bus
+  - launcher-bridge
+  - slash-commands
+  - bus-tail-emitter
+  - mesh-rail

--- a/scripts/_lib/template-loader.mjs
+++ b/scripts/_lib/template-loader.mjs
@@ -1,0 +1,85 @@
+// template-loader.mjs — loads and validates a named YAML template from the
+// pi-sandbox/templates/ directory, verifying that every listed extension has a
+// corresponding .ts file in the extensions directory.
+//
+// Exports a single named function: loadTemplate(name, fsContext) → string[]
+//
+// This module is intentionally not yet imported by the runner (Slice 1).
+// Runtime behaviour of npm run agent and npm run mesh is unchanged.
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+
+/**
+ * Loads a YAML template by name and returns its extensions list.
+ *
+ * @param {string} name - Template name (without .yaml extension).
+ * @param {{ templatesDir: string, extensionsDir: string }} fsContext
+ *   - templatesDir: absolute path to the templates directory.
+ *   - extensionsDir: absolute path to the extensions directory.
+ * @returns {string[]} The extensions list declared in the template, in order.
+ * @throws {Error} On any validation failure, with a "template-loader: " prefix.
+ */
+export function loadTemplate(name, fsContext) {
+  if (typeof name !== "string" || name.length === 0) {
+    throw new Error("template-loader: name must be a non-empty string");
+  }
+
+  const { templatesDir, extensionsDir } = fsContext ?? {};
+
+  if (typeof templatesDir !== "string") {
+    throw new Error("template-loader: fsContext.templatesDir must be a string");
+  }
+  if (typeof extensionsDir !== "string") {
+    throw new Error("template-loader: fsContext.extensionsDir must be a string");
+  }
+
+  const templatePath = path.join(templatesDir, `${name}.yaml`);
+
+  if (!existsSync(templatePath)) {
+    throw new Error(`template-loader: template not found: ${templatePath}`);
+  }
+
+  const raw = readFileSync(templatePath, "utf8");
+
+  let parsed;
+  try {
+    parsed = parseYaml(raw);
+  } catch (e) {
+    throw new Error(`template-loader: failed to parse ${templatePath}: ${e.message}`);
+  }
+
+  if (parsed === null || parsed === undefined || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`template-loader: template ${templatePath} must be a YAML mapping at top level`);
+  }
+
+  if (parsed.extensions === undefined || parsed.extensions === null) {
+    throw new Error(`template-loader: template ${templatePath} missing 'extensions' list`);
+  }
+
+  if (!Array.isArray(parsed.extensions)) {
+    throw new Error(`template-loader: template ${templatePath} 'extensions' must be a list`);
+  }
+
+  if (parsed.extensions.length === 0) {
+    return [];
+  }
+
+  for (let i = 0; i < parsed.extensions.length; i++) {
+    const entry = parsed.extensions[i];
+    if (typeof entry !== "string" || entry.length === 0) {
+      throw new Error(
+        `template-loader: template ${templatePath} 'extensions[${i}]' must be a non-empty string`
+      );
+    }
+    const extPath = path.join(extensionsDir, `${entry}.ts`);
+    if (!existsSync(extPath)) {
+      throw new Error(
+        `template-loader: extension '${entry}' listed in ${templatePath} not found at ${extPath}`
+      );
+    }
+  }
+
+  return [...parsed.extensions];
+}

--- a/scripts/_lib/template-loader.test.ts
+++ b/scripts/_lib/template-loader.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { loadTemplate } from "./template-loader.mjs";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+describe("template-loader", () => {
+  let tmpRoot: string;
+  let templatesDir: string;
+  let extensionsDir: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "template-loader-"));
+    templatesDir = path.join(tmpRoot, "templates");
+    extensionsDir = path.join(tmpRoot, "extensions");
+    fs.mkdirSync(templatesDir, { recursive: true });
+    fs.mkdirSync(extensionsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function writeTemplate(name: string, body: string): void {
+    fs.writeFileSync(path.join(templatesDir, `${name}.yaml`), body, "utf8");
+  }
+
+  function writeExtension(name: string): void {
+    fs.writeFileSync(path.join(extensionsDir, `${name}.ts`), "", "utf8");
+  }
+
+  it("happy path: returns the extensions list in declared order", () => {
+    writeTemplate("peer", "extensions:\n  - habitat\n  - sandbox\n  - mesh-rail\n");
+    writeExtension("habitat");
+    writeExtension("sandbox");
+    writeExtension("mesh-rail");
+    const result = loadTemplate("peer", { templatesDir, extensionsDir });
+    expect(result).toEqual(["habitat", "sandbox", "mesh-rail"]);
+  });
+
+  it("missing template file throws with template-loader: prefix and the path", () => {
+    const expectedPath = path.join(templatesDir, "peer.yaml");
+    expect(() => loadTemplate("peer", { templatesDir, extensionsDir })).toThrow(
+      /template-loader: template not found/
+    );
+    expect(() => loadTemplate("peer", { templatesDir, extensionsDir })).toThrow(expectedPath);
+  });
+
+  it("missing extension throws naming the extension and the template", () => {
+    writeTemplate("peer", "extensions:\n  - habitat\n  - ghost\n");
+    writeExtension("habitat");
+    expect(() => loadTemplate("peer", { templatesDir, extensionsDir })).toThrow(
+      /template-loader: extension 'ghost' listed in .* not found/
+    );
+  });
+
+  it("malformed YAML throws with the template path", () => {
+    writeTemplate("peer", "extensions: [unclosed\n");
+    expect(() => loadTemplate("peer", { templatesDir, extensionsDir })).toThrow(
+      /template-loader: failed to parse/
+    );
+  });
+
+  it("empty extensions list returns []", () => {
+    writeTemplate("peer", "extensions: []\n");
+    const result = loadTemplate("peer", { templatesDir, extensionsDir });
+    expect(result).toEqual([]);
+  });
+
+  it("missing extensions key throws (different from empty list)", () => {
+    writeTemplate("peer", "name: peer\n");
+    expect(() => loadTemplate("peer", { templatesDir, extensionsDir })).toThrow(
+      /missing 'extensions' list/
+    );
+  });
+
+  it("non-list extensions value throws", () => {
+    writeTemplate("peer", "extensions: foo\n");
+    expect(() => loadTemplate("peer", { templatesDir, extensionsDir })).toThrow(
+      /'extensions' must be a list/
+    );
+  });
+
+  it("rejects non-string entries in extensions list", () => {
+    writeTemplate("peer", "extensions:\n  - habitat\n  - 42\n");
+    writeExtension("habitat");
+    expect(() => loadTemplate("peer", { templatesDir, extensionsDir })).toThrow(
+      /'extensions\[1\]' must be a non-empty string/
+    );
+  });
+
+  it("does not return a reference to the parsed YAML's internal array", () => {
+    writeTemplate("peer", "extensions:\n  - habitat\n  - sandbox\n");
+    writeExtension("habitat");
+    writeExtension("sandbox");
+    const result = loadTemplate("peer", { templatesDir, extensionsDir });
+    result.push("hacked");
+    const result2 = loadTemplate("peer", { templatesDir, extensionsDir });
+    expect(result2.length).toBe(2);
+    expect(result2).not.toContain("hacked");
+  });
+});


### PR DESCRIPTION
## What this fixes

Foundation slice for the template/extends primitive (PRD #115). It introduces two new artifacts and a dedicated test suite, but deliberately changes nothing at runtime — `npm run agent` and `npm run mesh` continue to drive their baseline rails from `BASELINE_EXTENSIONS` and `MESH_PEER_EXTENSIONS` in `scripts/run-agent.mjs:19-54`.

- `pi-sandbox/templates/peer.yaml` — the universal-rail bundle every peer agent will eventually inherit. Its `extensions:` list contains the 14 names from the issue's acceptance criteria, in the exact order specified (note: `supervisor`/`intercept` precede `agent-bus` in the YAML, while the JS arrays in `run-agent.mjs` order `agent-bus` first; the JS arrays are intentionally untouched in this slice).
- `scripts/_lib/template-loader.mjs` — pure deep module exporting one named function: `loadTemplate(name, {templatesDir, extensionsDir}) → string[]`. Loud failures with `template-loader: ` prefixed errors for missing template, malformed YAML, missing top-level mapping, missing `extensions:` key, non-list `extensions:`, non-string entries, and listed extensions whose `<extensionsDir>/<name>.ts` file is absent. Empty list returns `[]`. Returns a defensive copy.
- `scripts/_lib/template-loader.test.ts` — hermetic vitest suite (tmpdir fixtures only, no real fs outside tmpdir, no env, no model calls). Covers all five required cases (happy path, missing template, missing extension, malformed YAML, empty list) plus four contract-locking extras (missing key vs empty list, non-list scalar, non-string entries, defensive return-array copy).

The runner does not import `template-loader.mjs`; subsequent slices in PRD #115 will wire it in.

## QA steps for the human

None — fully covered by the integration smoke. The smoke verified set-equality between the loader's live output and `BASELINE_EXTENSIONS ∪ MESH_PEER_EXTENSIONS`, confirmed every returned name resolves to a real `<name>.ts` file under `pi-sandbox/.pi/extensions/`, ran the full test suite (670/670 green), and confirmed `git diff main..HEAD -- scripts/run-agent.mjs scripts/launch-mesh.mjs` is empty.

## Automated coverage

Vitest: 30 files / 670 tests pass (3.1s), including the 9 new `template-loader` cases.

Closes #132

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xqspq4DYzmJgr4M3KD9Y25)_