### PR TITLE
Slice 3: Runner cutover — drop hardcoded baseline; add `extends: peer` to all recipes

### DIFF
--- a/pi-sandbox/.pi/extensions/habitat.ts
+++ b/pi-sandbox/.pi/extensions/habitat.ts
@@ -7,8 +7,8 @@
 // without the runner), a minimal Habitat is assembled from ctx.cwd
 // and PI_AGENT_NAME so the session still boots cleanly.
 //
-// This extension must be first in BASELINE_EXTENSIONS so it runs
-// before any rail that calls getHabitat() in its own session_start.
+// This extension must be first in the peer template's extension list so it
+// runs before any rail that calls getHabitat() in its own session_start.
 
 import os from "node:os";
 import path from "node:path";

--- a/pi-sandbox/agents/change-reviewer.yaml
+++ b/pi-sandbox/agents/change-reviewer.yaml
@@ -3,6 +3,7 @@
 # Read-only via the tools allowlist. All filesystem activity is sandboxed
 # to the directory you launched `npm run agent` from (or --sandbox <dir>).
 
+extends: peer
 model: LEAD_HARE_MODEL
 shortName: reviewer
 

--- a/pi-sandbox/agents/code-reviewer.yaml
+++ b/pi-sandbox/agents/code-reviewer.yaml
@@ -2,6 +2,7 @@
 # Read-only via the tools allowlist. All filesystem activity is sandboxed
 # to the directory you launched `npm run agent` from (or --sandbox <dir>).
 
+extends: peer
 model: LEAD_HARE_MODEL
 shortName: critic
 

--- a/pi-sandbox/agents/deferred-author.yaml
+++ b/pi-sandbox/agents/deferred-author.yaml
@@ -3,6 +3,7 @@
 # turn. All filesystem activity is sandboxed to the directory you launched
 # `npm run agent` from (or --sandbox <dir>).
 
+extends: peer
 model: TASK_RABBIT_MODEL
 shortName: author
 

--- a/pi-sandbox/agents/deferred-editor.yaml
+++ b/pi-sandbox/agents/deferred-editor.yaml
@@ -3,6 +3,7 @@
 # All filesystem activity is sandboxed to the directory you launched
 # `npm run agent` from (or --sandbox <dir>).
 
+extends: peer
 model: TASK_RABBIT_MODEL
 shortName: editor
 

--- a/pi-sandbox/agents/deferred-writer.yaml
+++ b/pi-sandbox/agents/deferred-writer.yaml
@@ -2,6 +2,7 @@
 # All filesystem activity is sandboxed to the directory you launched
 # `npm run agent` from (or --sandbox <dir>).
 
+extends: peer
 model: TASK_RABBIT_MODEL
 shortName: writer
 

--- a/pi-sandbox/agents/delegator.yaml
+++ b/pi-sandbox/agents/delegator.yaml
@@ -13,6 +13,7 @@
 #   > "delegate to recipe peer-chatter with task 'list files in cwd'"
 #   > "delegate to recipe deferred-writer with task 'draft README.md'"
 
+extends: peer
 model: LEAD_HARE_MODEL
 shortName: captain
 

--- a/pi-sandbox/agents/mesh-authority.yaml
+++ b/pi-sandbox/agents/mesh-authority.yaml
@@ -1,7 +1,7 @@
 # mesh-authority — mesh orchestrator recipe.
-# Loads agent-bus (peer membership on the bus) and mesh-authority (spawn/stop
-# long-running nodes). Also declares agents: so the atomic `delegate` tool is
-# available for finite task workers.
+# Inherits agent-bus (peer membership on the bus) from extends: peer, and adds
+# mesh-authority (spawn/stop long-running nodes). Also declares agents: so the
+# atomic `delegate` tool is available for finite task workers.
 #
 # The authority's instance name (--agent-name) is what peers use to address it
 # on the bus. Launched with an explicit name so multiple mesh topologies don't

--- a/pi-sandbox/agents/mesh-authority.yaml
+++ b/pi-sandbox/agents/mesh-authority.yaml
@@ -13,6 +13,7 @@
 # Or via the mesh launcher:
 #   npm run mesh -- pi-sandbox/meshes/authority-mesh.yaml
 
