### PR TITLE
Slice 6: --debug CLI flag + drop env-var fallbacks for PI_AGENT_BUS_ROOT / PI_AGENT_NAME

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -307,7 +307,7 @@ flow up through whatever escalation chain is configured.
 
 ### Debugging the rails
 
-Set `AGENT_DEBUG=1` in the environment when launching an agent and the
+Pass `-- --debug` when launching an agent and the
 `sandbox` and `no-edit` extensions will dump their resolved tool sets
 via `ctx.ui.notify` on `session_start`. Useful when you've added a new
 write tool and want to confirm it was picked up by introspection.
@@ -320,7 +320,7 @@ drive a full TUI session under tmux:
 ```sh
 set -a; source models.env; set +a
 tmux new-session -d -s pi-test -x 200 -y 50 \
-  'AGENT_DEBUG=1 npm run agent -- deferred-writer'
+  'npm run agent -- deferred-writer -- --debug'
 sleep 5                                              # let pi boot + print debug
 tmux send-keys -t pi-test 'draft hello.txt saying hi' Enter
 sleep 30                                             # wait for the model
@@ -445,8 +445,8 @@ Registers three tools and one CLI flag:
 - `agent_list()` — probe `${BUS_ROOT}/*.sock` for live peers; clean up
   stale socks left by crashed peers.
 - `--agent-bus-root <dir>` — the rendezvous directory. Resolution
-  order: this flag → `$PI_AGENT_BUS_ROOT` → `~/.pi-agent-bus/<basename
-  of sandbox-root>`. The runner sets the flag automatically and accepts
+  order: this flag → `~/.pi-agent-bus/<basename of sandbox-root>`.
+  The runner sets the flag automatically and accepts
   `--agent-bus <dir>` (parallel to `--sandbox <dir>`) to override.
 
 Each agent listens on `${BUS_ROOT}/${name}.sock` (name comes from
@@ -536,7 +536,7 @@ To exercise the **atomic delegate** end-to-end, drive
 set -a; source models.env; set +a
 mkdir -p /tmp/foreman-test
 tmux new-session -d -s foreman -x 200 -y 50 \
-  'AGENT_DEBUG=1 npm run agent -- writer-foreman --sandbox /tmp/foreman-test'
+  'npm run agent -- writer-foreman --sandbox /tmp/foreman-test -- --debug'
 sleep 5
 tmux send-keys -t foreman \
   'draft hello.txt with text "Hi"' Enter
@@ -598,7 +598,7 @@ message rather than crashing.
 |------|--------|-------------|
 | `approval-request` | peer in `acceptedFrom` | Queued; model prompted |
 | `submission` | peer in `acceptedFrom` | Queued; model prompted |
-| Either kind from unknown peer | anyone not in `acceptedFrom` | Dropped silently (stderr under `AGENT_DEBUG=1`) |
+| Either kind from unknown peer | anyone not in `acceptedFrom` | Dropped silently (stderr when `--debug`) |
 | `message` | any peer | Free-flow (unrestricted, existing behaviour) |
 
 ### Four-action flow via `respond_to_request`

--- a/pi-sandbox/.pi/extensions/_lib/supervisor-inbox.test.ts
+++ b/pi-sandbox/.pi/extensions/_lib/supervisor-inbox.test.ts
@@ -132,9 +132,8 @@ describe("dispatchEnvelope — acceptedFrom", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("logs a debug message to stderr when dropping from unknown peer (AGENT_DEBUG=1)", () => {
-    process.env.AGENT_DEBUG = "1";
-    setHabitat(BASE_HABITAT);
+  it("logs a debug message to stderr when dropping from unknown peer (debug: true in Habitat)", () => {
+    setHabitat({ ...BASE_HABITAT, debug: true });
     const inbox = createSupervisorInbox();
     const env = makeApprovalRequestEnvelope({
       from: "intruder",
@@ -150,8 +149,27 @@ describe("dispatchEnvelope — acceptedFrom", () => {
     });
     inbox.dispatchEnvelope(env, vi.fn());
     stderrSpy.mockRestore();
-    delete process.env.AGENT_DEBUG;
     expect(stderrLines.some((l) => l.includes("intruder"))).toBe(true);
+  });
+
+  it("does NOT log a debug message when debug: false in Habitat", () => {
+    setHabitat({ ...BASE_HABITAT, debug: false });
+    const inbox = createSupervisorInbox();
+    const env = makeApprovalRequestEnvelope({
+      from: "intruder",
+      to: "supervisor",
+      title: "x",
+      summary: "s",
+      preview: "p",
+    });
+    const stderrLines: string[] = [];
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((s) => {
+      stderrLines.push(String(s));
+      return true;
+    });
+    inbox.dispatchEnvelope(env, vi.fn());
+    stderrSpy.mockRestore();
+    expect(stderrLines.some((l) => l.includes("intruder"))).toBe(false);
   });
 
   it("queues a submission from any peer in acceptedFrom", () => {

--- a/pi-sandbox/.pi/extensions/_lib/supervisor-inbox.ts
+++ b/pi-sandbox/.pi/extensions/_lib/supervisor-inbox.ts
@@ -77,11 +77,13 @@ export function createSupervisorInbox(): SupervisorInbox {
       if (kind !== "approval-request" && kind !== "submission") return;
 
       if (!isAllowed(env.from)) {
-        if (process.env.AGENT_DEBUG === "1") {
-          process.stderr.write(
-            `[supervisor] dropping ${kind} from '${env.from}': not in acceptedFrom\n`,
-          );
-        }
+        try {
+          if (getHabitat().debug === true) {
+            process.stderr.write(
+              `[supervisor] dropping ${kind} from '${env.from}': not in acceptedFrom\n`,
+            );
+          }
+        } catch { /* Habitat not available */ }
         return;
       }
 

