### PR TITLE
fix(engine): mesh-mux pre-spawn workers no longer crash on initial_mesh (#172)

### DIFF
--- a/packages/engine/agent/extensions/mesh-mux.test.ts
+++ b/packages/engine/agent/extensions/mesh-mux.test.ts
@@ -47,3 +47,18 @@ describe("mesh-mux.ts — cwd inheritance (issue #172)", () => {
     expect(SRC).toMatch(/PI_BIN/);
   });
 });
+
+// ── Source-level assertions — spawn cmd (issue #172 follow-up) ──────────────
+
+describe("mesh-mux.ts — pool.spawn cmd (issue #172 follow-up)", () => {
+  it("does NOT pass cmd: process.execPath to pool.spawn", () => {
+    // process.execPath is the node binary. Spawning `node --recipe ...` would
+    // make node reject --recipe with `bad option` and exit 9 — every worker
+    // crashing immediately. cmd must be the pi bin itself (argv[0]).
+    expect(SRC).not.toMatch(/cmd:\s*process\.execPath/);
+  });
+
+  it("passes the pi bin (argv[0]) as cmd to pool.spawn", () => {
+    expect(SRC).toMatch(/cmd:\s*argv\[0\]/);
+  });
+});

--- a/packages/engine/agent/extensions/mesh-mux.test.ts
+++ b/packages/engine/agent/extensions/mesh-mux.test.ts
@@ -1,0 +1,49 @@
+/**
+ * mesh-mux.test.ts — source-level assertions for the mesh-mux extension.
+ *
+ * Tests verify that the host cwd is captured at session_start and threaded
+ * through MeshMuxState so spawned workers inherit the caller's working
+ * directory instead of the hard-coded REPO_ROOT (issue #172).
+ *
+ * Contract: pure file-content assertions; no jiti, no pi runtime, no live
+ * child processes. Hermetic by construction.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(path.join(__dirname, "mesh-mux.ts"), "utf8");
+
+// ── Source-level assertions — cwd inheritance (issue #172) ──────────────────
+
+describe("mesh-mux.ts — cwd inheritance (issue #172)", () => {
+  it("does NOT pass cwd: REPO_ROOT to pool.spawn", () => {
+    expect(SRC).not.toMatch(/cwd:\s*REPO_ROOT/);
+  });
+
+  it("passes the captured host cwd to pool.spawn", () => {
+    expect(SRC).toMatch(/cwd:\s*state\.hostCwd/);
+  });
+
+  it("captures ctx.cwd at session_start and stores it on state", () => {
+    // ctx.cwd must appear in the source (it's captured in the session_start handler)
+    expect(SRC).toMatch(/ctx\.cwd/);
+    // and must be assigned to hostCwd on the state object
+    expect(SRC).toMatch(/hostCwd:\s*ctx\.cwd/);
+  });
+
+  it("threads hostCwd through MeshMuxState interface", () => {
+    // The MeshMuxState interface must declare hostCwd: string
+    expect(SRC).toMatch(/hostCwd:\s*string/);
+  });
+
+  it("REPO_ROOT is still present (used by AGENTS_DIR and PI_BIN)", () => {
+    // REPO_ROOT must still exist — used for AGENTS_DIR path
+    expect(SRC).toMatch(/REPO_ROOT/);
+    expect(SRC).toMatch(/AGENTS_DIR/);
+    expect(SRC).toMatch(/PI_BIN/);
+  });
+});

--- a/packages/engine/agent/extensions/mesh-mux.ts
+++ b/packages/engine/agent/extensions/mesh-mux.ts
@@ -210,8 +210,8 @@ function spawnPeerViaPtyPool(
   // Spawn via PtyPool
   state.pool.spawn({
     name: workerName,
-    cmd: process.execPath,
-    args: argv.slice(1), // first element is the pi bin (the "cmd")
+    cmd: argv[0], // pi bin — invoked directly via its shebang
+    args: argv.slice(1),
     cols,
     rows,
     cwd: state.hostCwd,

--- a/packages/engine/agent/extensions/mesh-mux.ts
+++ b/packages/engine/agent/extensions/mesh-mux.ts
@@ -84,6 +84,8 @@ interface MeshMuxState {
   peers: Map<string, SpawnedPeer>;
   /** Pending spawn-result resolvers keyed by spawner-clientId:msg_id. */
   pendingSpawns: Map<string, (result: { ok: boolean; name?: string; error?: string }) => void>;