+extends: peer
 model: LEAD_HARE_MODEL
 shortName: authority
 
@@ -53,7 +54,6 @@ tools:
   - delegate
 
 extensions:
-  - agent-bus
   - mesh-authority
 
 agents:

--- a/pi-sandbox/agents/mesh-node.yaml
+++ b/pi-sandbox/agents/mesh-node.yaml
@@ -10,6 +10,7 @@
 # Or spawned by the authority agent via mesh_spawn:
 #   mesh_spawn({recipe: "mesh-node", name: "analyst", task: "wait for requests"})
 
+extends: peer
 model: TASK_RABBIT_MODEL
 shortName: node
 
@@ -35,6 +36,3 @@ tools:
   - agent_send
   - agent_inbox
   - agent_call
-
-extensions:
-  - agent-bus

--- a/pi-sandbox/agents/mesh-writer.yaml
+++ b/pi-sandbox/agents/mesh-writer.yaml
@@ -3,6 +3,7 @@
 # Launched via the mesh launcher or mesh_spawn; sandbox keeps writes
 # inside the node's working directory.
 
+extends: peer
 model: TASK_RABBIT_MODEL
 shortName: writer
 
@@ -30,6 +31,3 @@ tools:
   - agent_send
   - agent_inbox
   - agent_call
-
-extensions:
-  - agent-bus

--- a/pi-sandbox/agents/peer-chatter.yaml
+++ b/pi-sandbox/agents/peer-chatter.yaml
@@ -11,6 +11,7 @@
 #
 # Then prompt pane A: "call agent_list, then agent_send to worker-a with body 'ping'"
 
+extends: peer
 model: TASK_RABBIT_MODEL
 shortName: chatter
 
@@ -30,6 +31,3 @@ tools:
   - agent_send
   - agent_inbox
   - agent_list
-
-extensions:
-  - agent-bus

--- a/pi-sandbox/agents/writer-foreman.yaml
+++ b/pi-sandbox/agents/writer-foreman.yaml
@@ -11,6 +11,7 @@
 #
 # Run: `npm run agent -- writer-foreman --sandbox /tmp/foreman-test`
 
+extends: peer
 model: LEAD_HARE_MODEL
 shortName: foreman
 

--- a/pi-sandbox/templates/peer.yaml
+++ b/pi-sandbox/templates/peer.yaml
@@ -1,13 +1,9 @@
 # Universal-rail bundle for mesh peers.
 #
-# This template is the canonical source for the rails every peer agent
-# inherits — the union of BASELINE_EXTENSIONS and MESH_PEER_EXTENSIONS in
-# scripts/run-agent.mjs, in their load order. Recipes will eventually
-# `extends: peer` to pick up these rails and append per-role rails on top.
-#
-# NOTE: Slice 1 only ships this artifact and a hermetic loader. The runner
-# still drives runtime behaviour from the JS arrays in run-agent.mjs.
-# Editing this file does NOT change runtime behaviour yet.
+# This template is the canonical and authoritative source for the rails every
+# peer agent inherits. All recipes declare `extends: peer` to pick up these
+# rails; the runner resolves the extension list via resolveRecipe() (Slice 3).
+# Editing this file changes runtime behaviour for every recipe that extends it.
 extensions:
   - habitat
   - sandbox

--- a/scripts/_lib/recipe-resolver.mjs
+++ b/scripts/_lib/recipe-resolver.mjs
@@ -1,12 +1,13 @@
 // recipe-resolver.mjs — resolves a named agent recipe into an effective recipe
-// descriptor, mirroring the logic in scripts/run-agent.mjs without touching
-// process state (no process.exit, no console writes).
+// descriptor. The runner (scripts/run-agent.mjs) calls resolveRecipe() as the
+// sole source of the extension list (Slice 3 cutover); no duplicate JS-baseline
+// arrays remain in the runner.
 //
 // Exports a single named function: resolveRecipe(name, fsContext) → effectiveRecipe
 //
-// This module is intentionally a shadow read only (Slice 2). Runtime behaviour
-// of npm run agent and npm run mesh is unchanged; the runner calls this after
-// computing mergedExtensions and compares for divergence.
+// This module is hermetic: reads from the filesystem via fsContext paths only,
+// throws on any validation failure, and never writes to process state
+// (no process.exit, no console writes).
 
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";