--- a/pi-sandbox/.pi/extensions/agent-bus.ts
+++ b/pi-sandbox/.pi/extensions/agent-bus.ts
@@ -207,11 +207,13 @@ function handleIncoming(state: BusState, env: Envelope) {
       acceptedFrom = getHabitat().acceptedFrom;
     } catch { /* Habitat not yet available — default to empty (drop) */ }
     if (!acceptedFrom.includes(env.from)) {
-      if (process.env.AGENT_DEBUG === "1") {
-        process.stderr.write(
-          `[agent-bus] dropping ${kind} from '${env.from}': not in acceptedFrom\n`,
-        );
-      }
+      try {
+        if (getHabitat().debug === true) {
+          process.stderr.write(
+            `[agent-bus] dropping ${kind} from '${env.from}': not in acceptedFrom\n`,
+          );
+        }
+      } catch { /* Habitat not yet available */ }
       return;
     }
 
@@ -298,7 +300,7 @@ export default function (pi: ExtensionAPI) {
       busRoot = path.resolve(h.busRoot);
     } catch {
       // Habitat not available (direct pi invocation); fall back to ctx.cwd-derived defaults.
-      name = (process.env.PI_AGENT_NAME || "anonymous").trim() || "anonymous";
+      name = "anonymous";
       const sandboxRoot = path.resolve(ctx.cwd);
       busRoot = path.join(os.homedir(), ".pi-agent-bus", path.basename(sandboxRoot));
     }
@@ -312,10 +314,10 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
-    if (process.env.AGENT_DEBUG === "1") {
+    if (getHabitat().debug === true) {
       const dump = `agent-bus: name=${state.name} sock=${state.sockPath}`;
       ctx.ui.notify(dump, "info");
-      process.stderr.write(`[AGENT_DEBUG] ${dump}\n`);
+      process.stderr.write(`[agent-bus] ${dump}\n`);
     }
 
   });

--- a/pi-sandbox/.pi/extensions/agent-bus.ts
+++ b/pi-sandbox/.pi/extensions/agent-bus.ts
@@ -7,8 +7,8 @@
 //
 // busRoot and agentName are read from getHabitat() (materialised by the
 // habitat baseline extension before this session_start runs). The
-// resolution chain (--agent-bus → $PI_AGENT_BUS_ROOT → default) happens
-// in scripts/run-agent.mjs and lands as Habitat.busRoot. The bus root
+// resolution chain (--agent-bus → default) happens in scripts/run-agent.mjs
+// and lands as Habitat.busRoot. The bus root
 // deliberately lives outside scratchRoot so the sandbox extension's
 // path rejection doesn't trip on socket paths; the bus extension only
 // opens sockets, never invokes path-bearing tools, so the sandbox
@@ -314,11 +314,13 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
-    if (getHabitat().debug === true) {
-      const dump = `agent-bus: name=${state.name} sock=${state.sockPath}`;
-      ctx.ui.notify(dump, "info");
-      process.stderr.write(`[agent-bus] ${dump}\n`);
-    }
+    try {
+      if (getHabitat().debug === true) {
+        const dump = `agent-bus: name=${state.name} sock=${state.sockPath}`;
+        ctx.ui.notify(dump, "info");
+        process.stderr.write(`[agent-bus] ${dump}\n`);
+      }
+    } catch { /* Habitat not available */ }
 
   });
 

--- a/pi-sandbox/.pi/extensions/bus-tail-emitter.ts
+++ b/pi-sandbox/.pi/extensions/bus-tail-emitter.ts
@@ -184,11 +184,14 @@ export default function (pi: ExtensionAPI) {
           }
           syncObserver(state);
 
-          if (process.env.AGENT_DEBUG === "1") {
-            process.stderr.write(
-              `[bus-tail-emitter] tail-toggle: on=${on} filter=${state.filter ?? "none"}\n`,
-            );
-          }
+          try {
+            const { getHabitat: _getHabitat } = _require(path.resolve(__dirname, "_lib/habitat")) as { getHabitat: () => { debug: boolean } };
+            if (_getHabitat().debug === true) {
+              process.stderr.write(
+                `[bus-tail-emitter] tail-toggle: on=${on} filter=${state.filter ?? "none"}\n`,
+              );
+            }
+          } catch { /* Habitat not available */ }
         }
       });
     }

