### PR TITLE
recipe-loader: fail loud when a recipe's declared model can't be applied

### DIFF
--- a/packages/engine/agent/extensions/recipe-loader.test.ts
+++ b/packages/engine/agent/extensions/recipe-loader.test.ts
@@ -3,10 +3,12 @@
  * recipe-loader extension (packages/engine/agent/extensions/recipe-loader.ts).
  *
  * Verifies:
- *   1. The failHard helper exists, writes to stderr, and throws.
+ *   1. The failHard helper exists, writes to stderr, exits the process (so the
+ *      abort survives the SDK's ExtensionRunner.emit() try/catch), and throws
+ *      (unreachable, retained for the `never` contract if process.exit is stubbed).
  *   2. Fatal error paths (resolveRecipe, resolveRailPackages, missing clusters,
  *      resolveModel, topology-overlay JSON parse, setHabitat, missing API key,
- *      unknown model) use failHard.
+ *      unknown model) use failHard — so ALL 8 call sites actually abort.
  *   3. Non-fatal paths (skill resolution, invalid tool names) still use
  *      "warning" and do NOT use failHard.
  *
@@ -36,8 +38,15 @@ describe("recipe-loader.ts — failHard helper (issue #173)", () => {
     // verify 'throw new Error' appears before the next top-level function.
     const failHardIdx = SRC.indexOf("function failHard(");
     expect(failHardIdx).toBeGreaterThan(-1);
-    const failHardBody = SRC.slice(failHardIdx, failHardIdx + 300);
+    const failHardBody = SRC.slice(failHardIdx, failHardIdx + 700);
     expect(failHardBody).toMatch(/throw new Error/);
+  });
+
+  it("failHard exits the process so the abort survives the SDK catch", () => {
+    const idx = SRC.indexOf("function failHard");
+    expect(idx).toBeGreaterThan(-1);
+    const slice = SRC.slice(idx, idx + 500);
+    expect(slice).toMatch(/process\.exit\(\s*1\s*\)/);
   });
 
   it("failHard calls ctx.ui.notify so interactive TUI gets an error toast", () => {

--- a/packages/engine/agent/extensions/recipe-loader.test.ts
+++ b/packages/engine/agent/extensions/recipe-loader.test.ts
@@ -5,9 +5,10 @@
  * Verifies:
  *   1. The failHard helper exists, writes to stderr, and throws.
  *   2. Fatal error paths (resolveRecipe, resolveRailPackages, missing clusters,
- *      resolveModel, topology-overlay JSON parse, setHabitat) use failHard.
- *   3. Non-fatal paths (skill resolution, missing API key, unknown model,
- *      invalid tool names) still use "warning" and do NOT use failHard.
+ *      resolveModel, topology-overlay JSON parse, setHabitat, missing API key,
+ *      unknown model) use failHard.
+ *   3. Non-fatal paths (skill resolution, invalid tool names) still use
+ *      "warning" and do NOT use failHard.
  *
  * Contract: pure file-content assertions; no jiti, no pi runtime, no I/O
  * beyond reading the sibling source file.
@@ -197,12 +198,20 @@ describe("recipe-loader.ts — non-fatal paths kept as warnings (issue #173)", (
     expect(catchSlice).not.toMatch(/failHard\s*\(/);
   });
 
-  it("missing API key path uses warning (non-fatal)", () => {
-    expect(SRC).toMatch(/no API key available.*warning|warning.*no API key available/s);
+  it("uses failHard for missing API key (setModel returned false)", () => {
+    const idx = SRC.indexOf("no API key available");
+    expect(idx).toBeGreaterThan(-1);
+    const slice = SRC.slice(Math.max(0, idx - 100), idx + 150);
+    expect(slice).toMatch(/failHard\s*\(/);
+    expect(slice).not.toMatch(/"warning"/);
   });
 
-  it("unknown model path uses warning (non-fatal)", () => {
-    expect(SRC).toMatch(/not found in registry.*warning|warning.*not found in registry/s);
+  it("uses failHard for unknown model (not found in registry)", () => {
+    const idx = SRC.indexOf("not found in registry");
+    expect(idx).toBeGreaterThan(-1);
+    const slice = SRC.slice(Math.max(0, idx - 100), idx + 150);
+    expect(slice).toMatch(/failHard\s*\(/);
+    expect(slice).not.toMatch(/"warning"/);
   });
 
   it("invalid tool names path uses warning (non-fatal)", () => {

--- a/packages/engine/agent/extensions/recipe-loader.ts
+++ b/packages/engine/agent/extensions/recipe-loader.ts
@@ -330,15 +330,15 @@ export default function recipeLoader(pi: ExtensionAPI) {
     if (model) {
       const success = await pi.setModel(model);
       if (!success) {
-        ctx.ui.notify(
+        failHard(
+          ctx,
           `recipe-loader: no API key available for model '${concreteModelId}' — model not applied`,
-          "warning",
         );
       }
     } else {
-      ctx.ui.notify(
+      failHard(
+        ctx,
         `recipe-loader: model '${concreteModelId}' not found in registry — model not applied`,
-        "warning",
       );
     }
 

--- a/packages/engine/agent/extensions/recipe-loader.ts
+++ b/packages/engine/agent/extensions/recipe-loader.ts
@@ -31,16 +31,29 @@ import { discoverInstalledPackages } from "../lib/installed-packages.js";
 
 /**
  * Notify the user, write to stderr (visible in headless/worker mode where
- * ui.notify is a silent no-op), and throw so the SDK runner surfaces the
- * real error via console.error (print-mode) or showExtensionError (TUI).
+ * ui.notify is a silent no-op), exit the process so the abort survives the
+ * SDK's ExtensionRunner.emit() try/catch, and throw (unreachable but
+ * preserves the `never` contract if process.exit is stubbed in tests).
  *
  * Use for FATAL recipe-loader failures that must not silently leave
  * __pi_habitat__ unset and allow downstream extensions to crash with a
  * misleading "Habitat not materialised" message.
+ *
+ * Background: the pi SDK's ExtensionRunner.emit() wraps every session_start
+ * handler in a try/catch and continues on the fallback model after a throw,
+ * which would let the session degrade silently. process.exit(1) ensures a
+ * fatal recipe-loader misconfiguration truly aborts — same approach as
+ * peer-bus.ts's shutdown path.
  */
 function failHard(ctx: ExtensionContext, msg: string): never {
   ctx.ui.notify(msg, "error");
   process.stderr.write(`${msg}\n`);
+  // The pi SDK's ExtensionRunner.emit() wraps session_start handlers in a
+  // try/catch and continues after a throw, which would let the session proceed
+  // on a fallback model. Exit so a fatal recipe-loader misconfiguration truly
+  // aborts (same approach as peer-bus.ts's shutdown path).
+  process.exit(1);
+  // Unreachable — retained so the `never` contract holds if process.exit is stubbed.
   throw new Error(msg);
 }
 


### PR DESCRIPTION
## What this fixes

When a recipe's declared `model:` can't be applied at launch — the provider has no API key (`pi.setModel()` returns `false`) or the model isn't in the registry — the recipe-loader previously emitted a `"warning"` via `ctx.ui.notify` and **continued on pi's fallback model**. That silently undermines this repo's model-tier architecture: a planner recipe could end up running on a worker-tier model with only a transient warning.

The fix is two layers:

1. **`recipe-loader.ts` "Apply model" block** — both the no-API-key path and the model-not-found path now call `failHard(ctx, …)` instead of `notify(…, "warning")`, with the message strings unchanged.

2. **`failHard` itself (the root cause)** — `failHard` only `throw`ed, but the pi SDK's `ExtensionRunner.emit()` wraps every `session_start` handler in a try/catch that logs the error and continues (`runner.js` ~488-502). So a thrown `failHard` was swallowed and the session degraded to the fallback model anyway. `failHard` now calls `process.exit(1)` after writing to stderr (unreachable `throw` retained for the `never` contract), mirroring the `process.exit` precedent in `peer-bus.ts`.

Because all 8 `failHard` call sites live inside the `session_start` handler, this also repairs every *other* fatal path (missing rail cluster, invalid `--topology-overlay` JSON, `setHabitat` failure, etc.) — they were all being swallowed too. This restores the "recipe-loader fails loud" intent from #173 uniformly.

## QA steps for the human

- **Bug-fix path:** launch any recipe whose model can't be applied (e.g. a recipe with `model: bogus/does-not-exist`, or a real model whose provider key is absent). It now aborts non-zero with `recipe-loader: … — model not applied` and produces **no** assistant response, instead of warning + answering on a fallback model.
- **No regression:** a recipe with a valid, key-available model still launches and responds normally.

Both were exercised live in the integration smoke (exit code 1 + no fallback answer for the bad model; normal response for a good one).

## Automated coverage

`npm run typecheck` (clean) and `npm test` (**1001/1001 pass**) — including new source-text assertions that `failHard` calls `process.exit(1)` and that both model paths use `failHard`.

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)