--- a/scripts/_lib/recipe-resolver.test.ts
+++ b/scripts/_lib/recipe-resolver.test.ts
@@ -350,3 +350,110 @@ tools:
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Real-repo regression test: Slice 3 cutover invariants
+//
+// These tests resolve representative real recipes against the actual YAML
+// files in pi-sandbox/agents/ and pi-sandbox/templates/ to guard that:
+//   1. Every recipe resolves without error after `extends: peer` is added.
+//   2. The extensionList starts with the full peer-template chain in order.
+//   3. No duplicate `agent-bus` (or any other entry) appears in the list.
+// ---------------------------------------------------------------------------
+
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const REAL_AGENTS_DIR = path.join(REPO_ROOT, "pi-sandbox", "agents");
+const REAL_TEMPLATES_DIR = path.join(REPO_ROOT, "pi-sandbox", "templates");
+const REAL_EXTENSIONS_DIR = path.join(
+  REPO_ROOT,
+  "pi-sandbox",
+  ".pi",
+  "extensions",
+);
+const REAL_FS_CONTEXT = {
+  agentsDir: REAL_AGENTS_DIR,
+  templatesDir: REAL_TEMPLATES_DIR,
+  extensionsDir: REAL_EXTENSIONS_DIR,
+};
+
+// The peer template's extension chain in declaration order.
+const PEER_TEMPLATE_EXTENSIONS = [
+  "habitat",
+  "sandbox",
+  "no-startup-help",
+  "agent-header",
+  "agent-footer",
+  "hide-extensions-list",
+  "deferred-confirm",
+  "supervisor",
+  "intercept",
+  "agent-bus",
+  "launcher-bridge",
+  "slash-commands",
+  "bus-tail-emitter",
+  "mesh-rail",
+];
+
+describe("recipe-resolver real-repo recipes", () => {
+  it("peer-chatter: resolves without error and extensionList begins with the full peer-template chain", () => {
+    const result = resolveRecipe("peer-chatter", REAL_FS_CONTEXT);
+    expect(result.extensionList.slice(0, PEER_TEMPLATE_EXTENSIONS.length)).toEqual(
+      PEER_TEMPLATE_EXTENSIONS,
+    );
+  });
+
+  it("peer-chatter: no duplicate agent-bus in extensionList", () => {
+    const result = resolveRecipe("peer-chatter", REAL_FS_CONTEXT);
+    const occurrences = result.extensionList.filter((n) => n === "agent-bus");
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("deferred-writer: resolves without error and extensionList begins with the full peer-template chain", () => {
+    const result = resolveRecipe("deferred-writer", REAL_FS_CONTEXT);
+    expect(result.extensionList.slice(0, PEER_TEMPLATE_EXTENSIONS.length)).toEqual(
+      PEER_TEMPLATE_EXTENSIONS,
+    );
+  });
+
+  it("deferred-writer: no duplicate entries in extensionList", () => {
+    const result = resolveRecipe("deferred-writer", REAL_FS_CONTEXT);
+    const seen = new Set<string>();
+    for (const ext of result.extensionList) {
+      expect(seen.has(ext)).toBe(false);
+      seen.add(ext);
+    }
+  });
+
+  it("all real recipes resolve without error", () => {
+    const recipes = fs
+      .readdirSync(REAL_AGENTS_DIR)
+      .filter((f) => f.endsWith(".yaml"))
+      .map((f) => f.slice(0, -".yaml".length));
+    for (const name of recipes) {
+      expect(() => resolveRecipe(name, REAL_FS_CONTEXT)).not.toThrow();
+    }
+  });
+
+  it("all real recipes with extends: peer have extensionList starting with the full peer-template chain", () => {
+    const recipes = fs
+      .readdirSync(REAL_AGENTS_DIR)
+      .filter((f) => f.endsWith(".yaml"))
+      .map((f) => f.slice(0, -".yaml".length));
+    for (const name of recipes) {
+      const raw = fs.readFileSync(
+        path.join(REAL_AGENTS_DIR, `${name}.yaml`),
+        "utf8",
+      );
+      if (!raw.includes("extends: peer")) continue;
+      const result = resolveRecipe(name, REAL_FS_CONTEXT);
+      expect(result.extensionList.slice(0, PEER_TEMPLATE_EXTENSIONS.length)).toEqual(
+        PEER_TEMPLATE_EXTENSIONS,
+      );
+    }
+  });
+});

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -18,42 +18,6 @@ const EXTENSIONS_DIR = path.join(SANDBOX_ROOT, ".pi", "extensions");
 const SKILLS_DIR = path.join(SANDBOX_ROOT, "skills");
 const PI_BIN = path.join(REPO_ROOT, "node_modules", ".bin", "pi");
 
-const BASELINE_EXTENSIONS = [
-  // Must be first — materialises the Habitat before any rail reads it.
-  "habitat",
-  "sandbox",
-  "no-startup-help",
-  "agent-header",
-  "agent-footer",
-  "hide-extensions-list",
-  "deferred-confirm",
-  // Bus binding is a baseline now: atomic-delegate, supervisor rail,
-  // and the deferred-* submission flow all need a bound bus socket.
-  // The agent_send / agent_inbox / agent_list / agent_call tools stay
-  // gated by the recipe's `tools:` allowlist, so loading the extension
-  // by default does not change the tool surface seen by the model.
-  "agent-bus",
-  // supervisor must appear before intercept so intercept can wrap
-  // supervisor's globalThis dispatch hook at session_start. Both
-  // self-gate via getHabitat().acceptedFrom when the topology does not
-  // assign any inbound peers to this instance.
-  "supervisor",
-  "intercept",
-];
-
-// When launched under the mesh launcher (PI_MESH_PEER=1), load the launcher
-// bridge, focus-state, and slash-commands extensions as additional baselines.
-// These are silent no-ops when the launcher socket is absent (standalone mode).
-//
-// mesh-rail renders the mesh-status widget above the editor; only meaningful
-// under the launcher. Like the others, it degrades silently if hasUI is false
-// (print mode / no TUI).
-const MESH_PEER_EXTENSIONS = [
-  "launcher-bridge",
-  "slash-commands",
-  "bus-tail-emitter",
-  "mesh-rail",
-];
 const TIER_VARS = new Set(["RABBIT_SAGE_MODEL", "LEAD_HARE_MODEL", "TASK_RABBIT_MODEL"]);
 
 function die(msg) {
@@ -196,23 +160,12 @@ function resolveModel(tierOrId) {
   return requested;
 }
 
-function resolveExtensionPaths(names, isMeshPeer = false) {
-  const seen = new Set();
-  const baseline = isMeshPeer
-    ? [...BASELINE_EXTENSIONS, ...MESH_PEER_EXTENSIONS]
-    : BASELINE_EXTENSIONS;
-  const merged = [...baseline, ...names];
-  return merged
-    .filter((n) => {
-      if (seen.has(n)) return false;
-      seen.add(n);
-      return true;
-    })
-    .map((n) => {
-      const p = path.join(EXTENSIONS_DIR, `${n}.ts`);
-      if (!existsSync(p)) die(`extension not found: ${p}`);
-      return p;
-    });
+function resolveExtensionPaths(names) {
+  return names.map((n) => {
+    const p = path.join(EXTENSIONS_DIR, `${n}.ts`);
+    if (!existsSync(p)) die(`extension not found: ${p}`);
+    return p;
+  });
 }
 
 function resolveSkillPaths(names) {
@@ -270,14 +223,19 @@ const wired = wiredAgents;
 // declare any supervisory peer fields.
 wired.tools = mergeBaselineTools(wired.tools);
 
-// PI_MESH_PEER=1 is set by launch-mesh.mjs for all peers. It signals
-// run-agent.mjs to load the launcher-bridge + slash-commands baseline extensions
-// so peers can receive focus-changed signals and send /focus requests.
-// When run standalone via `npm run agent`, PI_MESH_PEER is unset,
-// so the launcher extensions degrade gracefully (socket not found = no-op).
-const isMeshPeer = process.env.PI_MESH_PEER === "1";
+// Resolve the effective extension list from the recipe (via resolveRecipe).
+// The resolver is now authoritative: it reads the recipe's `extends:` chain
+// (peer.yaml includes both baseline and mesh-peer rails) and deduplicates.
+// PI_MESH_PEER=1 is still read by the PTY-in-PTY check below for stdio
+// handling, but no longer gates extension loading.
+const resolved = resolveRecipe(args.name, {
+  agentsDir: AGENTS_DIR,
+  templatesDir: TEMPLATES_DIR,
+  extensionsDir: EXTENSIONS_DIR,
+});
+const mergedExtensions = resolved.extensionList;
 
-const extensionPaths = resolveExtensionPaths(wired.extensions, isMeshPeer);
+const extensionPaths = resolveExtensionPaths(mergedExtensions);
 const skillPaths = resolveSkillPaths(Array.isArray(recipe.skills) ? recipe.skills : []);
 
 // --agent-name passthrough is parsed only to capture the value into the
@@ -384,63 +342,6 @@ const hasSupervisoryHabitat =
   Boolean(habitatSpec.supervisor) ||
   Boolean(habitatSpec.submitTo);
 
-const effectiveBaseline = isMeshPeer
-  ? [...BASELINE_EXTENSIONS, ...MESH_PEER_EXTENSIONS]
-  : BASELINE_EXTENSIONS;
-const mergedExtensions = [
-  ...effectiveBaseline,
-  ...wired.extensions.filter((n) => !effectiveBaseline.includes(n)),
-];
-
-// ── Slice 2 shadow-mode comparator ───────────────────────────────────────────
-// Call resolveRecipe and compare its effective extension list with the one the
-// JS runner just computed. On mismatch, panic loudly so divergence is caught
-// immediately. On match, silent — runtime behaviour is unchanged.
-//
-// Slice 2 shadow-mode shim: today's recipes are bare (no `extends:`), so the
-// resolver returns only recipe-level extensions. We prepend effectiveBaseline
-// here for a like-for-like comparison. Once recipes start carrying
-// `extends: peer`, the JS baseline prefix will collapse to a no-op (all
-// baseline entries will already be present from the template chain).
-{
-  let resolverResult;
-  try {
-    resolverResult = resolveRecipe(args.name, {
-      agentsDir: AGENTS_DIR,
-      templatesDir: TEMPLATES_DIR,
-      extensionsDir: EXTENSIONS_DIR,
-    });
-  } catch (e) {
-    die(`recipe-resolver shadow failed for '${args.name}': ${e.message}`);
-  }
-
-  // Deduplicate baseline + resolver extension list (first-occurrence).
-  const seenShadow = new Set();
-  const shadowEffective = [];
-  for (const n of [...effectiveBaseline, ...resolverResult.extensionList]) {
-    if (!seenShadow.has(n)) {
-      seenShadow.add(n);
-      shadowEffective.push(n);
-    }
-  }
-
-  const mismatch =
-    mergedExtensions.length !== shadowEffective.length ||
-    mergedExtensions.some((n, i) => n !== shadowEffective[i]);
-
-  if (mismatch) {
-    process.stderr.write(
-      `run-agent: recipe-resolver shadow mismatch for '${args.name}':\n` +
-        `  js-baseline:   ${JSON.stringify(mergedExtensions)}\n` +
-        `  resolver+shim: ${JSON.stringify(shadowEffective)}\n` +
-        `  in js but not resolver: ${JSON.stringify(mergedExtensions.filter((n) => !shadowEffective.includes(n)))}\n` +
-        `  in resolver but not js: ${JSON.stringify(shadowEffective.filter((n) => !mergedExtensions.includes(n)))}\n`,
-    );
-    process.exit(1);
-  }
-}
-// ── End shadow comparator ─────────────────────────────────────────────────────
-
 const promptFragments = loadPromptFragments(mergedExtensions, hasSupervisoryHabitat);
 const promptParts = [...promptFragments, recipe.prompt.trim()];
 if (taskText.trim()) promptParts.push(taskText.trim());
@@ -493,12 +394,15 @@ if (!existsSync(PI_BIN)) die(`pi binary missing: ${PI_BIN} (run npm install)`);
 const isTTY = Boolean(process.stdout.isTTY);
 const isPrintMode = args.passthrough.includes("-p") || args.passthrough.includes("--print");
 
-// PTY-in-PTY fix (slice 3): when run-agent.mjs is launched as a PI_MESH_PEER=1
-// child of launch-mesh.mjs, its stdout is already inside the launcher's managed
-// PTY. Creating another PTY here would cause PTY-in-PTY nesting and break
-// terminal rendering. In that case, fall through to the inherited-stdio path so
-// pi writes directly to the launcher's PTY buffer.
-const isInsideManagedPty = isMeshPeer && isTTY;
+// PTY-in-PTY fix: when run-agent.mjs is launched as a PI_MESH_PEER=1 child of
+// launch-mesh.mjs, its stdout is already inside the launcher's managed PTY.
+// Creating another PTY here would cause PTY-in-PTY nesting and break terminal
+// rendering. In that case, fall through to the inherited-stdio path so pi
+// writes directly to the launcher's PTY buffer.
+// PI_MESH_PEER=1 no longer gates extension loading (the resolver handles that
+// via `extends: peer` in every recipe); it only controls stdio mode here.
+const isLauncherChild = process.env.PI_MESH_PEER === "1";
+const isInsideManagedPty = isLauncherChild && isTTY;
 
 if (isTTY && !isPrintMode && !isInsideManagedPty) {
   // Interactive launcher path: PTY + virtual buffer + multiplexer.


### PR DESCRIPTION
## What this fixes

This is the Slice 3 cutover for PRD #115 (YAML composition). Before this change, `scripts/run-agent.mjs` carried two hardcoded JS arrays — `BASELINE_EXTENSIONS` and `MESH_PEER_EXTENSIONS` — plus an `isMeshPeer` env-var gate and a shadow-mode comparator left over from Slice 2. The resolver in `scripts/_lib/recipe-resolver.mjs` was running in read-only shadow mode while the JS arrays still drove runtime.

After this change, the resolver is authoritative. The runner makes a single `resolveRecipe(name, { agentsDir, templatesDir, extensionsDir })` call after `loadRecipe` / `applyAgentsField` / `mergeBaselineTools`, and `resolved.extensionList` becomes the sole input to `resolveExtensionPaths` (now a plain name→path mapper, no baseline injection). Every recipe in `pi-sandbox/agents/` declares `extends: peer`, and the four mesh-tier recipes that listed `agent-bus` defensively in `extensions:` drop it (it now lives in `peer.yaml`). `PI_MESH_PEER` is still read for PTY-in-PTY stdio handling and is renamed to `isLauncherChild` locally to make that scope explicit; it no longer gates extension loading.

Net effect: "what extensions does my agent run" is answerable by reading the YAML alone — `peer.yaml` plus the recipe's own `extensions:` plus implicit `atomic-delegate` when `agents:` is non-empty.

Files changed: `scripts/run-agent.mjs`, `scripts/_lib/recipe-resolver.mjs` (docblock), `pi-sandbox/templates/peer.yaml` (header), `pi-sandbox/.pi/extensions/habitat.ts` (stale comment), all 11 recipes under `pi-sandbox/agents/`, and `scripts/_lib/recipe-resolver.test.ts` (new "real-repo recipes" describe block).

## QA steps for the human

None mandatory — the smoke covered the cutover path end-to-end. If you want a quick visual confirmation, run any one tmux smoke from `docs/agents.md` (e.g. `npm run agent -- deferred-writer`) and verify the agent header / footer render and the recipe boots — these scenarios all exercise the new resolver path.

## Automated coverage

`npm test` (695 passing, includes 6 new real-repo regression tests covering all 11 recipes); `node scripts/run-agent.mjs <recipe> -- --help` exits 0 for all 11 recipes; `validateTopology(pi-sandbox/meshes/authority-mesh.yaml)` returns zero errors; `grep -rn "BASELINE_EXTENSIONS|MESH_PEER_EXTENSIONS|isMeshPeer|effectiveBaseline|shadow" scripts/ pi-sandbox/` returns zero hits.

Closes #134

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPM6tJnVCnEPoipDn7PKc3)_