+  /** The cwd of the host session — inherited by all spawned workers. */
+  hostCwd: string;
 }
 
 function getMuxState(): MeshMuxState | undefined {
@@ -212,7 +214,7 @@ function spawnPeerViaPtyPool(
     args: argv.slice(1), // first element is the pi bin (the "cmd")
     cols,
     rows,
-    cwd: REPO_ROOT,
+    cwd: state.hostCwd,
     env: process.env as Record<string, string>,
   });
 
@@ -579,6 +581,7 @@ export default function (pi: ExtensionAPI) {
       cohortRegistry,
       peers: new Map(),
       pendingSpawns: new Map(),
+      hostCwd: ctx.cwd,
     };
 
     setMuxState(state);

--- a/packages/engine/agent/extensions/mesh-spawn.test.ts
+++ b/packages/engine/agent/extensions/mesh-spawn.test.ts
@@ -124,6 +124,31 @@ describe("mesh-spawn.ts — source-level", () => {
   });
 });
 
+// ── cwd inheritance (issue #172) ────────────────────────────────────────────
+
+describe("mesh-spawn.ts — cwd inheritance (issue #172)", () => {
+  it("does NOT pass cwd: REPO_ROOT to child_process.spawn", () => {
+    expect(SRC).not.toMatch(/cwd:\s*REPO_ROOT/);
+  });
+
+  it("threads caller cwd through productionSpawnWorker", () => {
+    expect(SRC).toMatch(/cwd:\s*args\.callerCwd/);
+  });
+
+  it("captures ctx in mesh_spawn.execute signature", () => {
+    // The execute signature must accept ctx as a parameter
+    expect(SRC).toMatch(/execute\([^)]*ctx[^)]*\)/);
+  });
+
+  it("passes callerCwd to runMeshSpawn at the call site", () => {
+    // The runMeshSpawn call must include a callerCwd: field
+    const runMeshIdx = SRC.indexOf("runMeshSpawn({");
+    expect(runMeshIdx).toBeGreaterThan(-1);
+    const afterRunMesh = SRC.slice(runMeshIdx, runMeshIdx + 500);
+    expect(afterRunMesh).toMatch(/callerCwd:/);
+  });
+});
+
 // ── Dynamic-worker admission predicate — registry-membership logic ──────────
 
 describe("__pi_mesh_spawn_is_my_worker__ predicate — registry membership", () => {

--- a/packages/engine/agent/extensions/mesh-spawn.ts
+++ b/packages/engine/agent/extensions/mesh-spawn.ts
@@ -146,7 +146,7 @@ function productionSpawnWorker(args: SpawnArgs): WorkerHandle {
     task: args.task && args.task.length > 0 ? args.task : undefined,
   });
   const child = spawn(process.execPath, childArgs, {
-    cwd: REPO_ROOT,
+    cwd: args.callerCwd,
     stdio: ["pipe", "pipe", "pipe"],
     env: { ...process.env },
   });
@@ -239,7 +239,7 @@ export default function (pi: ExtensionAPI) {
         Type.Array(Type.String(), { description: "Override inbound peers (Slice 3+, accepted but not yet plumbed to wiring resolver)." }),
       ),
     }),