--- a/pi-sandbox/.pi/extensions/habitat.ts
+++ b/pi-sandbox/.pi/extensions/habitat.ts
@@ -5,7 +5,7 @@
 // The runner serialises the fully-resolved Habitat into a single
 // --habitat-spec <json> flag. On fallback (direct `pi` invocations
 // without the runner), a minimal Habitat is assembled from ctx.cwd
-// and PI_AGENT_NAME so the session still boots cleanly.
+// (agentName defaults to "anonymous"; debug is always false in this path).
 //
 // This extension must be first in the peer template's extension list so it
 // runs before any rail that calls getHabitat() in its own session_start.

--- a/pi-sandbox/.pi/extensions/habitat.ts
+++ b/pi-sandbox/.pi/extensions/habitat.ts
@@ -28,14 +28,14 @@ export default function (pi: ExtensionAPI) {
       try {
         const h = materialiseHabitat(raw);
         setHabitat(h);
-        if (process.env.AGENT_DEBUG === "1") {
+        if (h.debug === true) {
           const dump = `habitat: agentName=${h.agentName} scratchRoot=${h.scratchRoot} busRoot=${h.busRoot}` +
             (h.supervisor ? ` supervisor=${h.supervisor}` : "") +
             (h.submitTo ? ` submitTo=${h.submitTo}` : "") +
             (h.acceptedFrom.length ? ` acceptedFrom=[${h.acceptedFrom.join(",")}]` : "") +
             (h.peers.length ? ` peers=[${h.peers.join(",")}]` : "");
           ctx.ui.notify(dump, "info");
-          process.stderr.write(`[AGENT_DEBUG] ${dump}\n`);
+          process.stderr.write(`[habitat] ${dump}\n`);
         }
         return;
       } catch (e) {
@@ -45,11 +45,9 @@ export default function (pi: ExtensionAPI) {
     }
 
     // Fallback for direct `pi` invocations that don't pass --habitat-spec.
-    const agentName = (process.env.PI_AGENT_NAME || "anonymous").trim() || "anonymous";
+    const agentName = "anonymous";
     const scratchRoot = path.resolve(ctx.cwd);
-    const busRoot =
-      process.env.PI_AGENT_BUS_ROOT ||
-      path.join(os.homedir(), ".pi-agent-bus", path.basename(scratchRoot));
+    const busRoot = path.join(os.homedir(), ".pi-agent-bus", path.basename(scratchRoot));
 
     const fallback: Habitat = {
       agentName,
@@ -63,10 +61,10 @@ export default function (pi: ExtensionAPI) {
     };
     setHabitat(fallback);
 
-    if (process.env.AGENT_DEBUG === "1") {
+    if (fallback.debug === true) {
       const dump = `habitat: fallback agentName=${fallback.agentName} scratchRoot=${fallback.scratchRoot}`;
       ctx.ui.notify(dump, "info");
-      process.stderr.write(`[AGENT_DEBUG] ${dump}\n`);
+      process.stderr.write(`[habitat] ${dump}\n`);
     }
   });
 }

--- a/pi-sandbox/.pi/extensions/intercept.ts
+++ b/pi-sandbox/.pi/extensions/intercept.ts
@@ -361,9 +361,11 @@ function buildInterceptDispatch(
     // Fire the dialog flow asynchronously — do not await here so the bus
     // connection handler returns promptly.
     void handleHumanDecision(env).catch((err) => {
-      if (process.env.AGENT_DEBUG === "1") {
-        process.stderr.write(`[intercept] handleHumanDecision error: ${String(err)}\n`);
-      }
+      try {
+        if (getHabitat().debug === true) {
+          process.stderr.write(`[intercept] handleHumanDecision error: ${String(err)}\n`);
+        }
+      } catch { /* Habitat not available */ }
     });
 
     // Returning true tells agent-bus the envelope was consumed.
@@ -415,9 +417,11 @@ export default function (pi: ExtensionAPI) {
     // Only wire if the supervisor inbound rail is active.
     if (!hasSupervisorInboundRail(acceptedFrom)) {
       state.active = false;
-      if (process.env.AGENT_DEBUG === "1") {
-        ctx.ui.notify("intercept: no supervisor inbound rail — no-op", "info");
-      }
+      try {
+        if (getHabitat().debug === true) {
+          ctx.ui.notify("intercept: no supervisor inbound rail — no-op", "info");
+        }
+      } catch { /* Habitat not available */ }
       return;
     }
 
@@ -438,9 +442,11 @@ export default function (pi: ExtensionAPI) {
     state.originalDispatch = originalDispatch;
     g.__pi_supervisor_dispatch__ = buildInterceptDispatch(originalDispatch);
 
-    if (process.env.AGENT_DEBUG === "1") {
-      ctx.ui.notify("intercept: focus-driven intercept rail active", "info");
-    }
+    try {
+      if (getHabitat().debug === true) {
+        ctx.ui.notify("intercept: focus-driven intercept rail active", "info");
+      }
+    } catch { /* Habitat not available */ }
   });
 
   pi.on("session_end", async () => {

--- a/pi-sandbox/.pi/extensions/launcher-bridge.test.ts
+++ b/pi-sandbox/.pi/extensions/launcher-bridge.test.ts
@@ -1,6 +1,7 @@
 /**
  * launcher-bridge.test.ts — source-level assertions for the launcher-bridge
- * extension post Slice 5 (replace PI_MESH_PEER env var with --inherit-pty flag).
+ * extension post Slice 5 (replace PI_MESH_PEER env var with --inherit-pty flag)
+ * and Slice 6 (replace AGENT_DEBUG env var with getHabitat().debug).
  *
  * Contract: pure file-content assertions; no jiti, no pi runtime, no I/O
  * beyond reading the sibling source file.
@@ -31,9 +32,15 @@ describe("launcher-bridge.ts — PI_MESH_PEER removal (Slice 5)", () => {
     // Confirm PI_MESH_PEER is not present in the header (or anywhere).
     expect(SRC).not.toMatch(/PI_MESH_PEER/);
   });
+});
 
-  it("AGENT_DEBUG=1 branch for standalone mode is still present", () => {
-    // The AGENT_DEBUG notify branches (connected / standalone) should survive.
-    expect(SRC).toMatch(/AGENT_DEBUG/);
+describe("launcher-bridge.ts — AGENT_DEBUG env var replaced with getHabitat().debug (Slice 6)", () => {
+  it("does not reference process.env.AGENT_DEBUG anywhere", () => {
+    expect(SRC).not.toMatch(/process\.env\.AGENT_DEBUG/);
+  });
+
+  it("debug branch uses getHabitat().debug === true", () => {
+    // The AGENT_DEBUG notify branches were replaced with getHabitat().debug === true.
+    expect(SRC).toMatch(/getHabitat\(\)\.debug\s*===\s*true/);
   });
 });

--- a/pi-sandbox/.pi/extensions/launcher-bridge.ts
+++ b/pi-sandbox/.pi/extensions/launcher-bridge.ts
@@ -161,15 +161,17 @@ export default function (pi: ExtensionAPI) {
     try {
       await client.connect(busRoot, 1000);
       state.ready = true;
-      if (process.env.AGENT_DEBUG === "1") {
+      if (getHabitat().debug === true) {
         ctx.ui.notify("launcher-bridge: connected to launcher socket", "info");
       }
     } catch {
       // Launcher socket not present — standalone mode. Degrade gracefully.
       state.client = null;
-      if (process.env.AGENT_DEBUG === "1") {
-        ctx.ui.notify("launcher-bridge: launcher socket not found (standalone mode)", "info");
-      }
+      try {
+        if (getHabitat().debug === true) {
+          ctx.ui.notify("launcher-bridge: launcher socket not found (standalone mode)", "info");
+        }
+      } catch { /* Habitat not available */ }
     }
   });
 

--- a/pi-sandbox/.pi/extensions/mesh-authority.ts
+++ b/pi-sandbox/.pi/extensions/mesh-authority.ts
@@ -24,6 +24,7 @@ import { parse as parseYaml } from "yaml";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import { generateInstanceName } from "./_lib/agent-naming.js";
+import { getHabitat } from "./_lib/habitat";
 
 const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../../..");
 const RUNNER_PATH = path.join(REPO_ROOT, "scripts", "run-agent.mjs");
@@ -148,14 +149,15 @@ export default function (pi: ExtensionAPI) {
         : path.join(os.tmpdir(), `pi-mesh-${instanceName}`);
       mkdirSync(sandbox, { recursive: true });
 
-      const busRoot = process.env.PI_AGENT_BUS_ROOT;
+      const busRoot = getHabitat().busRoot;
 
       const args = [
         RUNNER_PATH,
         params.recipe,
         "--sandbox",
         sandbox,
-        ...(busRoot ? ["--agent-bus", busRoot] : []),
+        "--agent-bus",
+        busRoot,
         "--",
         "--agent-name",
         instanceName,
@@ -166,11 +168,7 @@ export default function (pi: ExtensionAPI) {
       const child = spawn(process.execPath, args, {
         cwd: REPO_ROOT,
         stdio: ["pipe", "pipe", "pipe"],
-        env: {
-          ...process.env,
-          PI_AGENT_NAME: instanceName,
-          ...(busRoot ? { PI_AGENT_BUS_ROOT: busRoot } : {}),
-        },
+        env: { ...process.env },
       });
 
       // Send the initial task as the first RPC prompt command.
@@ -189,9 +187,11 @@ export default function (pi: ExtensionAPI) {
 
       child.once("exit", (code, sig) => {
         registry.delete(instanceName);
-        if (process.env.AGENT_DEBUG === "1") {
-          process.stderr.write(`[mesh-authority] node "${instanceName}" exited (code=${code} signal=${sig})\n`);
-        }
+        try {
+          if (getHabitat().debug === true) {
+            process.stderr.write(`[mesh-authority] node "${instanceName}" exited (code=${code} signal=${sig})\n`);
+          }
+        } catch { /* Habitat not available */ }
       });
 
       return {

--- a/pi-sandbox/.pi/extensions/no-edit.ts
+++ b/pi-sandbox/.pi/extensions/no-edit.ts
@@ -49,11 +49,13 @@ export default function (pi: ExtensionAPI) {
       );
     }
 
-    if (process.env.AGENT_DEBUG === "1") {
-      const dump = `no-edit createOnlyTools = [${[...createOnlyTools].sort().join(", ")}]`;
-      ctx.ui.notify(dump, "info");
-      process.stderr.write(`[AGENT_DEBUG] ${dump}\n`);
-    }
+    try {
+      if (getHabitat().debug === true) {
+        const dump = `no-edit createOnlyTools = [${[...createOnlyTools].sort().join(", ")}]`;
+        ctx.ui.notify(dump, "info");
+        process.stderr.write(`[no-edit] ${dump}\n`);
+      }
+    } catch { /* Habitat not available */ }
   });
 
   pi.on("tool_call", async (event) => {

--- a/pi-sandbox/.pi/extensions/sandbox.ts
+++ b/pi-sandbox/.pi/extensions/sandbox.ts
@@ -45,11 +45,13 @@ export default function (pi: ExtensionAPI) {
       );
     }
 
-    if (process.env.AGENT_DEBUG === "1") {
-      const dump = `sandbox pathTools = [${[...pathTools].sort().join(", ")}]`;
-      ctx.ui.notify(dump, "info");
-      process.stderr.write(`[AGENT_DEBUG] ${dump}\n`);
-    }
+    try {
+      if (getHabitat().debug === true) {
+        const dump = `sandbox pathTools = [${[...pathTools].sort().join(", ")}]`;
+        ctx.ui.notify(dump, "info");
+        process.stderr.write(`[sandbox] ${dump}\n`);
+      }
+    } catch { /* Habitat not available */ }
   });
 
   pi.on("tool_call", async (event, ctx) => {

--- a/pi-sandbox/.pi/extensions/supervisor.ts
+++ b/pi-sandbox/.pi/extensions/supervisor.ts
@@ -261,9 +261,11 @@ export default function (pi: ExtensionAPI) {
     // ordering for the message kind; typed envelopes come here.
     state.sendUserMessage = (text, opts) => pi.sendUserMessage(text, opts);
 
-    if (process.env.AGENT_DEBUG === "1") {
-      ctx.ui.notify("supervisor: inbound rail active", "info");
-    }
+    try {
+      if (getHabitat().debug === true) {
+        ctx.ui.notify("supervisor: inbound rail active", "info");
+      }
+    } catch { /* Habitat not available */ }
   });
 
   pi.registerTool({

--- a/scripts/_lib/no-env-fallbacks.test.mjs
+++ b/scripts/_lib/no-env-fallbacks.test.mjs
@@ -1,0 +1,61 @@
+// no-env-fallbacks.test.mjs — repo-wide guard that asserts PI_AGENT_BUS_ROOT,
+// PI_AGENT_NAME, and AGENT_DEBUG do not appear in non-test source files in
+// scripts/ or pi-sandbox/ (Slice 6: --debug flag + drop env-var fallbacks).
+//
+// Uses child_process.execSync to grep the relevant directories. The grep command
+// deliberately excludes test files themselves (*.test.*) to avoid self-referential
+// false positives. The test fails if grep finds any hit or exits with an
+// unexpected error (exit code 1 = hits found, any other code = tool failure).
+//
+// Contract: no model API calls, no network, no env from models.env.
+
+import { describe, it, expect } from "vitest";
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../..");
+
+describe("env-var fallback zero-hit guard (Slice 6)", () => {
+  it("grep finds no PI_AGENT_BUS_ROOT, PI_AGENT_NAME, or AGENT_DEBUG in scripts/ (excluding test files)", () => {
+    let output = "";
+    let exitCode = 0;
+    try {
+      output = execSync(
+        `grep -rn --include="*.mjs" --include="*.ts" --include="*.js" ` +
+          `--exclude="*.test.*" --exclude="*.spec.*" ` +
+          `-E "process\\.env\\.(PI_AGENT_BUS_ROOT|PI_AGENT_NAME|AGENT_DEBUG)" ` +
+          `"${REPO_ROOT}/scripts"`,
+        { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+      );
+    } catch (err) {
+      exitCode = err.status ?? 1;
+      output = err.stdout ?? "";
+    }
+    // grep exit code 1 means "no matches" — that is the expected success case.
+    // exit code 0 means matches were found — the test must fail.
+    // Any other exit code indicates a tool error — let the error propagate.
+    expect(exitCode).toBe(1);
+    expect(output.trim()).toBe("");
+  });
+
+  it("grep finds no PI_AGENT_BUS_ROOT, PI_AGENT_NAME, or AGENT_DEBUG in pi-sandbox/ (excluding test files)", () => {
+    let output = "";
+    let exitCode = 0;
+    try {
+      output = execSync(
+        `grep -rn --include="*.mjs" --include="*.ts" --include="*.js" ` +
+          `--exclude="*.test.*" --exclude="*.spec.*" ` +
+          `-E "process\\.env\\.(PI_AGENT_BUS_ROOT|PI_AGENT_NAME|AGENT_DEBUG)" ` +
+          `"${REPO_ROOT}/pi-sandbox"`,
+        { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+      );
+    } catch (err) {
+      exitCode = err.status ?? 1;
+      output = err.stdout ?? "";
+    }
+    expect(exitCode).toBe(1);
+    expect(output.trim()).toBe("");
+  });
+});

--- a/scripts/launch-mesh.mjs
+++ b/scripts/launch-mesh.mjs
@@ -460,8 +460,6 @@ for (let i = 0; i < topology.nodes.length; i++) {
 
   const peerEnv = {
     ...process.env,
-    PI_AGENT_NAME: name,
-    PI_AGENT_BUS_ROOT: busRoot,
   };
 
   pool.spawn({

--- a/scripts/launch-mesh.test.mjs
+++ b/scripts/launch-mesh.test.mjs
@@ -1,5 +1,6 @@
 // launch-mesh.test.mjs — source-level assertions for the --inherit-pty peerArgs
-// change in launch-mesh.mjs (Slice 5: replace PI_MESH_PEER env var).
+// change in launch-mesh.mjs (Slice 5: replace PI_MESH_PEER env var) and
+// Slice 6 env-var elimination (drop PI_AGENT_NAME, PI_AGENT_BUS_ROOT from peerEnv).
 //
 // Contract: pure file-content assertions; no exec, no model API calls, no network.
 // Hermetic by construction — reads the sibling source file and pattern-matches.
@@ -36,9 +37,13 @@ describe("launch-mesh.mjs — --inherit-pty in peerArgs", () => {
     expect(SRC).not.toMatch(/PI_MESH_PEER/);
   });
 
-  it("peerEnv still includes PI_AGENT_NAME and PI_AGENT_BUS_ROOT", () => {
-    // These env vars carry peer identity information and must remain.
-    expect(SRC).toMatch(/PI_AGENT_NAME/);
-    expect(SRC).toMatch(/PI_AGENT_BUS_ROOT/);
+  it("does not set PI_AGENT_NAME in peerEnv (Slice 6: identity flows via CLI flags)", () => {
+    // After Slice 6, identity is passed via --agent-name in peerArgs, not env vars.
+    expect(SRC).not.toMatch(/PI_AGENT_NAME/);
+  });
+
+  it("does not set PI_AGENT_BUS_ROOT in peerEnv (Slice 6: bus root flows via --agent-bus)", () => {
+    // After Slice 6, bus root is passed via --agent-bus in peerArgs, not env vars.
+    expect(SRC).not.toMatch(/PI_AGENT_BUS_ROOT/);
   });
 });

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -26,7 +26,7 @@ function die(msg) {
 }
 
 function parseArgs(argv) {
-  const out = { name: null, sandbox: null, agentBus: null, inheritPty: false, passthrough: [] };
+  const out = { name: null, sandbox: null, agentBus: null, inheritPty: false, debug: false, passthrough: [] };
   let passthroughOnly = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -42,6 +42,8 @@ function parseArgs(argv) {
       out.agentBus = argv[++i] ?? die("--agent-bus requires a directory");
     } else if (a === "--inherit-pty") {
       out.inheritPty = true;
+    } else if (a === "--debug") {
+      out.debug = true;
     } else if (a === "--help" || a === "-h") {
       printHelp();
       process.exit(0);
@@ -62,7 +64,8 @@ function printHelp() {
       `extension restricts all fs activity to <dir> (default: cwd where you\n` +
       `invoked npm run agent) and disables bash entirely.\n\n` +
       `  --inherit-pty   Pass when the launcher's PTY already wraps this runner's\n` +
-      `                  stdio (skips nested PTY allocation).\n\n` +
+      `                  stdio (skips nested PTY allocation).\n` +
+      `  --debug         Set Habitat.debug = true; rails dump diagnostics on session_start.\n\n` +
       `Run without a name to list available agents.\n`,
   );
 }
@@ -270,7 +273,6 @@ args.passthrough = passthrough;
 
 const busRoot =
   args.agentBus ||
-  process.env.PI_AGENT_BUS_ROOT ||
   path.join(os.homedir(), ".pi-agent-bus", path.basename(sandboxRoot));
 
 // If no manual --agent-name was provided in passthrough, generate one
@@ -302,6 +304,7 @@ const habitatSpec = {
   busRoot,
   skills: recipeSkills,
   agents: wired.allowed,
+  debug: args.debug,
   ...(typeof recipe.description === "string" && recipe.description.trim()
     ? { description: recipe.description.trim() }
     : {}),

--- a/scripts/run-agent.mjs
+++ b/scripts/run-agent.mjs
@@ -31,7 +31,11 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (passthroughOnly) {
-      out.passthrough.push(a);
+      if (a === "--debug") {
+        out.debug = true;
+      } else {
+        out.passthrough.push(a);
+      }
       continue;
     }
     if (a === "--") {
@@ -55,6 +59,8 @@ function parseArgs(argv) {
   }
   return out;
 }
+
+export { parseArgs };
 
 function printHelp() {
   process.stdout.write(
@@ -211,6 +217,8 @@ function loadPromptFragments(extensionNames, hasSupervisoryHabitat = false) {
   return fragments;
 }
 
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isMain) {
 const args = parseArgs(process.argv.slice(2));
 if (!args.name) {
   listAgents();
@@ -473,3 +481,4 @@ if (isTTY && !isPrintMode && !isInsideManagedPty) {
     else process.exit(code ?? 0);
   });
 }
+} // end isMain

--- a/scripts/run-agent.test.mjs
+++ b/scripts/run-agent.test.mjs
@@ -1,9 +1,11 @@
 // run-agent.test.mjs — source-level assertions for the --inherit-pty flag in
 // run-agent.mjs (Slice 5: replace PI_MESH_PEER env var) and
 // Slice 6: --debug flag + drop env-var fallbacks.
+// Issue #137 regression: --debug after the -- separator must be consumed by
+// the runner (not forwarded to pi).
 //
-// Contract: pure file-content assertions; no exec, no model API calls, no network.
-// Hermetic by construction — reads the sibling source file and pattern-matches.
+// Contract: no exec, no model API calls, no network.
+// Hermetic by construction — reads/imports the sibling source file.
 
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
@@ -12,6 +14,8 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SRC = readFileSync(path.join(__dirname, "run-agent.mjs"), "utf8");
+
+import { parseArgs } from "./run-agent.mjs";
 
 describe("run-agent.mjs — --inherit-pty flag parsing", () => {
   it("initialises inheritPty: false in the parseArgs output object", () => {
@@ -79,5 +83,24 @@ describe("run-agent.mjs — --debug flag parsing (Slice 6)", () => {
 
   it("does not reference PI_AGENT_BUS_ROOT (Slice 6: env-var fallback dropped)", () => {
     expect(SRC).not.toMatch(/PI_AGENT_BUS_ROOT/);
+  });
+});
+
+describe("run-agent.mjs — --debug after the -- separator (Issue #137 regression)", () => {
+  it("--debug after -- sets debug: true and is NOT forwarded to pi", () => {
+    const result = parseArgs(["deferred-writer", "--", "--debug"]);
+    expect(result.debug).toBe(true);
+    expect(result.passthrough).not.toContain("--debug");
+  });
+
+  it("--debug after -- with other passthrough args preserves the rest", () => {
+    const result = parseArgs(["deferred-writer", "--", "--debug", "-p", "hello"]);
+    expect(result.debug).toBe(true);
+    expect(result.passthrough).toEqual(["-p", "hello"]);
+  });
+
+  it("--debug before -- still works (pre-separator position unchanged)", () => {
+    const result = parseArgs(["deferred-writer", "--debug"]);
+    expect(result.debug).toBe(true);
   });
 });

--- a/scripts/run-agent.test.mjs
+++ b/scripts/run-agent.test.mjs
@@ -1,5 +1,6 @@
 // run-agent.test.mjs — source-level assertions for the --inherit-pty flag in
-// run-agent.mjs (Slice 5: replace PI_MESH_PEER env var).
+// run-agent.mjs (Slice 5: replace PI_MESH_PEER env var) and
+// Slice 6: --debug flag + drop env-var fallbacks.
 //
 // Contract: pure file-content assertions; no exec, no model API calls, no network.
 // Hermetic by construction — reads the sibling source file and pattern-matches.
@@ -46,5 +47,37 @@ describe("run-agent.mjs — --inherit-pty flag parsing", () => {
 
   it("printHelp documents the --inherit-pty flag", () => {
     expect(SRC).toMatch(/--inherit-pty/);
+  });
+});
+
+describe("run-agent.mjs — --debug flag parsing (Slice 6)", () => {
+  it("initialises debug: false in the parseArgs output object", () => {
+    expect(SRC).toMatch(/debug\s*:\s*false/);
+  });
+
+  it("parses --debug and sets out.debug = true", () => {
+    expect(SRC).toMatch(/--debug/);
+    expect(SRC).toMatch(/debug\s*=\s*true/);
+  });
+
+  it("consumes --debug as a boolean flag (no value arg consumed)", () => {
+    const lines = SRC.split("\n");
+    const flagLine = lines.findIndex((l) => l.includes('"--debug"'));
+    expect(flagLine).toBeGreaterThanOrEqual(0);
+    const context = lines.slice(flagLine, flagLine + 3).join("\n");
+    expect(context).not.toMatch(/argv\[.*\+\+i.*\]/);
+  });
+
+  it("printHelp documents the --debug flag", () => {
+    expect(SRC).toMatch(/--debug/);
+    expect(SRC).toMatch(/Habitat\.debug/);
+  });
+
+  it("habitatSpec carries the debug field from args.debug", () => {
+    expect(SRC).toMatch(/debug\s*:\s*args\.debug/);
+  });
+
+  it("does not reference PI_AGENT_BUS_ROOT (Slice 6: env-var fallback dropped)", () => {
+    expect(SRC).not.toMatch(/PI_AGENT_BUS_ROOT/);
   });
 });


### PR DESCRIPTION
## What this fixes

Final env-var elimination slice for PRD #115. Before this change, debug diagnostics were toggled by `AGENT_DEBUG=1` in the environment and identity (`PI_AGENT_NAME`, `PI_AGENT_BUS_ROOT`) had env-var fallbacks scattered across `habitat.ts`, `agent-bus.ts`, `mesh-authority.ts`, `run-agent.mjs`, and `launch-mesh.mjs`. Those fallbacks let identity and debug state leak through the process tree (children silently inherited `AGENT_DEBUG=1` from a parent shell), and they made it impossible to flip debug on for one peer without flipping it for every child it spawned.

This slice routes everything through the existing `--habitat-spec` plumbing:

- `scripts/run-agent.mjs` parses a new `--debug` boolean flag and threads it into `habitatSpec.debug` (the schema field added in #135).
- All 12 `process.env.AGENT_DEBUG === "1"` sites across `bus-tail-emitter.ts`, `launcher-bridge.ts`, `agent-bus.ts`, `sandbox.ts`, `intercept.ts`, `no-edit.ts`, `habitat.ts`, `supervisor.ts`, `mesh-authority.ts`, and `_lib/supervisor-inbox.ts` now read `getHabitat().debug === true`. Async / late-running call sites are wrapped in try/catch so a not-yet-materialised Habitat doesn't throw. The two sites inside `habitat.ts` itself read the local `h` / `fallback` object since they execute mid-materialisation.
- `habitat.ts` (extension), `agent-bus.ts`, `mesh-authority.ts`, and `run-agent.mjs` drop their `process.env.PI_AGENT_NAME` / `process.env.PI_AGENT_BUS_ROOT` fallbacks. Identity flows exclusively through `--agent-bus` / `--agent-name` CLI flags + `--habitat-spec`. `mesh-authority.ts`'s child spawn now sources `busRoot` from `getHabitat().busRoot` and passes `--agent-bus` unconditionally; the env-var entries it used to set on the child process are gone.
- `scripts/launch-mesh.mjs` per-node `peerEnv` no longer sets `PI_AGENT_NAME`, `PI_AGENT_BUS_ROOT`, or `AGENT_DEBUG`.
- A new repo-wide grep guard (`scripts/_lib/no-env-fallbacks.test.mjs`) asserts zero hits for `process.env.(PI_AGENT_BUS_ROOT|PI_AGENT_NAME|AGENT_DEBUG)` across `scripts/` and `pi-sandbox/.pi/extensions/` (test files excluded). This locks the invariant so future work can't silently re-introduce a fallback.
- `docs/agents.md` examples updated from `AGENT_DEBUG=1 npm run agent -- ...` to `npm run agent -- ... -- --debug`; the `--agent-bus-root` resolution doc no longer references `$PI_AGENT_BUS_ROOT`.

After this slice, the only env vars the system reads are the three tier vars (`RABBIT_SAGE_MODEL`, `LEAD_HARE_MODEL`, `TASK_RABBIT_MODEL`) and `INIT_CWD` (npm convention).

## QA steps for the human

The full-rail tmux smokes (`deferred-writer`, `writer-foreman`, `mesh-authority`) are conventionally manual in this repo (cost real model tokens, only render under PTY). Worth running once each before merge:

1. `npm run agent -- deferred-writer -- --debug` — confirm rails emit `[AGENT_DEBUG]` stderr lines on session_start.
2. `npm run agent -- deferred-writer` (no flag) — confirm rails are silent.
3. `AGENT_DEBUG=1 npm run agent -- deferred-writer` — confirm the env-var form is **no longer** recognised (rails stay silent).
4. `npm run agent -- writer-foreman --sandbox /tmp/foreman-test -- --debug` and prompt a delegation — confirm the parent has debug output but the spawned worker does NOT (debug should not auto-propagate through `delegate`).
5. `npm run mesh -- pi-sandbox/meshes/authority-mesh.yaml` — confirm peers spawn cleanly without the three env vars in their environment, and `mesh_spawn` still works (it now reads `busRoot` from Habitat).

## Automated coverage

`npm test` (vitest run) — 727/727 pass on `claude/ralph-one-137-1kRk2`. Includes the new `scripts/_lib/no-env-fallbacks.test.mjs` grep guard (2/2), inverted assertions in `launch-mesh.test.mjs`, new `--debug` parsing coverage in `run-agent.test.mjs`, and `_lib/supervisor-inbox.test.ts` rewritten to drive `setHabitat({...debug:true})` instead of mutating `process.env.AGENT_DEBUG`.

Closes #137

---
_Generated by [Claude Code](https://claude.ai/code/session_019w81Yh8e2rh1cdY9Xvu2nZ)_