### PR TITLE
ci: run npm run typecheck as a parallel CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,13 @@ jobs:
           node-version: '22'
       - run: npm ci
       - run: npm test
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci
+      - run: npm run typecheck


### PR DESCRIPTION
## What this does

Adds a dedicated `typecheck` job to the CI workflow that runs `npm run typecheck`
(the `tsc --noEmit` gate across all four package tsconfigs added in #179).

The repo executes everything through `tsx`, which never typechecks, so without a
CI gate the engine's hard-won 0-error state could silently regress. This makes
the typecheck an independent required check.

## Why a separate job (not a step in `test`)

Running it as its own `runs-on` job means a type regression fails the `typecheck`
check on its own — it doesn't mask, or get masked by, the unit-test result, and
the two run in parallel. The marginal cost is one extra `npm ci`.

## Coverage

`npm run typecheck` already passes locally (0 errors, all four packages). This PR
only adds the workflow job; no source changes.

Follow-up to #178 / #179.
