### PR TITLE
Add continuous handoff and HTML preview skills

### DIFF
--- a/.claude/hooks/continuous-reminder.sh
+++ b/.claude/hooks/continuous-reminder.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+# UserPromptSubmit hook for the /continuous skill.
+# No-op unless a continuity session is active (marker file present).
+git_dir="$(git rev-parse --git-dir 2>/dev/null)" || exit 0
+marker="$git_dir/continuous-active"
+[ -f "$marker" ] || exit 0
+token="$(cat "$marker")"
+doc="../html-previews-wt/continuous/$token.html"
+echo "[continuous] Continuity session $token is active. As you work this turn, capture any new task progress, decisions, discovered information, plan changes/dead ends, or user-provided nuance into $doc: rewrite the snapshot section, append to the Decisions & nuance log. Then commit and push the html-previews branch. Read that file first if unsure of its current content."
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"$CLAUDE_PROJECT_DIR/.claude/hooks/continuous-reminder.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/continuous/SKILL.md
+++ b/.claude/skills/continuous/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: continuous
+description: Maintain a live HTML handoff doc on the html-previews branch, updated every turn as work progresses, so a fresh session can resume the work. Use when the user runs /continuous to start tracking a task, or /continuous <token> to resume one.
+argument-hint: "[token to resume, or blank to start]"
+---
+
+# Continuous handoff
+
+A living handoff doc, published as one HTML file and kept fresh every turn, so a
+fresh session can pick up exactly where this one left off.
+
+Terms: a **continuity token** (e.g. `0x4F9A`) identifies a **continuity doc**;
+`/continuous <token>` resumes it.
+
+## Two modes
+
+- `/continuous` (no token) — **start**. Mint a token, create the doc from the
+  current conversation, arm the per-turn hook, give the user the token + URL.
+- `/continuous <token>` — **resume**. Fetch the doc, rehydrate context, re-arm
+  the hook, continue working. If the token's file does not exist, list what is
+  in `continuous/` and ask the user which token they meant.
+
+## Starting (`/continuous`)
+
+1. Mint a token: `0x` + 4 random uppercase hex chars (e.g. `0x4F9A`). If that
+   file already exists in step 2's worktree, mint another.
+
+2. Set up the publish worktree on the `html-previews` branch (a dedicated branch
+   for browser-viewable artifacts — never merge it in or out of your working
+   branch):
+
+   ```sh
+   git fetch origin html-previews 2>/dev/null
+   if [ ! -d ../html-previews-wt ]; then
+     if git ls-remote --exit-code --heads origin html-previews >/dev/null 2>&1; then
+       git worktree add ../html-previews-wt html-previews
+     else
+       git worktree add --detach ../html-previews-wt
+       git -C ../html-previews-wt checkout --orphan html-previews
+       git -C ../html-previews-wt rm -rf . >/dev/null 2>&1 || true
+     fi
+   fi
+   mkdir -p ../html-previews-wt/continuous
+   ```
+
+3. Write the doc to `../html-previews-wt/continuous/<token>.html` (structure
+   below), seeded from the current conversation.
+
+4. Arm the marker so the per-turn hook activates:
+
+   ```sh
+   echo "<token>" > "$(git rev-parse --git-dir)/continuous-active"
+   ```
+
+5. Commit and push:
+
+   ```sh
+   git -C ../html-previews-wt add continuous/<token>.html
+   git -C ../html-previews-wt commit -m "continuous(<token>): start"
+   git -C ../html-previews-wt push -u origin html-previews
+   ```
+
+6. Give the user the token and the htmlpreview URL. Derive `<owner>/<repo>` from
+   `git remote get-url origin`:
+
+   `http://htmlpreview.github.io/?http://raw.githubusercontent.com/<owner>/<repo>/html-previews/continuous/<token>.html`
+
+   Tell them they can resume in any new session with `/continuous <token>`.
+
+## The doc
+
+One self-contained HTML file, inline CSS, no build step. Semantic HTML —
+headings, lists, a simple timeline — so a resuming agent reads the raw file
+directly. Three parts:
+
+- **Snapshot** — rewritten on every update, kept tight: the task title, Goal,
+  Status, Open questions, Next steps.
+- **Decisions & nuance** — append-only; never rewrite or delete entries. A
+  timeline of decisions made, information discovered, plan changes/dead ends,
+  and nuance the user gave. One terse entry per item, each tagged with a turn
+  number or short timestamp.
+- **How to resume** — static footer: "Run `/continuous <token>` in a new
+  session."
+
+## Staying current (every turn)
+
+A `UserPromptSubmit` hook re-injects a reminder each turn while the marker
+exists — you do not have to remember on your own, but you MUST act on it.
+
+Whenever a turn produces new task progress, a decision, discovered information,
+a plan change/dead end, or user-provided nuance: update the local doc (rewrite
+the snapshot, append to the log), then commit and push:
+
+```sh
+git -C ../html-previews-wt add continuous/<token>.html
+git -C ../html-previews-wt commit -m "continuous(<token>): update"
+git -C ../html-previews-wt push origin html-previews
+```
+
+Pushing every turn is expected. If a push is rejected, run
+`git -C ../html-previews-wt pull --rebase origin html-previews` and retry. If
+unsure of the doc's current content, read the file first.
+
+## Resuming (`/continuous <token>`)
+
+1. Set up the worktree (step 2 above), then read
+   `../html-previews-wt/continuous/<token>.html`. Missing → list `continuous/`
+   and ask which token.
+2. Append a log entry: `— resumed in a new session —`.
+3. Re-arm the marker (step 4 above).
+4. Continue the conversation naturally — no state-dump summary. A one-line
+   "resumed, caught up" acknowledgement is fine if the user gave no instruction.
+
+## Notes
+
+- Redaction is minimal: scrub only live credentials / API keys. Everything else
+  — decisions, file paths, specifics — is captured. The doc lives in committed
+  git history, so if the user pastes something obviously secret, flag it.
+- Continuity lapses on its own when the session ends; the marker is per-checkout
+  and there is no stop command.
+- Private repo: the user must be signed into GitHub in the same browser for
+  htmlpreview to render the doc.

