### PR TITLE
Tier 1: trivial, safe simplifications (dedup encodeEnvelope, sha256, effectiveGroups)

### DIFF
--- a/packages/engine/agent/extensions/intercept.ts
+++ b/packages/engine/agent/extensions/intercept.ts
@@ -18,6 +18,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { getHabitat, tryGetHabitat } from "../lib/habitat.js";
 import {
+  encodeEnvelope,
   makeApprovalResultEnvelope,
   makeRevisionRequestedEnvelope,
   renderInboundForUser,
@@ -122,7 +123,7 @@ async function sendApprovalResult(opts: {
     approved: opts.approved,
     ...(opts.note !== undefined ? { note: opts.note } : {}),
   });
-  await sendOverBus(opts.busRoot, opts.to, `${JSON.stringify(env)}\n`);
+  await sendOverBus(opts.busRoot, opts.to, encodeEnvelope(env));
 }
 
 async function sendRevisionRequested(opts: {
@@ -138,7 +139,7 @@ async function sendRevisionRequested(opts: {
     in_reply_to: opts.inReplyTo,
     note: opts.note,
   });
-  await sendOverBus(opts.busRoot, opts.to, `${JSON.stringify(env)}\n`);
+  await sendOverBus(opts.busRoot, opts.to, encodeEnvelope(env));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/engine/agent/lib/cohort-registry.ts
+++ b/packages/engine/agent/lib/cohort-registry.ts
@@ -8,6 +8,7 @@
 // See ADR-0008 for the reference grammar and resolution semantics.
 
 import { resolveRef, type CounterState } from "./ref-resolver.js";
+import { effectiveGroups } from "./visibility.js";
 
 // ---------------------------------------------------------------------------
 // Data structures
@@ -64,7 +65,7 @@ export function addMember(
 ): void {
   if (!reg.has(spawner)) reg.set(spawner, new Map());
   const gm = reg.get(spawner)!;
-  const effective = groups.length > 0 ? groups : ["_default"];
+  const effective = effectiveGroups(groups);
   for (const g of effective) {
     if (!gm.has(g)) gm.set(g, []);
     const members = gm.get(g)!;
@@ -175,13 +176,11 @@ export function resolveCohortRef(opts: ResolveCohortRefOptions): string | string
 
   if (body === "$myGroups") {
     // @$myGroups — all peers in any of resolver's own groups
-    const effectiveGroups = resolverGroups.length > 0 ? resolverGroups : ["_default"];
-    groupFilter = effectiveGroups;
+    groupFilter = effectiveGroups(resolverGroups);
     recipeFilter = undefined;
   } else if (body.startsWith("$myGroups:")) {
     // @$myGroups:<recipe>
-    const effectiveGroups = resolverGroups.length > 0 ? resolverGroups : ["_default"];
-    groupFilter = effectiveGroups;
+    groupFilter = effectiveGroups(resolverGroups);
     recipeFilter = body.slice("$myGroups:".length);
   } else if (body.includes(":")) {
     // @<group>:<recipe>

--- a/packages/engine/agent/lib/cohort-tracker.ts
+++ b/packages/engine/agent/lib/cohort-tracker.ts
@@ -14,6 +14,7 @@
 
 import type { GroupMap } from "./cohort-registry.js";
 import type { MeshUpdateChange } from "./bus-envelope.js";
+import { effectiveGroups } from "./visibility.js";
 
 // ---------------------------------------------------------------------------
 // __pi_cohort_lookup__ hook interface
@@ -69,8 +70,8 @@ export function ingestMeshUpdate(
 ): void {
   for (const change of update.changes) {
     if (change.op === "add") {
-      const effectiveGroups = change.groups.length > 0 ? change.groups : ["_default"];
-      for (const g of effectiveGroups) {
+      const groups = effectiveGroups(change.groups);
+      for (const g of groups) {
         if (!cache.has(g)) cache.set(g, []);
         const members = cache.get(g)!;
         // Keep the CohortMember shape for compatibility with GroupMap type
@@ -120,10 +121,10 @@ export function expandGroupRef(
   let recipeFilter: string | undefined;
 
   if (body === "$myGroups") {
-    groupKeys = selfGroups.length > 0 ? selfGroups : ["_default"];
+    groupKeys = effectiveGroups(selfGroups);
     recipeFilter = undefined;
   } else if (body.startsWith("$myGroups:")) {
-    groupKeys = selfGroups.length > 0 ? selfGroups : ["_default"];
+    groupKeys = effectiveGroups(selfGroups);
     recipeFilter = body.slice("$myGroups:".length);
   } else if (colonIdx !== -1) {
     groupKeys = [body.slice(0, colonIdx)];

--- a/packages/engine/agent/lib/group-membership.ts
+++ b/packages/engine/agent/lib/group-membership.ts
@@ -7,6 +7,8 @@
 //   aggregateGroupMembership(topo)  — legacy topology-shaped builder (unchanged)
 //   buildGroupMap(entries)          — spawner-scoped builder for CohortRegistry use
 
+import { effectiveGroups } from "./visibility.js";
+
 export interface NodeWithGroups {
   name?: string;
   groups?: string[];
@@ -97,7 +99,7 @@ export function buildGroupMap(entries: GroupMapEntry[]): Map<string, string[]> {
   const result = new Map<string, string[]>();
 
   for (const entry of entries) {
-    const groups = entry.groups.length > 0 ? entry.groups : ["_default"];
+    const groups = effectiveGroups(entry.groups);
     for (const g of groups) {
       if (!result.has(g)) result.set(g, []);
       const members = result.get(g)!;

--- a/packages/engine/agent/lib/sha256.ts
+++ b/packages/engine/agent/lib/sha256.ts
@@ -1,0 +1,6 @@
+import { createHash } from "node:crypto";
+
+/** SHA-256 of a UTF-8 string, hex-encoded. */
+export function sha256(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex");
+}

--- a/packages/engine/agent/lib/submission-apply.ts
+++ b/packages/engine/agent/lib/submission-apply.ts
@@ -7,11 +7,11 @@
 //      deletes) so compositions like "edit X then move it to Y" work
 //      deterministically regardless of the order artifacts arrive in.
 
-import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { Artifact } from "./bus-envelope";
 import { applyUnique } from "./string-edit";
+import { sha256 } from "./sha256";
 
 export interface ApplyResult {
   ok: boolean;
@@ -25,10 +25,6 @@ const KIND_ORDER: Record<Artifact["kind"], number> = {
   move: 2,
   delete: 3,
 };
-
-function sha256(s: string): string {
-  return createHash("sha256").update(s, "utf8").digest("hex");
-}
 
 export async function applyArtifacts(
   canonicalRoot: string,

--- a/packages/engine/agent/lib/submission-emit.ts
+++ b/packages/engine/agent/lib/submission-emit.ts
@@ -5,11 +5,9 @@
 // dispatch supervisor replies into it from a different module graph —
 // the same pattern as deferred-confirm's handler registry.
 
-import { createHash } from "node:crypto";
 import { encodeEnvelope, makeSubmissionEnvelope, type Artifact, type Envelope } from "./bus-envelope";
 import { sendOverBus, type BusSendResult } from "./bus-transport";
-
-const sha256 = (s: string) => createHash("sha256").update(s, "utf8").digest("hex");
+import { sha256 } from "./sha256";
 
 // ---------------------------------------------------------------------------
 // Artifact builders

--- a/packages/engine/agent/lib/visibility.ts
+++ b/packages/engine/agent/lib/visibility.ts
@@ -30,8 +30,8 @@ export interface PeerNode {
 // ---------------------------------------------------------------------------
 
 /** Effective groups — [] becomes ["_default"]. */
-function effectiveGroups(peer: PeerNode): string[] {
-  return peer.groups.length > 0 ? peer.groups : ["_default"];
+export function effectiveGroups(groups: string[]): string[] {
+  return groups.length > 0 ? groups : ["_default"];
 }
 
 /** True if sets share at least one element. */
@@ -60,7 +60,7 @@ export function canSee(x: PeerNode, y: PeerNode): boolean {
     x.spawner !== undefined &&
     y.spawner !== undefined &&
     x.spawner === y.spawner &&
-    setsOverlap(effectiveGroups(x), effectiveGroups(y))
+    setsOverlap(effectiveGroups(x.groups), effectiveGroups(y.groups))
   ) {
     return true;
   }


### PR DESCRIPTION
## What this fixes

Three open-coded duplications in `packages/engine/agent`, collapsed to single sources of truth. No behavior change — pure dedup.

- **Envelope encoding** — `extensions/intercept.ts` hand-rolled `` `${JSON.stringify(env)}\n` `` at two send sites. Both now call `encodeEnvelope(env)` from `lib/bus-envelope.ts`, which is byte-for-byte identical. Future wire-format changes now have one place to change.
- **`sha256` helper** — was defined twice (`lib/submission-emit.ts`, `lib/submission-apply.ts`). Extracted to new `lib/sha256.ts` (`createHash("sha256").update(s,"utf8").digest("hex")`); both submission modules import it and drop their now-unused `createHash` import.
- **`effectiveGroups`** — the `groups.length > 0 ? groups : ["_default"]` ternary appeared 8× across `cohort-tracker.ts`, `cohort-registry.ts`, `group-membership.ts`. `lib/visibility.ts` already had a private `effectiveGroups` (taking a `PeerNode`); it's now generalized to take a `string[]`, exported, and reused at all sites. visibility's own two internal callers updated to pass `.groups`. Two shadowing locals also named `effectiveGroups` (in `cohort-registry.resolveCohortRef`) and one in `cohort-tracker.ingestMeshUpdate` were removed/renamed.

## QA steps for the human

None — fully covered by the integration smoke. The change is behavior-preserving and the existing cohort/visibility/submission/bus-envelope suites (202 tests) are the behavioral guard.

## Automated coverage

`npm run typecheck` clean (4 projects); `npm test` = 1000 tests / 52 files pass; live tsx smoke confirmed `encodeEnvelope` byte-identical to the old inline form, `sha256("abc")` correct, and `effectiveGroups([]) → ["_default"]`.

Closes #181