-    async execute(_id, params): Promise<{ content: Array<{ type: string; text: string }>; details: Record<string, unknown> }> {
+    async execute(_id, params, _signal, _onUpdate, ctx): Promise<{ content: Array<{ type: string; text: string }>; details: Record<string, unknown> }> {
       // ── 1. Read habitat ──────────────────────────────────────────────────
       let spawns: string[] = [];
       let callerName = "anonymous";
@@ -425,6 +425,7 @@ export default function (pi: ExtensionAPI) {
         groups: params.groups,
         callerSandbox,
         callerName,
+        callerCwd: ctx.cwd,
         spawnWorker: productionSpawnWorker,
       });
 

--- a/packages/engine/agent/lib/peer-spawn.test.ts
+++ b/packages/engine/agent/lib/peer-spawn.test.ts
@@ -143,6 +143,7 @@ describe("runMeshSpawn", () => {
       task: "monitor logs",
       callerSandbox,
       callerName: "authority",
+      callerCwd: "/tmp/caller-cwd",
       spawnWorker,
     };
 
@@ -168,6 +169,7 @@ describe("runMeshSpawn", () => {
       busRoot: "/tmp/bus",
       callerSandbox,
       callerName: "authority",
+      callerCwd: "/tmp/caller-cwd",
       spawnWorker,
     };
 
@@ -193,6 +195,7 @@ describe("runMeshSpawn", () => {
       busRoot: "/tmp/mybus",
       callerSandbox,
       callerName: "orchestrator",
+      callerCwd: "/tmp/caller-cwd",
       spawnWorker,
     };
 
@@ -506,6 +509,61 @@ describe("resolveInitialMeshScalarRef", () => {
   it("returns raw ref when @group matches nothing", () => {
     const index = makeIndex([]);
     expect(resolveInitialMeshScalarRef("@nobody", index)).toBe("@nobody");
+  });
+});
+
+// ── runMeshSpawn — callerCwd forwarding (issue #172) ─────────────────────────
+
+describe("runMeshSpawn — callerCwd forwarding (issue #172)", () => {
+  it("forwards callerCwd to spawnWorker", async () => {
+    const callerSandbox = makeTmpDir();
+    let capturedArgs: SpawnArgs | null = null;
+    const handle = makePendingHandle();
+    const spawnWorker = vi.fn((args: SpawnArgs) => {
+      capturedArgs = args;
+      return handle as WorkerHandle;
+    });
+
+    const ctx: MeshSpawnContext = {
+      recipe: "mesh-node",
+      workerName: "cwd-test-node",
+      busRoot: "/tmp/bus",
+      callerSandbox,
+      callerName: "orchestrator",
+      callerCwd: "/tmp/test-cwd",
+      spawnWorker,
+    };
+
+    const result = await runMeshSpawn(ctx);
+    expect(result.ok).toBe(true);
+    expect(capturedArgs).not.toBeNull();
+    expect(capturedArgs!.callerCwd).toBe("/tmp/test-cwd");
+    fs.rmSync(result.scratchRoot, { recursive: true, force: true });
+  });
+
+  it("passes distinct callerCwd values through unchanged", async () => {
+    const callerSandbox = makeTmpDir();
+    const cwds: string[] = [];
+    const handle = makePendingHandle();
+    const spawnWorker = vi.fn((args: SpawnArgs) => {
+      cwds.push(args.callerCwd);
+      return handle as WorkerHandle;
+    });
+
+    const ctx: MeshSpawnContext = {
+      recipe: "mesh-node",
+      workerName: "cwd-test-node-2",
+      busRoot: "/tmp/bus",
+      callerSandbox,
+      callerName: "orchestrator",
+      callerCwd: "/home/user/pi-sandbox",
+      spawnWorker,
+    };
+
+    const result = await runMeshSpawn(ctx);
+    expect(result.ok).toBe(true);
+    expect(cwds).toEqual(["/home/user/pi-sandbox"]);
+    fs.rmSync(result.scratchRoot, { recursive: true, force: true });
   });
 });
 

--- a/packages/engine/agent/lib/peer-spawn.ts
+++ b/packages/engine/agent/lib/peer-spawn.ts
@@ -189,6 +189,8 @@ export interface SpawnArgs {
   scratchRoot: string;
   busRoot: string;
   task: string;
+  /** The cwd of the caller — workers are spawned with this as their working directory. */
+  callerCwd: string;
   /** Group memberships for the spawned worker (seeded into its Habitat). */
   groups?: string[];
   habitatOverlay: {
@@ -224,6 +226,8 @@ export interface MeshSpawnContext {
   groups?: string[];
   callerSandbox: string;
   callerName: string;
+  /** The cwd of the calling session — workers inherit this as their working directory. */
+  callerCwd: string;
   spawnWorker: (args: SpawnArgs) => WorkerHandle;
 }
 
@@ -425,6 +429,7 @@ export async function runMeshSpawn(ctx: MeshSpawnContext): Promise<MeshSpawnResu
     scratchRoot,
     busRoot: ctx.busRoot,
     task: ctx.task ?? "",
+    callerCwd: ctx.callerCwd,
     groups: ctx.groups,
     habitatOverlay,
   };


### PR DESCRIPTION
## What this fixes

`pi --recipe mesh-host-example --is-host` (and any host recipe with `initial_mesh:`) silently killed every pre-spawned worker within ~16ms with `code=9 signal=0`. Two compounding bugs in `mesh-mux.spawnPeerViaPtyPool`:

**Bug A — wrong cwd.** Workers were spawned with `cwd: REPO_ROOT`. The worker's `recipe-loader.getRecipeDirs(ctx.cwd)` searched `<REPO_ROOT>/.pi/recipes/` — doesn't exist → recipe-loader threw → no `setHabitat` → next extension calling `getHabitat()` (`launcher-bridge.ts:150`) crashed with "Habitat has not been materialised yet."

**Bug B — wrong spawn cmd.** Workers were spawned as `cmd: process.execPath` (node) with `args: argv.slice(1)` (the pi argv with the pi-bin path stripped). The actual invocation was `node --recipe mesh-node ...` — node rejects `--recipe` as `bad option` and exits 9 *before* any extension binds, masking Bug A.

Bug B kills the worker before Bug A's failure path is even reachable. Once both are fixed, peers boot and survive: in a 12-second live smoke they exit `code=0 signal=15` (clean SIGTERM cascade when the host shuts down) instead of `code=9 signal=0` (extension crash).

The fix:

- **`mesh-mux.ts`**
  - Add `hostCwd: string` to `MeshMuxState`; capture `ctx.cwd` at host `session_start`; spawn workers with `cwd: state.hostCwd`.
  - Change `cmd: process.execPath` → `cmd: argv[0]` (the pi bin). `mesh-spawn.ts` already had the correct shape and is unchanged.
- **`peer-spawn.ts`** — thread `callerCwd: string` through `MeshSpawnContext` → `SpawnArgs`.
- **`mesh-spawn.ts`** — widen the `mesh_spawn` tool's `execute` signature to accept `ctx`; pass `ctx.cwd` as `callerCwd` into `runMeshSpawn`; the no-host-fallback `productionSpawnWorker` now uses `args.callerCwd` instead of `REPO_ROOT`.

Tests added:
- `mesh-mux.test.ts` (new) — 7 source-level assertions: cwd is `state.hostCwd` (not `REPO_ROOT`); `MeshMuxState` declares `hostCwd: string`; `ctx.cwd` captured at session_start; `cmd: argv[0]` (not `process.execPath`); `REPO_ROOT` still present for `AGENTS_DIR`/`PI_BIN`.
- `mesh-spawn.test.ts` — 4 new source-level assertions in a `cwd inheritance (issue #172)` block: no `cwd: REPO_ROOT`; `cwd: args.callerCwd`; `execute` accepts `ctx`; `callerCwd:` is in the `runMeshSpawn` call site.
- `peer-spawn.test.ts` — load-bearing behavioural test: `runMeshSpawn` forwards `callerCwd` to `spawnWorker`.

## QA steps for the human

End-to-end live verification (requires the `pi-sandbox/.pi/recipes` symlink workaround per #170):

```sh
mkdir -p pi-sandbox/.pi
ln -sfn ../agents pi-sandbox/.pi/recipes
ln -sfn ../templates pi-sandbox/.pi/templates
set -a; source models.env; set +a
cd pi-sandbox
timeout 12 ../node_modules/.bin/pi --recipe mesh-host-example --is-host --debug 2>/tmp/dia.log
grep -E 'spawned|crashed|Habitat has not been materialised' /tmp/dia.log
# Expect: 2× "spawned initial_mesh peer ..." lines, then 2× "crashed (code=0 signal=15)"
# (timeout SIGTERMing the host, cascading to children). NO "Habitat has not been
# materialised" lines, NO code=9.
rm pi-sandbox/.pi/recipes pi-sandbox/.pi/templates; rmdir pi-sandbox/.pi
```

## Automated coverage

`npm test` — 960 passing, 0 failures (was 947 before; +13 new tests in mesh-mux/mesh-spawn/peer-spawn). Live host-boot smoke confirms peers survive until the parent is terminated.

## Companion issues

- #170 — recipe-loader doesn't search `pi-sandbox/agents/` on fresh clones (the symlink workaround above papers over it); orthogonal, owned separately.
- #173 — `launcher-bridge` and sibling extensions should not hard-fail with the misleading "Habitat has not been materialised" message when `recipe-loader` fails; defensive hardening, owned separately.

Closes #172.

https://claude.ai/code/session_01Pc48Q89kjNBoome2NxNMsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pc48Q89kjNBoome2NxNMsn)_