### PR TITLE
fix(engine): recipe-loader discovers repo-local pi-sandbox/agents (#170)

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -3,9 +3,11 @@
 Day-to-day, the way to launch a focused agent is `pi --recipe <name>`.
 The `--recipe` flag is registered by the `@agentfactory/pi-engine`
 extension package, which resolves the named recipe from
-`<cwd>/.pi/recipes/` → `~/.pi/agent/recipes/` → bundled (project >
-global > bundled), then configures the pi session with the recipe's
-model, tools, extensions, and system prompt. Extensions come from the
+`<cwd>/.pi/recipes/` → `~/.pi/agent/recipes/` → `<cwd>/pi-sandbox/agents/` → `<cwd>/agents/` → bundled (project >
+global > repo-local > bundled), then configures the pi session with the recipe's
+model, tools, extensions, and system prompt. The two repo-local tiers mean
+`pi --recipe <name>` works from the repo root (matching `pi-sandbox/agents/`)
+and from `pi-sandbox/` (matching `agents/`) without any symlinks. Extensions come from the
 installed engine and cluster packages, and every recipe gets the
 engine-baseline rails automatically — see
 [`agents/rails-reference.md`](./agents/rails-reference.md).
@@ -32,7 +34,7 @@ Design rationale lives in [`adr/`](./adr/).
 ## Recipe shape
 
 ```yaml
-# pi-sandbox/agents/<name>.yaml  (also loadable from <cwd>/.pi/recipes/ or ~/.pi/agent/recipes/)
+# pi-sandbox/agents/<name>.yaml  (also loadable from <cwd>/.pi/recipes/, ~/.pi/agent/recipes/, or auto-discovered from repo root / pi-sandbox/)
 model: TASK_RABBIT_MODEL          # tier name resolved via env → ~/.pi/agent/models.json → bundled tier-defaults.json, or a literal model ID
 description: Drafts files...      # optional; shown by agent-header in the TUI
 prompt: |                         # the agent's role, prepended with extension fragments

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -43,10 +43,13 @@ Pi's working directory is `pi-sandbox/`; the `npm run pi` script handles the
 
 - `pi-sandbox/agents/` — YAML recipes for `pi --recipe <name>`. Recipe
   search order: project-local `.pi/recipes/` → `~/.pi/agent/recipes/` →
-  bundled in the engine package (currently empty). Recipes in this dir
-  are found when `pi --recipe` is invoked from the repo root. Also hosts
-  host recipes (e.g. `anon-grouped-mesh.yaml`, `authority-mesh.yaml`,
-  `grouped-mesh.yaml`) launched via `npm run mesh -- <recipe-name>`
+  `<cwd>/pi-sandbox/agents/` → `<cwd>/agents/` → bundled in the engine
+  package (currently empty). The two repo-local tiers mean recipes here
+  are auto-discovered when `pi --recipe` is invoked from the repo root
+  (matching `pi-sandbox/agents/`) or from inside `pi-sandbox/` (matching
+  `agents/`), with no symlinks required. Also hosts host recipes (e.g.
+  `anon-grouped-mesh.yaml`, `authority-mesh.yaml`, `grouped-mesh.yaml`)
+  launched via `npm run mesh -- <recipe-name>`
   (see `docs/agents/host-recipes.md`).
 - `pi-sandbox/templates/` — Template YAML files used by `extends:` chains
   in recipes (e.g. `peer.yaml`).

--- a/packages/engine/agent/extensions/recipe-loader-search-paths.test.ts
+++ b/packages/engine/agent/extensions/recipe-loader-search-paths.test.ts
@@ -8,10 +8,16 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import { getRecipeDirs, getTemplateDirs } from "./recipe-loader.js";
 import { resolveRecipe } from "../lib/resolve-recipe.js";
 
-const REPO_ROOT = "/home/user/AgentFactory";
+// Resolve repo root from this file's location so the tests run on any host
+// (local /home/user/AgentFactory, CI runner, contributor laptop). Walk up four
+// levels: extensions/ → agent/ → engine/ → packages/ → <repo>.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..", "..");
 
 describe("recipe-loader search paths — repo-root invocation (issue #170)", () => {
   it("getRecipeDirs(repoRoot) discovers writer-foreman via pi-sandbox/agents/", () => {

--- a/packages/engine/agent/extensions/recipe-loader-search-paths.test.ts
+++ b/packages/engine/agent/extensions/recipe-loader-search-paths.test.ts
@@ -1,0 +1,39 @@
+/**
+ * recipe-loader-search-paths.test.ts — behavioural tests for the repo-local
+ * search path expansion introduced in issue #170.
+ *
+ * Imports the promoted named exports (getRecipeDirs, getTemplateDirs) and
+ * passes them to resolveRecipe to verify the engine discovers recipes in
+ * pi-sandbox/agents/ from both repo-root and pi-sandbox/ invocation forms.
+ */
+
+import { describe, it, expect } from "vitest";
+import { getRecipeDirs, getTemplateDirs } from "./recipe-loader.js";
+import { resolveRecipe } from "../lib/resolve-recipe.js";
+
+const REPO_ROOT = "/home/user/AgentFactory";
+
+describe("recipe-loader search paths — repo-root invocation (issue #170)", () => {
+  it("getRecipeDirs(repoRoot) discovers writer-foreman via pi-sandbox/agents/", () => {
+    const recipeDirs = getRecipeDirs(REPO_ROOT);
+    const templateDirs = getTemplateDirs(REPO_ROOT);
+    // Must not throw; writer-foreman lives in pi-sandbox/agents/
+    let result: ReturnType<typeof resolveRecipe>;
+    expect(() => {
+      result = resolveRecipe("writer-foreman", { recipeDirs, templateDirs });
+    }).not.toThrow();
+    expect(result!.prompt).toBeTruthy();
+  });
+
+  it("getRecipeDirs(pi-sandbox/) discovers writer-foreman via agents/", () => {
+    const piSandboxDir = `${REPO_ROOT}/pi-sandbox`;
+    const recipeDirs = getRecipeDirs(piSandboxDir);
+    const templateDirs = getTemplateDirs(piSandboxDir);
+    // pi-sandbox/agents/ is <piSandboxDir>/agents — should be in the dirs list
+    let result: ReturnType<typeof resolveRecipe>;
+    expect(() => {
+      result = resolveRecipe("writer-foreman", { recipeDirs, templateDirs });
+    }).not.toThrow();
+    expect(result!.prompt).toBeTruthy();
+  });
+});

--- a/packages/engine/agent/extensions/recipe-loader.test.ts
+++ b/packages/engine/agent/extensions/recipe-loader.test.ts
@@ -98,6 +98,90 @@ describe("recipe-loader.ts — fatal error paths use failHard (issue #173)", () 
   });
 });
 
+describe("recipe-loader.ts — repo-local search paths (issue #170)", () => {
+  it("getRecipeDirs includes <cwd>/pi-sandbox/agents", () => {
+    const idx = SRC.indexOf("function getRecipeDirs(");
+    expect(idx).toBeGreaterThan(-1);
+    const body = SRC.slice(idx, idx + 400);
+    expect(body).toMatch(/path\.join\(cwd,\s*["']pi-sandbox["'],\s*["']agents["']\)/);
+  });
+
+  it("getRecipeDirs includes <cwd>/agents", () => {
+    const idx = SRC.indexOf("function getRecipeDirs(");
+    expect(idx).toBeGreaterThan(-1);
+    const body = SRC.slice(idx, idx + 400);
+    // Must contain "agents" as a standalone segment (not only via pi-sandbox/agents)
+    expect(body).toMatch(/path\.join\(cwd,\s*["']agents["']\)/);
+  });
+
+  it("getTemplateDirs includes <cwd>/pi-sandbox/templates", () => {
+    const idx = SRC.indexOf("function getTemplateDirs(");
+    expect(idx).toBeGreaterThan(-1);
+    const body = SRC.slice(idx, idx + 400);
+    expect(body).toMatch(/path\.join\(cwd,\s*["']pi-sandbox["'],\s*["']templates["']\)/);
+  });
+
+  it("getTemplateDirs includes <cwd>/templates", () => {
+    const idx = SRC.indexOf("function getTemplateDirs(");
+    expect(idx).toBeGreaterThan(-1);
+    const body = SRC.slice(idx, idx + 400);
+    expect(body).toMatch(/path\.join\(cwd,\s*["']templates["']\)/);
+  });
+
+  it("getTemplateDirs does NOT include <cwd>/agents", () => {
+    const idx = SRC.indexOf("function getTemplateDirs(");
+    expect(idx).toBeGreaterThan(-1);
+    // Capture just the getTemplateDirs body (stop before the next export function)
+    const afterFn = SRC.slice(idx, idx + 400);
+    const bodyEnd = afterFn.indexOf("export function", 1);
+    const body = bodyEnd > 0 ? afterFn.slice(0, bodyEnd) : afterFn;
+    // The body should not reference "agents" (that's for getRecipeDirs)
+    expect(body).not.toMatch(/["']agents["']/);
+  });
+
+  it("getSkillDirs includes <cwd>/pi-sandbox/skills", () => {
+    const idx = SRC.indexOf("function getSkillDirs(");
+    expect(idx).toBeGreaterThan(-1);
+    const body = SRC.slice(idx, idx + 400);
+    expect(body).toMatch(/path\.join\(cwd,\s*["']pi-sandbox["'],\s*["']skills["']\)/);
+  });
+
+  it("getSkillDirs includes <cwd>/skills", () => {
+    const idx = SRC.indexOf("function getSkillDirs(");
+    expect(idx).toBeGreaterThan(-1);
+    const body = SRC.slice(idx, idx + 400);
+    expect(body).toMatch(/path\.join\(cwd,\s*["']skills["']\)/);
+  });
+
+  it("project-local precedence preserved: .pi/recipes appears before pi-sandbox/agents", () => {
+    const idx = SRC.indexOf("function getRecipeDirs(");
+    expect(idx).toBeGreaterThan(-1);
+    const body = SRC.slice(idx, idx + 400);
+    const projectLocalIdx = body.indexOf('".pi"');
+    const altIdx = body.indexOf("'.pi'");
+    const piIdx = projectLocalIdx !== -1 ? projectLocalIdx : altIdx;
+    expect(piIdx).toBeGreaterThan(-1);
+    // Find pi-sandbox/agents as separate path.join args in the source
+    const sandboxMatch = /path\.join\(cwd,\s*["']pi-sandbox["'],\s*["']agents["']\)/.exec(body);
+    expect(sandboxMatch).not.toBeNull();
+    const sandboxIdx = sandboxMatch!.index;
+    expect(piIdx).toBeLessThan(sandboxIdx);
+  });
+
+  it("repo-local before bundled: pi-sandbox/agents appears before BUNDLED_RECIPES_DIR", () => {
+    const idx = SRC.indexOf("function getRecipeDirs(");
+    expect(idx).toBeGreaterThan(-1);
+    const body = SRC.slice(idx, idx + 400);
+    // Find pi-sandbox/agents as separate path.join args in the source
+    const sandboxMatch = /path\.join\(cwd,\s*["']pi-sandbox["'],\s*["']agents["']\)/.exec(body);
+    expect(sandboxMatch).not.toBeNull();
+    const sandboxIdx = sandboxMatch!.index;
+    const bundledIdx = body.indexOf("BUNDLED_RECIPES_DIR");
+    expect(bundledIdx).toBeGreaterThan(-1);
+    expect(sandboxIdx).toBeLessThan(bundledIdx);
+  });
+});
+
 describe("recipe-loader.ts — non-fatal paths kept as warnings (issue #173)", () => {
   it("keeps skill resolution failure as warning (non-fatal)", () => {
     // The skills catch block must use "warning" severity, not failHard.

--- a/packages/engine/agent/extensions/recipe-loader.ts
+++ b/packages/engine/agent/extensions/recipe-loader.ts
@@ -53,36 +53,45 @@ const BUNDLED_EXTENSIONS_DIR = path.join(PACKAGE_DIR, "agent", "extensions");
 
 /**
  * Returns the precedence-ordered list of recipe directories:
- * project (<cwd>/.pi/recipes/) → global (~/.pi/agent/recipes/) → bundled.
+ * project (<cwd>/.pi/recipes/) → global (~/.pi/agent/recipes/) →
+ * repo-local (<cwd>/pi-sandbox/agents/ or <cwd>/agents/) → bundled.
  */
-function getRecipeDirs(cwd: string): string[] {
+export function getRecipeDirs(cwd: string): string[] {
   return [
     path.join(cwd, ".pi", "recipes"),
     path.join(os.homedir(), ".pi", "agent", "recipes"),
+    path.join(cwd, "pi-sandbox", "agents"),
+    path.join(cwd, "agents"),
     BUNDLED_RECIPES_DIR,
   ];
 }
 
 /**
  * Returns the precedence-ordered list of template directories:
- * project (<cwd>/.pi/templates/) → global (~/.pi/agent/templates/) → bundled.
+ * project (<cwd>/.pi/templates/) → global (~/.pi/agent/templates/) →
+ * repo-local (<cwd>/pi-sandbox/templates/ or <cwd>/templates/) → bundled.
  */
-function getTemplateDirs(cwd: string): string[] {
+export function getTemplateDirs(cwd: string): string[] {
   return [
     path.join(cwd, ".pi", "templates"),
     path.join(os.homedir(), ".pi", "agent", "templates"),
+    path.join(cwd, "pi-sandbox", "templates"),
+    path.join(cwd, "templates"),
     BUNDLED_TEMPLATES_DIR,
   ];
 }
 
 /**
  * Returns the precedence-ordered list of skill directories:
- * project (<cwd>/.pi/skills/) → global (~/.pi/agent/skills/) → bundled.
+ * project (<cwd>/.pi/skills/) → global (~/.pi/agent/skills/) →
+ * repo-local (<cwd>/pi-sandbox/skills/ or <cwd>/skills/) → bundled.
  */
-function getSkillDirs(cwd: string): string[] {
+export function getSkillDirs(cwd: string): string[] {
   return [
     path.join(cwd, ".pi", "skills"),
     path.join(os.homedir(), ".pi", "agent", "skills"),
+    path.join(cwd, "pi-sandbox", "skills"),
+    path.join(cwd, "skills"),
     BUNDLED_SKILLS_DIR,
   ];
 }
@@ -141,7 +150,7 @@ function readExtensionFragment(extName: string): string | null {
 
 export default function recipeLoader(pi: ExtensionAPI) {
   pi.registerFlag("recipe", {
-    description: "Name of the recipe to load from <cwd>/.pi/recipes/, ~/.pi/agent/recipes/, or bundled recipes",
+    description: "Name of the recipe to load from <cwd>/.pi/recipes/, ~/.pi/agent/recipes/, <cwd>/pi-sandbox/agents/, <cwd>/agents/, or bundled recipes",
     type: "string",
   });
 


### PR DESCRIPTION
## What this fixes

`getRecipeDirs(cwd)` searched `<cwd>/.pi/recipes/` + `~/.pi/agent/recipes/` + `BUNDLED_RECIPES_DIR`. None of these matched `pi-sandbox/agents/` — where this repo actually ships its recipes — so on a fresh `git clone && npm install`, the two documented invocations both failed with `recipe-loader: resolveRecipe: recipe 'X' not found`:

```sh
npm run mesh -- mesh-host-example                                # cd pi-sandbox → cwd has no .pi/recipes
pi --recipe writer-foreman --sandbox /tmp/X                      # cwd=repoRoot has no .pi/recipes
```

Contributors patched it locally with untracked symlinks (`pi-sandbox/.pi/recipes -> ../agents`). This PR makes that workaround unnecessary.

**The fix.** Extend each of the three dir-getters in `recipe-loader.ts` (`getRecipeDirs`, `getTemplateDirs`, `getSkillDirs`) with two new tiers, between the existing user-local and bundled tiers:

1. `<cwd>/.pi/{recipes|templates|skills}/` — existing project-local *(highest precedence; shadowing still works)*
2. `~/.pi/agent/{recipes|templates|skills}/` — existing global
3. **NEW:** `<cwd>/pi-sandbox/{agents|templates|skills}/` — repo-root invocation form
4. **NEW:** `<cwd>/{agents|templates|skills}/` — `cd pi-sandbox` invocation form
5. `BUNDLED_*` — existing (kept; harmless when empty)

User-local tiers keep precedence so contributors can still shadow recipes via `.pi/recipes/`. `findRecipeFile` is a first-match loop (verified), so this ordering is binding.

**Why not committed symlinks?** Symlinks would only fix one of the two invocation forms (the `cd pi-sandbox` one — `pi --recipe X` from repo root would still fail without a second symlink), and committed Linux symlinks are a Windows portability footgun. The engine already hardcodes `pi-sandbox/agents/` in `mesh-mux.ts:107` and `mesh-spawn.ts:54` via `resolveRepoRoot()`, so teaching `recipe-loader` the same layout propagates an already-accepted assumption to where it's needed rather than introducing a new one.

The three dir-getters are now exported (named exports) so tests can verify the search order behaviourally; previously they were file-local. `--recipe`'s flag description string was also updated so `pi --help` lists the new locations accurately.

`docs/agents.md` (recipe-loader search-order tour) and `docs/repo-layout.md` (parenthetical in the recipe-layout section) updated to reflect the new tiers.

## QA steps for the human

Both ACs verified live during the integration smoke; the only useful additional check is the documented mesh-rails smoke in `docs/agents/testing.md`:

```sh
rm -rf pi-sandbox/.pi/recipes pi-sandbox/.pi/templates  # ensure no symlink workaround
set -a; source models.env; set +a
npm run mesh -- mesh-host-example       # AC #1; should resolve recipes + spawn analyst/scribe
# Ctrl-C / /quit after a few seconds

mkdir -p /tmp/wf
node_modules/.bin/pi --recipe writer-foreman --sandbox /tmp/wf -p "hi"   # AC #2; should boot print mode
rm -rf /tmp/wf
```

Expected: zero `recipe not found` errors in either invocation.

## Automated coverage

`npm test` — 994 passing, 0 failures (was 983 before; +11 new tests across `recipe-loader.test.ts` (9 source-level assertions: each new path, ordering precedence, templates-vs-agents typo guard) and the new `recipe-loader-search-paths.test.ts` (2 behavioural cases calling `resolveRecipe` from `cwd=repoRoot` and `cwd=pi-sandbox`)).

## Companion issues

- #172 (merged `b1aef32`) — mesh-mux workers crashing on `initial_mesh:`. Workers inherit the host's cwd, so this fix's new search paths apply transitively to children with no further change.
- #173 (merged `6d6816e`) — recipe-loader fails loud + launcher-bridge defensive guard. This PR turns the previously-papered-over "recipe not found" failure into a path that simply works.

Closes #170.

https://claude.ai/code/session_01Pc48Q89kjNBoome2NxNMsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pc48Q89kjNBoome2NxNMsn)_