### PR TITLE
recipe-loader: findModelByString mis-resolves OpenRouter slugs (model ids that contain '/')

### DIFF
--- a/packages/engine/agent/extensions/recipe-loader.test.ts
+++ b/packages/engine/agent/extensions/recipe-loader.test.ts
@@ -192,6 +192,16 @@ describe("recipe-loader.ts — repo-local search paths (issue #170)", () => {
   });
 });
 
+describe("recipe-loader.ts — OpenRouter slug resolution wiring (issue #187)", () => {
+  it("delegates to resolveModelFromRegistry (import present)", () => {
+    expect(SRC).toMatch(/resolveModelFromRegistry\(/);
+  });
+
+  it("reads ctx.model?.provider as the active provider", () => {
+    expect(SRC).toMatch(/ctx\.model\?\.provider/);
+  });
+});
+
 describe("recipe-loader.ts — non-fatal paths kept as warnings (issue #173)", () => {
   it("keeps skill resolution failure as warning (non-fatal)", () => {
     // The skills catch block must use "warning" severity, not failHard.

--- a/packages/engine/agent/extensions/recipe-loader.ts
+++ b/packages/engine/agent/extensions/recipe-loader.ts
@@ -28,6 +28,7 @@ import { assemblePrompt } from "../lib/assemble-prompt.js";
 import { setHabitat } from "../lib/habitat-glue.js";
 import { resolveRailPackages, RAIL_TO_CLUSTER } from "../lib/rail-packages.js";
 import { discoverInstalledPackages } from "../lib/installed-packages.js";
+import { resolveModelFromRegistry } from "../lib/resolve-model-from-registry.js";
 
 /**
  * Notify the user, write to stderr (visible in headless/worker mode where
@@ -110,22 +111,17 @@ export function getSkillDirs(cwd: string): string[] {
 }
 
 /**
- * Find a model in the registry by a `provider/model-id` string.
- * Returns undefined if not found.
+ * Find a model in the registry by a model string, using the session's active
+ * provider (ctx.model?.provider) to correctly resolve OpenRouter-style slugs
+ * (whose ids contain '/') before falling back to first-slash splitting and
+ * full-id scan.
  */
 function findModelByString(
   ctx: ExtensionContext,
   modelString: string,
 ): Model<Api> | undefined {
-  // Split on first '/' to get provider and model id.
-  const slashIdx = modelString.indexOf("/");
-  if (slashIdx === -1) {
-    // No slash — try to find any model whose id matches.
-    return ctx.modelRegistry.getAll().find((m) => m.id === modelString);
-  }
-  const provider = modelString.slice(0, slashIdx);
-  const modelId = modelString.slice(slashIdx + 1);
-  return ctx.modelRegistry.find(provider, modelId);
+  const activeProvider = ctx.model?.provider;
+  return resolveModelFromRegistry(ctx.modelRegistry, modelString, activeProvider);
 }
 
 /**

--- a/packages/engine/agent/lib/resolve-model-from-registry.test.ts
+++ b/packages/engine/agent/lib/resolve-model-from-registry.test.ts
@@ -1,0 +1,114 @@
+// resolve-model-from-registry.test.ts — hermetic unit tests for the
+// OpenRouter-aware registry resolver.
+// No model calls, no network, no env-var pollution.
+
+import { describe, it, expect } from "vitest";
+import { resolveModelFromRegistry } from "./resolve-model-from-registry.js";
+import type { RegistryLike } from "./resolve-model-from-registry.js";
+
+// ── Minimal fixture models (cast to satisfy Model<Api>) ──────────────────────
+
+type FakeModel = { provider: string; id: string };
+
+const FIXTURES: FakeModel[] = [
+  { provider: "openrouter", id: "deepseek/deepseek-v3.2" },
+  { provider: "openrouter", id: "google/gemini-2.5-flash-lite" },
+  { provider: "google", id: "gemini-2.5-flash-lite" },
+  { provider: "anthropic", id: "claude-sonnet-4" },
+];
+
+// ── Fake RegistryLike backed by the fixture list ──────────────────────────────
+
+function makeRegistry(models: FakeModel[]): RegistryLike {
+  return {
+    find(provider, modelId) {
+      const found = models.find(
+        (m) => m.provider === provider && m.id === modelId,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return found as any;
+    },
+    getAll() {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return models as any[];
+    },
+  };
+}
+
+const reg = makeRegistry(FIXTURES);
+
+// ── Test cases ────────────────────────────────────────────────────────────────
+
+describe("resolveModelFromRegistry — OpenRouter slug (id contains '/')", () => {
+  it("case 1: resolves deepseek/deepseek-v3.2 under openrouter active provider (bug regression)", () => {
+    const result = resolveModelFromRegistry(reg, "deepseek/deepseek-v3.2", "openrouter");
+    // Must return the openrouter entry, not split on '/' and fail.
+    expect(result).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).provider).toBe("openrouter");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).id).toBe("deepseek/deepseek-v3.2");
+  });
+
+  it("case 2: resolves google/gemini-2.5-flash-lite to openrouter entry (not google-native) when active provider is openrouter", () => {
+    const result = resolveModelFromRegistry(reg, "google/gemini-2.5-flash-lite", "openrouter");
+    expect(result).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).provider).toBe("openrouter");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).id).toBe("google/gemini-2.5-flash-lite");
+  });
+});
+
+describe("resolveModelFromRegistry — split path (genuine provider/id)", () => {
+  it("case 3: anthropic/claude-sonnet-4 with undefined active provider resolves via split path", () => {
+    const result = resolveModelFromRegistry(reg, "anthropic/claude-sonnet-4", undefined);
+    expect(result).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).provider).toBe("anthropic");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).id).toBe("claude-sonnet-4");
+  });
+
+  it("case 4: anthropic/claude-sonnet-4 still resolves when active provider is openrouter (step1 miss, step2 hit — backward-compat)", () => {
+    // activeProvider=openrouter → find(openrouter, "anthropic/claude-sonnet-4") → undefined
+    // then split → find(anthropic, "claude-sonnet-4") → hit
+    const result = resolveModelFromRegistry(reg, "anthropic/claude-sonnet-4", "openrouter");
+    expect(result).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).provider).toBe("anthropic");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).id).toBe("claude-sonnet-4");
+  });
+});
+
+describe("resolveModelFromRegistry — no-slash getAll path", () => {
+  it("case 5a: gemini-2.5-flash-lite with active provider google resolves google-native entry", () => {
+    const result = resolveModelFromRegistry(reg, "gemini-2.5-flash-lite", "google");
+    expect(result).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).provider).toBe("google");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).id).toBe("gemini-2.5-flash-lite");
+  });
+
+  it("case 5b: gemini-2.5-flash-lite with undefined active provider finds the entry via getAll id-scan", () => {
+    // No slash, activeProvider=undefined → skip step1 → skip step2 → getAll scan by id
+    const result = resolveModelFromRegistry(reg, "gemini-2.5-flash-lite", undefined);
+    expect(result).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).id).toBe("gemini-2.5-flash-lite");
+  });
+});
+
+describe("resolveModelFromRegistry — nonexistent id", () => {
+  it("case 6: nonexistent model id returns undefined", () => {
+    const result = resolveModelFromRegistry(reg, "no-such-provider/no-such-model", "openrouter");
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for a completely unknown id with no active provider", () => {
+    const result = resolveModelFromRegistry(reg, "totally-unknown", undefined);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/engine/agent/lib/resolve-model-from-registry.ts
+++ b/packages/engine/agent/lib/resolve-model-from-registry.ts
@@ -1,0 +1,57 @@
+// resolve-model-from-registry.ts — resolves a recipe model string to a registry
+// Model, preferring the session's active provider so OpenRouter-style ids (which
+// contain '/') resolve correctly.
+//
+// Pure: no I/O, no process.env access. The caller passes the registry and the
+// active provider explicitly so this module is hermetically testable.
+
+import type { Api, Model } from "@earendil-works/pi-ai";
+
+export interface RegistryLike {
+  find(provider: string, modelId: string): Model<Api> | undefined;
+  getAll(): Model<Api>[];
+}
+
+/**
+ * Resolve a recipe model string to a registry Model, preferring the session's
+ * active provider so OpenRouter-style ids (which contain '/') resolve correctly.
+ *
+ * Precedence:
+ *   1. activeProvider set → find(activeProvider, fullModelString)   // whole slug is the id
+ *   2. first-slash split  → find(prefix, rest)                       // genuine provider/id
+ *   3. no/failed split    → getAll().find(m => m.id === fullModelString)
+ *
+ * @param registry       - The pi model registry.
+ * @param modelString    - The concrete model ID string (e.g. "deepseek/deepseek-v3.2").
+ * @param activeProvider - The session's active provider (from ctx.model?.provider), or undefined.
+ * @returns The matching Model entry, or undefined if not found.
+ */
+export function resolveModelFromRegistry(
+  registry: RegistryLike,
+  modelString: string,
+  activeProvider: string | undefined,
+): Model<Api> | undefined {
+  // Step 1: If there's an active provider, try treating the entire model string
+  // as the model id under that provider. This is the correct resolution for
+  // OpenRouter slugs like "deepseek/deepseek-v3.2" or "google/gemini-2.5-flash-lite"
+  // which are stored as full slugs under provider "openrouter".
+  if (activeProvider) {
+    const underActive = registry.find(activeProvider, modelString);
+    if (underActive) return underActive;
+  }
+
+  // Step 2: Try splitting on the first '/' and treating the prefix as the
+  // provider and the rest as the model id. This handles genuine "provider/id"
+  // strings like "anthropic/claude-sonnet-4".
+  const slashIdx = modelString.indexOf("/");
+  if (slashIdx !== -1) {
+    const provider = modelString.slice(0, slashIdx);
+    const modelId = modelString.slice(slashIdx + 1);
+    const split = registry.find(provider, modelId);
+    if (split) return split;
+  }
+
+  // Step 3: Fall back to a full id scan across all models in the registry.
+  // Handles no-slash ids like "gemini-2.5-flash-lite".
+  return registry.getAll().find((m) => m.id === modelString);
+}


### PR DESCRIPTION
## What this fixes

`findModelByString` (`recipe-loader.ts`) resolved a recipe's `model:` string by splitting on the first `/` and treating the prefix as the provider. OpenRouter model ids *contain* a slash — in pi's static registry they're stored under provider `openrouter` with the full slug as the id (e.g. `openrouter` / `deepseek/deepseek-v3.2`). So `deepseek/deepseek-v3.2` mis-split to provider `deepseek` (nonexistent) → `find()` returned `undefined`. Before #185 this silently fell back; after #185 it `failHard`/`process.exit(1)`s, so `npm run pi --recipe deferred-writer` died with `model 'deepseek/deepseek-v3.2' not found in registry`.

The fix reads the session's **active provider** (resolved by pi before `session_start`, exposed as `ctx.model?.provider`) and resolves against it. The resolution logic is extracted into a pure, dependency-injected helper, `resolveModelFromRegistry` in `packages/engine/agent/lib/resolve-model-from-registry.ts` (matching the repo's existing `agent/lib/resolve-model.ts` convention), with precedence:

1. `find(activeProvider, fullModelString)` — treat the whole slug as the id under the active provider (resolves OpenRouter slugs, and picks the OpenRouter copy over a same-named native entry).
2. first-slash split `find(prefix, rest)` — genuine `provider/id` strings.
3. `getAll().find(m.id === modelString)` — no-slash bare ids.

`findModelByString` now just reads `ctx.model?.provider` and delegates. The `failHard` "not found in registry" path is unchanged and now fires only for genuinely absent models. Undefined active provider / non-OpenRouter providers fall through to the old behavior, so it's backward-compatible.

## QA steps for the human

- `npm run pi -- --recipe deferred-writer -p "say hi"` — launches on `deepseek/deepseek-v3.2` instead of aborting with "not found in registry" (requires an OpenRouter key in the environment).
- A recipe with a genuinely nonexistent model still aborts with "not found in registry".

Both were exercised live in the integration smoke (deferred-writer responded "DW OK"; a `bogus/...` model aborted correctly).

## Automated coverage

`npm run typecheck` (clean) and `npm test` (**1011/1011 pass**) — including 8 hermetic unit tests for `resolveModelFromRegistry` (OpenRouter slug-with-slash, google/ slug picking the openrouter copy, split fallback, no-slash, not-found) plus source-text assertions pinning the `ctx.model?.provider` wiring.

## Note / out of scope

`npm run mesh` and `mesh_spawn` children don't receive `--provider openrouter`, so their active provider defaults to `google`; OpenRouter slugs in spawned-child recipes would still fall through to the legacy split. That's a pre-existing limitation orthogonal to this issue (whose scope is `npm run pi --provider openrouter`) — a candidate follow-up is forwarding `--provider` through `buildRecipeChildArgv`.

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)