### PR TITLE
Extract a `BusTransport` interface to make the mesh transport swappable

### DIFF
--- a/packages/engine/agent/extensions/peer-bus.test.ts
+++ b/packages/engine/agent/extensions/peer-bus.test.ts
@@ -51,10 +51,13 @@ describe("peer-bus.ts — lazy acquisition gate", () => {
     expect(SRC).toMatch(/import.*habitatHasPeers.*from/);
   });
 
-  it("guards bindServer call with habitatHasPeers", () => {
-    // The gate check must appear before the bindServer call in session_start.
+  it("guards transport.listen call with habitatHasPeers", () => {
+    // The gate check must appear before the transport bind/listen call in session_start.
     const gateIdx = SRC.indexOf("habitatHasPeers");
-    const bindIdx = SRC.indexOf("await bindServer");
+    // Accept either the old "await bindServer" or the new "transport.listen" pattern.
+    const bindIdx = SRC.indexOf("await bindServer") !== -1
+      ? SRC.indexOf("await bindServer")
+      : SRC.indexOf(".listen(");
     expect(gateIdx).toBeGreaterThan(-1);
     expect(bindIdx).toBeGreaterThan(-1);
     // Gate comes before bind (lazy acquisition).

--- a/packages/engine/agent/extensions/peer-bus.ts
+++ b/packages/engine/agent/extensions/peer-bus.ts
@@ -26,8 +26,6 @@
 // pi --recipe run (no peers) binds no OS socket; mesh tools are still
 // registered unconditionally so recipe allowlists resolve.
 
-import fs from "node:fs";
-import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -41,7 +39,7 @@ import {
   type Envelope,
 } from "../lib/bus-envelope.js";
 import { dispatchSubmissionReply } from "../lib/submission-emit.js";
-import { sendOverBus } from "../lib/bus-transport.js";
+import { createUnixSocketTransport, type BusTransport } from "../lib/bus-transport.js";
 import { habitatHasPeers } from "../lib/mesh-peering.js";
 import {
   ingestMeshUpdate,
@@ -59,8 +57,8 @@ interface PendingCall {
 }
 
 interface BusState {
-  server?: net.Server;
-  sockPath?: string;
+  transport?: BusTransport;
+  bound: boolean;
   name: string;
   busRoot: string;
   inbox: Envelope[];
@@ -82,6 +80,7 @@ interface BusState {
 function getState(): BusState {
   const g = globalThis as { __pi_peer_bus__?: BusState };
   return (g.__pi_peer_bus__ ??= {
+    bound: false,
     name: "",
     busRoot: "",
     inbox: [],
@@ -96,78 +95,6 @@ function getState(): BusState {
 
 // busRoot and instanceName are resolved from the Habitat materialised by
 // the habitat baseline extension before this session_start runs.
-
-function probeSocketLive(sockPath: string, timeoutMs = 200): Promise<boolean> {
-  return new Promise((resolve) => {
-    const sock = net.connect(sockPath);
-    const done = (live: boolean) => {
-      sock.removeAllListeners();
-      sock.destroy();
-      resolve(live);
-    };
-    const timer = setTimeout(() => done(false), timeoutMs);
-    sock.once("connect", () => {
-      clearTimeout(timer);
-      done(true);
-    });
-    sock.once("error", () => {
-      clearTimeout(timer);
-      done(false);
-    });
-  });
-}
-
-async function bindServer(state: BusState, ctx: { ui: { notify: (m: string, l?: string) => void } }) {
-  const sockPath = path.join(state.busRoot, `${state.name}.sock`);
-  state.sockPath = sockPath;
-  fs.mkdirSync(state.busRoot, { recursive: true });
-
-  const server = net.createServer((conn) => {
-    let buf = "";
-    conn.setEncoding("utf8");
-    conn.on("data", (chunk: string) => {
-      buf += chunk;
-      let nl: number;
-      while ((nl = buf.indexOf("\n")) !== -1) {
-        const line = buf.slice(0, nl);
-        buf = buf.slice(nl + 1);
-        if (!line.trim()) continue;
-        const env = tryDecodeEnvelope(line);
-        if (!env) continue; // drop malformed / wrong-version envelopes silently
-        handleIncoming(state, env);
-      }
-    });
-    conn.on("error", () => conn.destroy());
-  });
-
-  const tryListen = (): Promise<void> =>
-    new Promise((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(sockPath, () => {
-        server.removeAllListeners("error");
-        resolve();
-      });
-    });
-
-  try {
-    await tryListen();
-  } catch (e) {
-    const err = e as NodeJS.ErrnoException;
-    if (err.code !== "EADDRINUSE") throw e;
-    const live = await probeSocketLive(sockPath);
-    if (live) {
-      ctx.ui.notify(
-        `peer-bus: name "${state.name}" already held by a live peer at ${sockPath} — refusing to bind`,
-        "error",
-      );
-      throw new Error(`peer-bus name collision: ${state.name}`);
-    }
-    fs.unlinkSync(sockPath);
-    await tryListen();
-  }
-
-  state.server = server;
-}
 
 function notifyBusTailObserver(env: Envelope, direction: "in" | "out") {
   const observer = (
@@ -319,44 +246,12 @@ function pushToModel(state: BusState, envs: Envelope[]) {
 }
 
 async function sendEnvelope(state: BusState, env: Envelope): Promise<{ delivered: boolean; reason?: string }> {
-  const result = await sendOverBus(state.busRoot, env.to, encodeEnvelope(env));
-  // Opportunistic cleanup: if the peer's socket was left by a crashed process,
-  // unlink it so probeSocketLive and peer_list return an accurate picture.
-  if (!result.delivered && result.reason === "peer offline") {
-    const dest = path.join(state.busRoot, `${env.to}.sock`);
-    try { fs.unlinkSync(dest); } catch { /* noop */ }
-  }
+  // Delegate send (including opportunistic offline-socket cleanup) to the transport.
+  const result = await state.transport!.send(env.to, encodeEnvelope(env));
   // Notify the bus-tail observer on successful outbound delivery.
+  // notifyBusTailObserver needs the Envelope object, so it stays in the extension.
   if (result.delivered) notifyBusTailObserver(env, "out");
   return result;
-}
-
-async function listLivePeers(state: BusState): Promise<{ name: string; addr: string }[]> {
-  let entries: string[];
-  try {
-    entries = fs.readdirSync(state.busRoot);
-  } catch {
-    return [];
-  }
-  const candidates = entries.filter((f) => f.endsWith(".sock")).map((f) => f.slice(0, -".sock".length));
-  const results: { name: string; addr: string }[] = [];
-  for (const peerName of candidates) {
-    const addr = path.join(state.busRoot, `${peerName}.sock`);
-    if (peerName === state.name) {
-      results.push({ name: peerName, addr });
-      continue;
-    }
-    if (await probeSocketLive(addr)) {
-      results.push({ name: peerName, addr });
-    } else {
-      try {
-        fs.unlinkSync(addr);
-      } catch {
-        /* noop */
-      }
-    }
-  }
-  return results;
 }
 
 export default function (pi: ExtensionAPI) {
@@ -386,19 +281,36 @@ export default function (pi: ExtensionAPI) {
 
     // LAZY ACQUISITION: skip socket binding for solo runs (no peers configured).
     // Tools are already registered unconditionally; they return "bus not initialized"
-    // when state.server is unset, which is the correct behavior for solo mode.
+    // when state.transport/state.bound is unset, which is the correct behavior for solo mode.
     if (!hasPeers) return;
 
+    state.transport = createUnixSocketTransport(busRoot!);
+
+    const onLine = (line: string) => {
+      const env = tryDecodeEnvelope(line);
+      if (!env) return; // drop malformed / wrong-version envelopes silently
+      handleIncoming(state, env);
+    };
+
     try {
-      await bindServer(state, ctx);
+      await state.transport.listen(state.name, onLine);
+      state.bound = true;
     } catch (e) {
-      ctx.ui.notify(`peer-bus: failed to bind ${state.sockPath}: ${(e as Error).message}`, "error");
+      const msg = (e as Error).message;
+      // Re-surface the collision message exactly as before, or fall back to generic.
+      ctx.ui.notify(
+        msg.startsWith("peer-bus name collision:")
+          ? `peer-bus: name "${state.name}" already held by a live peer — refusing to bind`
+          : `peer-bus: failed to bind for ${state.name}: ${msg}`,
+        "error",
+      );
       return;
     }
 
     try {
       if (getHabitat().debug === true) {
-        const dump = `peer-bus: name=${state.name} sock=${state.sockPath}`;
+        const sockPath = path.join(busRoot!, `${state.name}.sock`);
+        const dump = `peer-bus: name=${state.name} sock=${sockPath}`;
         ctx.ui.notify(dump, "info");
         process.stderr.write(`[peer-bus] ${dump}\n`);
       }
@@ -423,21 +335,9 @@ export default function (pi: ExtensionAPI) {
       pending.reject(new Error("peer-bus shutdown"));
     }
     state.pendingCalls.clear();
-    if (state.server) {
-      try {
-        state.server.close();
-      } catch {
-        /* noop */
-      }
-      state.server = undefined;
-    }
-    if (state.sockPath) {
-      try {
-        fs.unlinkSync(state.sockPath);
-      } catch {
-        /* noop */
-      }
-    }
+    state.transport?.closeSync();
+    state.transport = undefined;
+    state.bound = false;
   };
   pi.on("session_shutdown", async () => cleanup());
   process.once("exit", cleanup);
@@ -466,7 +366,7 @@ export default function (pi: ExtensionAPI) {
       ),
     }),
     async execute(_id, params) {
-      if (!state.server) {
+      if (!state.transport || !state.bound) {
         return {
           content: [{ type: "text", text: "peer-bus not initialized; cannot send." }],
           details: { delivered: false, reason: "bus not initialized" },
@@ -568,7 +468,9 @@ export default function (pi: ExtensionAPI) {
     description: "List currently-live peers on the bus (probes each socket; cleans stale entries).",
     parameters: Type.Object({}),
     async execute() {
-      const peers = await listLivePeers(state);
+      const peers = await (state.transport
+        ? state.transport.discover(state.name)
+        : Promise.resolve([]));
       const lines = peers.map((p) => `${p.name}${p.name === state.name ? " (self)" : ""} — ${p.addr}`);
       return {
         content: [{ type: "text", text: lines.length === 0 ? "(no peers)" : lines.join("\n") }],
@@ -595,7 +497,7 @@ export default function (pi: ExtensionAPI) {
       ),
     }),
     async execute(_id, params) {
-      if (!state.server) {
+      if (!state.transport || !state.bound) {
         return {
           content: [{ type: "text", text: "peer-bus not initialized; cannot call." }],
           details: { delivered: false, reason: "bus not initialized" },

--- a/packages/engine/agent/lib/bus-transport.test.ts
+++ b/packages/engine/agent/lib/bus-transport.test.ts
@@ -5,19 +5,24 @@
 // The timeout case uses a server that accepts the connection but never
 // reads, forcing the write callback to time out.
 
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import net from "node:net";
 import { describe, it, expect, afterEach } from "vitest";
-import { sendOverBus } from "./bus-transport";
+import { sendOverBus, createUnixSocketTransport, type BusTransport } from "./bus-transport";
 
 const tmpDir = mkdtempSync(join(tmpdir(), "bus-transport-test-"));
 
 // Servers we need to close after each test
 const openServers: net.Server[] = [];
+// Transports we need to close after each test
+const openTransports: BusTransport[] = [];
 
 afterEach(async () => {
+  for (const t of openTransports.splice(0)) {
+    await t.close().catch(() => { /* noop */ });
+  }
   for (const s of openServers.splice(0)) {
     await new Promise<void>((r) => {
       // closeAllConnections is Node 18+; fall back to close() for older.
@@ -110,4 +115,139 @@ describe("sendOverBus", () => {
     expect(result.delivered).toBe(false);
     expect(result.reason).toBe("timeout");
   }, 10_000);
+});
+
+// ---------------------------------------------------------------------------
+// UnixSocketTransport tests
+// ---------------------------------------------------------------------------
+
+// Each test gets a fresh sub-directory under tmpDir to avoid socket-name
+// collisions across tests running in the same tmpDir.
+let subDirCounter = 0;
+function makeBusRoot(): string {
+  return mkdtempSync(join(tmpDir, `ust-${++subDirCounter}-`));
+}
+
+describe("UnixSocketTransport", () => {
+  it("listen binds and onLine receives a newline-framed line sent via send (round-trip)", async () => {
+    const busRoot = makeBusRoot();
+    const receiver = createUnixSocketTransport(busRoot);
+    openTransports.push(receiver);
+
+    const received: string[] = [];
+    await receiver.listen("peer-a", (line) => received.push(line));
+
+    const sender = createUnixSocketTransport(busRoot);
+    openTransports.push(sender);
+
+    const result = await sender.send("peer-a", '{"hello":"world"}\n');
+    expect(result.delivered).toBe(true);
+
+    // Give the OS a moment to deliver the bytes to the server's onLine callback.
+    await new Promise<void>((r) => setTimeout(r, 50));
+    expect(received).toHaveLength(1);
+    expect(received[0]).toBe('{"hello":"world"}');
+  });
+
+  it("listen reclaims a stale socket (EADDRINUSE + not-live)", async () => {
+    const busRoot = makeBusRoot();
+    const sockPath = join(busRoot, "stale-peer.sock");
+
+    // Create a stale socket by starting a server and immediately closing it
+    // (socket file stays on disk but nothing listens — ECONNREFUSED).
+    const dead = net.createServer();
+    await new Promise<void>((r) => dead.listen(sockPath, () => r()));
+    await new Promise<void>((r) => dead.close(() => r()));
+
+    // Now try to bind to the same name — should succeed by reclaiming the stale socket.
+    const transport = createUnixSocketTransport(busRoot);
+    openTransports.push(transport);
+    await expect(transport.listen("stale-peer", () => {})).resolves.toBeUndefined();
+  });
+
+  it("listen rejects with 'peer-bus name collision: <name>' when a live peer already holds the name", async () => {
+    const busRoot = makeBusRoot();
+
+    const first = createUnixSocketTransport(busRoot);
+    openTransports.push(first);
+    await first.listen("live-peer", () => {});
+
+    const second = createUnixSocketTransport(busRoot);
+    openTransports.push(second);
+    await expect(second.listen("live-peer", () => {})).rejects.toThrow(
+      "peer-bus name collision: live-peer",
+    );
+  });
+
+  it("discover returns self (unprobed) + a live peer, and unlinks a dead peer's socket", async () => {
+    const busRoot = makeBusRoot();
+
+    // Start a live peer
+    const livePeer = createUnixSocketTransport(busRoot);
+    openTransports.push(livePeer);
+    await livePeer.listen("peer-live", () => {});
+
+    // Create a stale socket for a dead peer
+    const deadSockPath = join(busRoot, "peer-dead.sock");
+    const dead = net.createServer();
+    await new Promise<void>((r) => dead.listen(deadSockPath, () => r()));
+    await new Promise<void>((r) => dead.close(() => r()));
+
+    // Discover from self's perspective
+    const self = createUnixSocketTransport(busRoot);
+    openTransports.push(self);
+    await self.listen("peer-self", () => {});
+
+    const peers = await self.discover("peer-self");
+    const names = peers.map((p) => p.name).sort();
+
+    // Should find self and live-peer; dead-peer should be cleaned up
+    expect(names).toContain("peer-self");
+    expect(names).toContain("peer-live");
+    expect(names).not.toContain("peer-dead");
+
+    // The dead socket file should have been unlinked
+    expect(() => statSync(deadSockPath)).toThrow();
+  });
+
+  it("close removes the bound socket file; subsequent listen on same name succeeds", async () => {
+    const busRoot = makeBusRoot();
+    const sockPath = join(busRoot, "peer-close.sock");
+
+    const transport = createUnixSocketTransport(busRoot);
+    await transport.listen("peer-close", () => {});
+
+    // Socket file should exist
+    expect(() => statSync(sockPath)).not.toThrow();
+
+    await transport.close();
+
+    // Socket file should be gone
+    expect(() => statSync(sockPath)).toThrow();
+
+    // A new transport can now rebind the same name
+    const transport2 = createUnixSocketTransport(busRoot);
+    openTransports.push(transport2);
+    await expect(transport2.listen("peer-close", () => {})).resolves.toBeUndefined();
+  });
+
+  it("send to an offline peer returns {delivered:false, reason:'peer offline'} and unlinks the leftover dead socket", async () => {
+    const busRoot = makeBusRoot();
+
+    // Create a stale socket (dead peer)
+    const deadSockPath = join(busRoot, "peer-gone.sock");
+    const dead = net.createServer();
+    await new Promise<void>((r) => dead.listen(deadSockPath, () => r()));
+    await new Promise<void>((r) => dead.close(() => r()));
+
+    const sender = createUnixSocketTransport(busRoot);
+    openTransports.push(sender);
+
+    const result = await sender.send("peer-gone", '{"msg":"hi"}\n');
+    expect(result.delivered).toBe(false);
+    expect(result.reason).toBe("peer offline");
+
+    // The stale socket file should have been unlinked by the transport
+    expect(() => statSync(deadSockPath)).toThrow();
+  });
 });

--- a/packages/engine/agent/lib/bus-transport.ts
+++ b/packages/engine/agent/lib/bus-transport.ts
@@ -4,7 +4,12 @@
 // open a socket to ${busRoot}/${toName}.sock, write one JSON line, and close.
 // This module provides a single tested implementation so a future change
 // (wire-format checksum, retry policy, etc.) has one home.
+//
+// Also defines the BusTransport interface and the default UnixSocketTransport
+// implementation, so the mesh transport is swappable without modifying
+// peer-bus.ts (the extension) directly.
 
+import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
 
@@ -50,4 +55,221 @@ export function sendOverBus(
       done({ delivered: false, reason });
     });
   });
+}
+
+// ---------------------------------------------------------------------------
+// BusTransport interface + UnixSocketTransport default implementation
+// ---------------------------------------------------------------------------
+
+/** Callback invoked by the transport for every raw newline-framed line received. */
+export type LineHandler = (line: string) => void;
+
+/** A discovered peer on the bus. */
+export interface BusPeer {
+  name: string;
+  addr: string;
+}
+
+/**
+ * Abstraction over the peer-bus transport layer. All Unix-socket I/O
+ * (bind/listen, send, discover, close) goes through this interface so a
+ * future transport (e.g. a message broker) can replace the default
+ * implementation without touching the extension.
+ *
+ * Wire-format invariant: the transport is line-oriented (newline-framed JSON).
+ * It does NOT decode envelopes — that responsibility stays in peer-bus.ts.
+ */
+export interface BusTransport {
+  /**
+   * Send a single newline-terminated line to a named peer.
+   * Fire-and-forget: always resolves a BusSendResult, never rejects.
+   */
+  send(toName: string, line: string, timeoutMs?: number): Promise<BusSendResult>;
+
+  /**
+   * Bind to the given name on the bus and start receiving lines.
+   * Calls onLine for each complete newline-framed line received.
+   * Throws (with message `peer-bus name collision: ${name}`) if the name is
+   * already held by a live peer; callers should surface this as a UI error.
+   * Reclaims a stale socket (EADDRINUSE + not-live) transparently.
+   */
+  listen(selfName: string, onLine: LineHandler): Promise<void>;
+
+  /**
+   * Discover live peers on the bus. Self is always included (unprobed).
+   * Stale sockets for other names are probed and unlinked when dead.
+   */
+  discover(selfName: string): Promise<BusPeer[]>;
+
+  /**
+   * Probe whether a named peer's socket is currently live.
+   */
+  isLive(name: string): Promise<boolean>;
+
+  /** Async close: close the server and remove the bound socket file. */
+  close(): Promise<void>;
+
+  /**
+   * Synchronous close for process.once("exit") handlers.
+   * Node ignores pending async work at exit, so this must be synchronous.
+   */
+  closeSync(): void;
+}
+
+// ---------------------------------------------------------------------------
+// UnixSocketTransport — the default Unix-domain-socket implementation
+// ---------------------------------------------------------------------------
+
+class UnixSocketTransport implements BusTransport {
+  private readonly busRoot: string;
+  private server: net.Server | undefined;
+  private boundSockPath: string | undefined;
+
+  constructor(busRoot: string) {
+    this.busRoot = busRoot;
+  }
+
+  send(toName: string, line: string, timeoutMs?: number): Promise<BusSendResult> {
+    // Delegate to the existing tested sendOverBus implementation.
+    const result = sendOverBus(this.busRoot, toName, line, timeoutMs);
+
+    // Opportunistic cleanup: if the peer's socket was left by a crashed
+    // process, unlink it so isLive and discover return an accurate picture.
+    return result.then((r) => {
+      if (!r.delivered && r.reason === "peer offline") {
+        const dest = path.join(this.busRoot, `${toName}.sock`);
+        try { fs.unlinkSync(dest); } catch { /* noop */ }
+      }
+      return r;
+    });
+  }
+
+  listen(selfName: string, onLine: LineHandler): Promise<void> {
+    const sockPath = path.join(this.busRoot, `${selfName}.sock`);
+    fs.mkdirSync(this.busRoot, { recursive: true });
+
+    const server = net.createServer((conn) => {
+      let buf = "";
+      conn.setEncoding("utf8");
+      conn.on("data", (chunk: string) => {
+        buf += chunk;
+        let nl: number;
+        while ((nl = buf.indexOf("\n")) !== -1) {
+          const line = buf.slice(0, nl);
+          buf = buf.slice(nl + 1);
+          if (!line.trim()) continue;
+          onLine(line);
+        }
+      });
+      conn.on("error", () => conn.destroy());
+    });
+
+    const tryListen = (): Promise<void> =>
+      new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(sockPath, () => {
+          server.removeAllListeners("error");
+          resolve();
+        });
+      });
+
+    return (async () => {
+      try {
+        await tryListen();
+      } catch (e) {
+        const err = e as NodeJS.ErrnoException;
+        if (err.code !== "EADDRINUSE") throw e;
+        const live = await this.isLive(selfName);
+        if (live) {
+          // Preserve the exact message text that peer-bus.ts expects to catch.
+          throw new Error(`peer-bus name collision: ${selfName}`);
+        }
+        fs.unlinkSync(sockPath);
+        await tryListen();
+      }
+      this.server = server;
+      this.boundSockPath = sockPath;
+    })();
+  }
+
+  async discover(selfName: string): Promise<BusPeer[]> {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(this.busRoot);
+    } catch {
+      return [];
+    }
+    const candidates = entries
+      .filter((f) => f.endsWith(".sock"))
+      .map((f) => f.slice(0, -".sock".length));
+    const results: BusPeer[] = [];
+    for (const peerName of candidates) {
+      const addr = path.join(this.busRoot, `${peerName}.sock`);
+      if (peerName === selfName) {
+        // Self is always included without probing.
+        results.push({ name: peerName, addr });
+        continue;
+      }
+      if (await this.isLive(peerName)) {
+        results.push({ name: peerName, addr });
+      } else {
+        try { fs.unlinkSync(addr); } catch { /* noop */ }
+      }
+    }
+    return results;
+  }
+
+  isLive(name: string): Promise<boolean> {
+    const sockPath = path.join(this.busRoot, `${name}.sock`);
+    return new Promise((resolve) => {
+      const sock = net.connect(sockPath);
+      const done = (live: boolean) => {
+        sock.removeAllListeners();
+        sock.destroy();
+        resolve(live);
+      };
+      const timer = setTimeout(() => done(false), 200);
+      sock.once("connect", () => {
+        clearTimeout(timer);
+        done(true);
+      });
+      sock.once("error", () => {
+        clearTimeout(timer);
+        done(false);
+      });
+    });
+  }
+
+  async close(): Promise<void> {
+    const { server, boundSockPath } = this;
+    this.server = undefined;
+    this.boundSockPath = undefined;
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+    if (boundSockPath) {
+      try { fs.unlinkSync(boundSockPath); } catch { /* noop */ }
+    }
+  }
+
+  closeSync(): void {
+    const { server, boundSockPath } = this;
+    this.server = undefined;
+    this.boundSockPath = undefined;
+    if (server) {
+      try { server.close(); } catch { /* noop */ }
+    }
+    if (boundSockPath) {
+      try { fs.unlinkSync(boundSockPath); } catch { /* noop */ }
+    }
+  }
+}
+
+/**
+ * Factory for the default Unix-socket transport.
+ * peer-bus.ts depends on this so it can be swapped via the interface
+ * without importing the class directly.
+ */
+export function createUnixSocketTransport(busRoot: string): BusTransport {
+  return new UnixSocketTransport(busRoot);
 }


### PR DESCRIPTION
## What this fixes

The Peer Bus transport was only half-abstracted: `sendOverBus()` centralised
sends and `bus-envelope.ts` kept the wire format transport-agnostic, but the
**receive** (socket bind/listen) and **discovery** (the `.sock` directory scan)
paths were inline `net`/`fs` calls in `peer-bus.ts`. Swapping the transport
meant editing the extension, not one implementation file.

This change introduces a `BusTransport` interface in
`packages/engine/agent/lib/bus-transport.ts` and a default
`UnixSocketTransport` (with a `createUnixSocketTransport(busRoot)` factory) that
owns all socket/fs I/O:

- **`send`** wraps the unchanged `sendOverBus()` free function and performs the
  opportunistic stale-`.sock` unlink on `peer offline`.
- **`listen`** binds the peer's socket, frames the inbound byte stream on
  newlines, and hands each line to an `onLine` callback — preserving the
  EADDRINUSE → probe-live → unlink-dead → retry stale-socket reclaim, and
  throwing the exact `peer-bus name collision: <name>` error on a live
  collision.
- **`discover`** runs the `.sock`-suffix directory scan (self included
  unprobed; dead peers probed and unlinked).
- **`isLive`** is the shared liveness probe (reused by bind, discover, and
  send-offline cleanup).
- **`close`** / **`closeSync`** reap the bound socket — `closeSync` exists so
  the synchronous `process.once("exit")` handler still unlinks the socket
  exactly as before (Node ignores pending async work at exit).

`peer-bus.ts` now holds a `transport` instance and delegates; it imports
**neither `net` nor `fs`**. The transport/extension seam keeps the transport
wire-format-agnostic — envelope decode/dispatch and `notifyBusTailObserver`
stay in `peer-bus.ts`. The on-disk layout (`${BUS_ROOT}/<name>.sock`), the
`Envelope` wire format (`bus-envelope.ts` untouched), and `sendOverBus`'s
signature and its 5 importers are all unchanged. An actual non-socket
transport (RabbitMQ etc.) remains out of scope.

## QA steps for the human

Largely covered by automated tests + smoke, but to confirm the live mesh by
hand:

1. `set -a; source models.env; set +a`
2. `npm run mesh -- mesh-host-example` (or another `initial_mesh:` recipe),
   then in-session run the peer-list tool and send a message to a pre-spawned
   peer — peers should bind, appear in discovery, and receive the message.
3. After exit, confirm the host's `.sock` under `$BUS_ROOT` is gone.

Note: `tsc` is not a dependency in this repo (everything runs via `tsx`), so
there is no standalone typecheck command — the vitest suite is the type/behaviour
source of truth.

## Automated coverage

`npm test` — 1000/1000 green, including 6 new `UnixSocketTransport` tests
(round-trip listen+send, stale-socket reclaim, live-collision rejection,
discover self+live with dead-socket unlink, close/rebind, offline-send unlink)
and the unchanged `sendOverBus` regression tests. Live integration smoke
exercised the extracted I/O end-to-end (real bind, discovery, fire-and-forget
send, peer-offline reason, stale-socket rebind, closeSync reaping); the live
host also bound and reaped its bus socket cleanly.

Closes #146
