### PR TITLE
Engine package does not typecheck: 19 pre-existing `tsc` errors masked by tsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@ai-hero/sandcastle": "^0.5.6",
+        "typescript": "5.9.3",
         "vitest": "^4.1.5"
       }
     },
@@ -5055,6 +5056,20 @@
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
       "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici": {
       "version": "7.25.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "pi": "bash -c 'set -a && source models.env && set +a && cd pi-sandbox && exec pi --no-context-files --provider openrouter \"$@\"' --",
     "mesh": "bash -c 'set -a && source models.env && set +a && cd pi-sandbox && exec pi --recipe \"$1\" --is-host' --",
     "test": "vitest run --passWithNoTests",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit -p packages/engine/tsconfig.json && tsc --noEmit -p packages/deferred-rails/tsconfig.json && tsc --noEmit -p packages/containment-rails/tsconfig.json && tsc --noEmit -p packages/ui-rails/tsconfig.json"
   },
   "dependencies": {
     "@earendil-works/pi-ai": "^0.75.4",
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@ai-hero/sandcastle": "^0.5.6",
+    "typescript": "5.9.3",
     "vitest": "^4.1.5"
   }
 }

--- a/packages/engine/agent/extensions/bus-tail-emitter.ts
+++ b/packages/engine/agent/extensions/bus-tail-emitter.ts
@@ -199,7 +199,7 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
-  pi.on("session_end", async () => {
+  pi.on("session_shutdown", async () => {
     const state = getEmitterState();
     state.focused = false;
     state.tailOn = false;

--- a/packages/engine/agent/extensions/intercept.ts
+++ b/packages/engine/agent/extensions/intercept.ts
@@ -441,7 +441,7 @@ export default function (pi: ExtensionAPI) {
     } catch { /* Habitat not available */ }
   });
 
-  pi.on("session_end", async () => {
+  pi.on("session_shutdown", async () => {
     const state = getState();
     // Restore original dispatch hook on cleanup.
     if (state.originalDispatch !== null) {

--- a/packages/engine/agent/extensions/launcher-bridge.ts
+++ b/packages/engine/agent/extensions/launcher-bridge.ts
@@ -250,7 +250,7 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
-  pi.on("session_end", async () => {
+  pi.on("session_shutdown", async () => {
     const state = getBridgeState();
     if (state.client) {
       try { state.client.disconnect(); } catch { /* ignore */ }

--- a/packages/engine/agent/extensions/mesh-rail.ts
+++ b/packages/engine/agent/extensions/mesh-rail.ts
@@ -70,7 +70,7 @@ export default function (pi: ExtensionAPI) {
     });
   });
 
-  pi.on("session_end", async () => {
+  pi.on("session_shutdown", async () => {
     clearMeshRailHandle();
   });
 }

--- a/packages/engine/agent/extensions/mesh-spawn.ts
+++ b/packages/engine/agent/extensions/mesh-spawn.ts
@@ -239,7 +239,7 @@ export default function (pi: ExtensionAPI) {
         Type.Array(Type.String(), { description: "Override inbound peers (Slice 3+, accepted but not yet plumbed to wiring resolver)." }),
       ),
     }),
-    async execute(_id, params, _signal, _onUpdate, ctx): Promise<{ content: Array<{ type: string; text: string }>; details: Record<string, unknown> }> {
+    async execute(_id, params, _signal, _onUpdate, ctx): Promise<{ content: Array<{ type: "text"; text: string }>; details: Record<string, unknown> }> {
       // ── 1. Read habitat ──────────────────────────────────────────────────
       let spawns: string[] = [];
       let callerName = "anonymous";
@@ -479,7 +479,7 @@ export default function (pi: ExtensionAPI) {
     parameters: Type.Object({
       name: Type.String({ description: "Instance name of the worker to terminate." }),
     }),
-    async execute(_id, params): Promise<{ content: Array<{ type: string; text: string }>; details: Record<string, unknown> }> {
+    async execute(_id, params): Promise<{ content: Array<{ type: "text"; text: string }>; details: Record<string, unknown> }> {
       const node = registry.get(params.name);
       if (!node) {
         return {

--- a/packages/engine/agent/extensions/peer-bus.ts
+++ b/packages/engine/agent/extensions/peer-bus.ts
@@ -28,7 +28,7 @@
 
 import os from "node:os";
 import path from "node:path";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { AgentToolResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { getHabitat } from "../lib/habitat.js";
 import {
@@ -365,7 +365,7 @@ export default function (pi: ExtensionAPI) {
         Type.String({ description: "Optional msg_id of the message you are replying to." }),
       ),
     }),
-    async execute(_id, params) {
+    async execute(_id, params): Promise<AgentToolResult<Record<string, unknown>>> {
       if (!state.transport || !state.bound) {
         return {
           content: [{ type: "text", text: "peer-bus not initialized; cannot send." }],
@@ -496,7 +496,7 @@ export default function (pi: ExtensionAPI) {
         Type.Number({ description: "Max wait in ms for a reply. Default 30000." }),
       ),
     }),
-    async execute(_id, params) {
+    async execute(_id, params): Promise<AgentToolResult<Record<string, unknown>>> {
       if (!state.transport || !state.bound) {
         return {
           content: [{ type: "text", text: "peer-bus not initialized; cannot call." }],

--- a/packages/engine/agent/extensions/recipe-loader.ts
+++ b/packages/engine/agent/extensions/recipe-loader.ts
@@ -261,7 +261,7 @@ export default function recipeLoader(pi: ExtensionAPI) {
 
     // --peer-name overrides instance identity; falls back to sessionId then recipeName.
     const peerNameFlag = (pi.getFlag("peer-name") as string | undefined)?.trim();
-    const instanceName = peerNameFlag || ctx.sessionId || recipeName;
+    const instanceName = peerNameFlag || ctx.sessionManager.getSessionId() || recipeName;
 
     // --sandbox overrides the working directory / scratchRoot.
     const sandboxFlag = (pi.getFlag("sandbox") as string | undefined)?.trim();

--- a/packages/engine/agent/extensions/slash-commands.ts
+++ b/packages/engine/agent/extensions/slash-commands.ts
@@ -18,7 +18,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { getHabitat } from "../lib/habitat.js";
 import { getMeshRailHandle } from "../lib/mesh-rail.js";
-import { createDecisionsOverlayComponent } from "../lib/decisions-overlay.js";
+import { createDecisionsOverlayComponent, type DecisionsOverlayResult } from "../lib/decisions-overlay.js";
 // IMPORTANT: this is a static jiti-resolved import, not createRequire().
 // Node's createRequire cannot resolve .ts files, so any attempt to load the
 // bridge dynamically (e.g. _require("./launcher-bridge")) silently throws and
@@ -243,7 +243,7 @@ export default function (pi: ExtensionAPI) {
       const railHandle = getMeshRailHandle();
       const state = railHandle?.getState() ?? { peers: [], decisions: [], decisionCount: 0, peerName: "" };
 
-      const result = await ctx.ui.custom(
+      const result = await ctx.ui.custom<DecisionsOverlayResult>(
         (_tui, _theme, _keybindings, done) => {
           const overlay = createDecisionsOverlayComponent({
             peers: state.peers,

--- a/packages/engine/agent/extensions/supervisor.ts
+++ b/packages/engine/agent/extensions/supervisor.ts
@@ -331,12 +331,12 @@ export default function (pi: ExtensionAPI) {
       }
       return {
         content: [{ type: "text", text: `respond_to_request(${params.action}) sent for ${params.msg_id.slice(0, 8)}.` }],
-        details: { ok: true },
+        details: { ok: true, error: undefined },
       };
     },
   });
 
-  pi.on("session_end", async () => {
+  pi.on("session_shutdown", async () => {
     // Clear ctx so no stale reference is held after the session ends.
     state.ctx = null;
     state.sendUserMessage = undefined;

--- a/packages/engine/agent/lib/child-spawn.d.mts
+++ b/packages/engine/agent/lib/child-spawn.d.mts
@@ -1,0 +1,34 @@
+/**
+ * child-spawn.d.mts — TypeScript declarations for child-spawn.mjs
+ */
+
+/**
+ * Resolve the absolute path to the `pi` binary for spawning children.
+ * @param repoRoot - Absolute path to the repository root.
+ * @returns Absolute path to node_modules/.bin/pi.
+ */
+export function resolvePiBin(repoRoot: string): string;
+
+/**
+ * Resolve the repo root relative to this module's location.
+ * engine lib lives at packages/engine/agent/lib/ → 4 levels up = repo root.
+ * @returns Absolute path to the repo root.
+ */
+export function resolveRepoRoot(): string;
+
+/**
+ * Build the argv array for spawning a `pi --recipe` child process.
+ */
+export function buildRecipeChildArgv(opts: {
+  piBin: string;
+  recipe: string;
+  sandbox: string;
+  busRoot: string;
+  instanceName?: string;
+  agentName?: string;
+  topologyOverlay?: string;
+  task?: string;
+  inheritPty?: boolean;
+  debug?: boolean;
+  printPrompt?: string;
+}): string[];

--- a/packages/engine/agent/lib/peer-spawn.test.ts
+++ b/packages/engine/agent/lib/peer-spawn.test.ts
@@ -220,6 +220,7 @@ describe("runMeshSpawn", () => {
       workerName: name,
       busRoot: "/tmp/bus",
       callerSandbox,
+      callerCwd: "/tmp/caller-cwd",
       callerName: "authority",
       spawnWorker,
     });
@@ -249,6 +250,7 @@ describe("runMeshSpawn", () => {
       busRoot: "/tmp/bus",
       workspace: { include: ["ref.md"] },
       callerSandbox,
+      callerCwd: "/tmp/caller-cwd",
       callerName: "authority",
       spawnWorker,
     };


### PR DESCRIPTION
## What this fixes

The `@agentfactory/pi-engine` package never typechecked: the repo executes
everything through `tsx` (transpile-only) and didn't even depend on TypeScript,
so 18 `tsc` errors had accumulated unseen across the engine extensions. This PR
adds `typescript` as a devDependency plus a `typecheck` npm script and drives the
engine to **0 errors**, without changing runtime behaviour.

The fixes, by root cause:

- **`session_end` → `session_shutdown` (5 files)** — `bus-tail-emitter.ts`,
  `intercept.ts`, `launcher-bridge.ts`, `mesh-rail.ts`, `supervisor.ts`. The
  installed `@earendil-works/pi-coding-agent` renamed the lifecycle event;
  `session_end` no longer exists on the `.on()` overloads. All five handlers are
  zero-arg cleanup callbacks, so the rename is mechanical and behaviour-preserving
  — they still fire on quit/reload/new/resume/fork.
- **Tool-handler return types (TS2322)** — `mesh-spawn.ts` narrows content `type`
  from `string` to the literal `"text"`; `peer-bus.ts` `peer_send`/`peer_call`
  gain an explicit `Promise<AgentToolResult<Record<string, unknown>>>` annotation
  so heterogeneous `details` branches (including `reason: string | undefined`)
  type-check; `supervisor.ts` adds `error: undefined` to its success branch so
  both result branches share one shape.
- **Missing declaration (TS7016)** — new `packages/engine/agent/lib/child-spawn.d.mts`
  declares `resolvePiBin` / `resolveRepoRoot` / `buildRecipeChildArgv`, following
  the repo's existing sibling-`.d.mts` convention, replacing an implicit `any`.
- **`ExtensionContext` drift (TS2339)** — `recipe-loader.ts` reads the session id
  via `ctx.sessionManager.getSessionId()` (the field `ctx.sessionId` was removed),
  in the same peer-name fallback position.
- **Untyped overlay result (TS2339)** — `slash-commands.ts` passes the explicit
  `ctx.ui.custom<DecisionsOverlayResult>()` type argument so `.action`/`.peer`
  resolve.
- **Test fixtures (TS2741)** — two `MeshSpawnContext` fixtures in
  `peer-spawn.test.ts` gain the now-required `callerCwd` field.

No `@ts-ignore` / `as any` / `tsconfig` weakening was used — every fix is
type-honest.

## QA steps for the human

None required for behaviour — fully covered below. The two behavioural renames
(`session_shutdown`, `getSessionId()`) were exercised live: a harness fired
`session_shutdown` in isolation against the real extension modules and confirmed
the peer-bus socket is still reaped, and model-backed `mesh-host-example` runs
loaded the recipe, named/spawned peers, and exited with `BUS_ROOT` empty.

If you want to confirm by hand: `npm run typecheck` (expect 0 errors), then
`set -a; source models.env; set +a; npm run mesh -- mesh-host-example`, exit the
session, and confirm no `.sock` lingers under the bus root.

## Automated coverage

`npm run typecheck` — 0 errors across all four package tsconfigs (engine,
deferred-rails, containment-rails, ui-rails). `npm test` — 1000/1000 green.
Live mesh smoke: socket bind→reap under `session_shutdown` proven in isolation;
4 headless host runs exited cleanly with empty bus root.

Closes #178