--- a/.claude/skills/html/SKILL.md
+++ b/.claude/skills/html/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: html
+description: Build a single static HTML page and give the user a temporary URL to view it in their browser. Use whenever the user asks to "show", "preview", "mock up", "demo", or "build" a webpage, landing page, or one-file HTML design.
+---
+
+# HTML Preview (single, temporary)
+
+Previews live on a dedicated `html-previews` branch that holds preview `.html`
+files (and the `continuous/` folder used by the `/continuous` skill) — never
+other repo content. Each preview is its own uniquely-named file. Never merge
+this branch into or out of your working branch.
+
+When invoked:
+
+1. Pick a unique filename: `preview-<random>.html`, where `<random>` is a short
+   random string (e.g. `preview-7f3a9c2e.html`). Build the page as that single
+   file — inline all CSS and JS, no build step.
+
+2. Publish it to `html-previews` without disturbing your current branch or
+   working tree, using a separate worktree:
+
+   ```sh
+   git fetch origin html-previews 2>/dev/null
+   if [ ! -d ../html-previews-wt ]; then
+     if git ls-remote --exit-code --heads origin html-previews >/dev/null 2>&1; then
+       git worktree add ../html-previews-wt html-previews
+     else
+       # First time: orphan branch with no history and no other repo files
+       git worktree add --detach ../html-previews-wt
+       git -C ../html-previews-wt checkout --orphan html-previews
+       git -C ../html-previews-wt rm -rf . >/dev/null 2>&1 || true
+     fi
+   fi
+   ```
+
+3. Write the HTML into `../html-previews-wt/preview-<random>.html`, then commit
+   and push:
+
+   ```sh
+   git -C ../html-previews-wt add preview-<random>.html
+   git -C ../html-previews-wt commit -m "Add preview-<random>.html"
+   git -C ../html-previews-wt push -u origin html-previews
+   ```
+
+4. Give the user this URL (substitute owner, repo, filename):
+
+   `http://htmlpreview.github.io/?http://raw.githubusercontent.com/<owner>/<repo>/html-previews/preview-<random>.html`
+
+5. For revisions: edit that same file in `../html-previews-wt/`, commit, and push
+   again. The URL stays the same; they just refresh. For a brand-new preview,
+   generate a fresh filename and repeat steps 1–4.
+
+Notes:
+- For private repos, the user needs to be signed into GitHub in the same browser
+  for htmlpreview to fetch it.
+- Don't try to spin up a local server — the cloud sandbox isn't reachable from
+  the user's browser.
+- The `html-previews` branch is shared with the `/continuous` skill. Don't delete
+  files from it or delete the branch — other skills and sessions rely on it.


### PR DESCRIPTION
## Summary

Introduces two new Claude skills for enhanced workflow continuity and HTML previewing:

1. **Continuous handoff** (`/continuous`) — maintains a live HTML document on a dedicated `html-previews` branch that persists across sessions, allowing a fresh Claude instance to resume work with full context.
2. **HTML preview** (`/html`) — builds single static HTML pages and publishes them to the same branch for temporary browser viewing.

Both skills use a shared `html-previews` worktree to avoid disrupting the main working branch.

## Key Changes

- **`.claude/skills/continuous/SKILL.md`** — Defines the continuous handoff skill with two modes:
  - Start mode (`/continuous`): mints a token, creates a self-contained HTML doc seeded from conversation, arms a per-turn hook, and publishes to `html-previews` branch
  - Resume mode (`/continuous <token>`): fetches the doc, rehydrates context, and re-arms the hook
  - Specifies doc structure (snapshot, decisions log, resume instructions) and per-turn update workflow

- **`.claude/skills/html/SKILL.md`** — Defines the HTML preview skill:
  - Generates unique preview files on the `html-previews` branch
  - Provides temporary htmlpreview.github.io URLs for browser viewing
  - Supports revisions by editing the same file

- **`.claude/settings.json`** — Registers a `UserPromptSubmit` hook to activate the continuous reminder

- **`.claude/hooks/continuous-reminder.sh`** — Shell script that runs each turn when a continuity session is active, reminding the agent to update the handoff doc and push changes

## Notable Details

- Both skills share the `html-previews` branch as a dedicated artifact store, isolated from the main working branch via git worktree
- The continuous skill uses a marker file (`git_dir/continuous-active`) to track active sessions and trigger per-turn reminders
- Docs are self-contained HTML with inline CSS for portability and easy resumption by a fresh session
- Minimal redaction policy: only live credentials/API keys are scrubbed; all decisions and specifics are captured for continuity

https://claude.ai/code/session_01VZMpAQ6ZjPXzZdzKEnHwps