### PR TITLE
mesh: forward --provider to spawned children (and set it in npm run mesh)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "sandcastle": "npx tsx .sandcastle/main.ts",
     "pi": "bash -c 'set -a && source models.env && set +a && cd pi-sandbox && exec pi --no-context-files --provider openrouter \"$@\"' --",
-    "mesh": "bash -c 'set -a && source models.env && set +a && cd pi-sandbox && exec pi --recipe \"$1\" --is-host' --",
+    "mesh": "bash -c 'set -a && source models.env && set +a && cd pi-sandbox && exec pi --recipe \"$1\" --provider openrouter --is-host' --",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit -p packages/engine/tsconfig.json && tsc --noEmit -p packages/deferred-rails/tsconfig.json && tsc --noEmit -p packages/containment-rails/tsconfig.json && tsc --noEmit -p packages/ui-rails/tsconfig.json"

--- a/packages/engine/agent/extensions/mesh-mux.test.ts
+++ b/packages/engine/agent/extensions/mesh-mux.test.ts
@@ -48,6 +48,22 @@ describe("mesh-mux.ts — cwd inheritance (issue #172)", () => {
   });
 });
 
+// ── Source-level assertions — provider forwarding (issue #189) ──────────────
+
+describe("mesh-mux.ts — provider forwarding (issue #189)", () => {
+  it("declares hostProvider?: string on MeshMuxState interface", () => {
+    expect(SRC).toMatch(/hostProvider\?:\s*string/);
+  });
+
+  it("captures ctx.model?.provider as hostProvider at session_start", () => {
+    expect(SRC).toMatch(/hostProvider:\s*ctx\.model\?\.provider/);
+  });
+
+  it("passes provider: state.hostProvider in spawnPeerViaPtyPool's buildRecipeChildArgv call", () => {
+    expect(SRC).toMatch(/provider:\s*state\.hostProvider/);
+  });
+});
+
 // ── Source-level assertions — spawn cmd (issue #172 follow-up) ──────────────
 
 describe("mesh-mux.ts — pool.spawn cmd (issue #172 follow-up)", () => {

--- a/packages/engine/agent/extensions/mesh-mux.ts
+++ b/packages/engine/agent/extensions/mesh-mux.ts
@@ -86,6 +86,8 @@ interface MeshMuxState {
   pendingSpawns: Map<string, (result: { ok: boolean; name?: string; error?: string }) => void>;
   /** The cwd of the host session — inherited by all spawned workers. */
   hostCwd: string;
+  /** The provider of the host session — forwarded to all spawned workers. */
+  hostProvider?: string;
 }
 
 function getMuxState(): MeshMuxState | undefined {
@@ -198,6 +200,7 @@ function spawnPeerViaPtyPool(
     sandbox: scratchRoot,
     busRoot,
     instanceName: workerName,
+    provider: state.hostProvider,
     topologyOverlay,
     task,
     inheritPty: true, // children run inside host's PTY pool
@@ -578,6 +581,7 @@ export default function (pi: ExtensionAPI) {
       peers: new Map(),
       pendingSpawns: new Map(),
       hostCwd: ctx.cwd,
+      hostProvider: ctx.model?.provider,
     };
 
     setMuxState(state);

--- a/packages/engine/agent/extensions/mesh-spawn.test.ts
+++ b/packages/engine/agent/extensions/mesh-spawn.test.ts
@@ -124,6 +124,21 @@ describe("mesh-spawn.ts — source-level", () => {
   });
 });
 
+// ── provider forwarding (issue #189) ────────────────────────────────────────
+
+describe("mesh-spawn.ts — provider forwarding (issue #189)", () => {
+  it("passes provider: args.provider in productionSpawnWorker's buildRecipeChildArgv call", () => {
+    expect(SRC).toMatch(/provider:\s*args\.provider/);
+  });
+
+  it("passes provider: ctx.model?.provider at the runMeshSpawn call site", () => {
+    const runMeshIdx = SRC.indexOf("runMeshSpawn({");
+    expect(runMeshIdx).toBeGreaterThan(-1);
+    const afterRunMesh = SRC.slice(runMeshIdx, runMeshIdx + 600);
+    expect(afterRunMesh).toMatch(/provider:\s*ctx\.model\?\.provider/);
+  });
+});
+
 // ── cwd inheritance (issue #172) ────────────────────────────────────────────
 
 describe("mesh-spawn.ts — cwd inheritance (issue #172)", () => {

--- a/packages/engine/agent/extensions/mesh-spawn.ts
+++ b/packages/engine/agent/extensions/mesh-spawn.ts
@@ -140,6 +140,7 @@ function productionSpawnWorker(args: SpawnArgs): WorkerHandle {
     sandbox: args.scratchRoot,
     busRoot: args.busRoot,
     instanceName: args.workerName,
+    provider: args.provider,
     topologyOverlay,
     // For long-lived workers, task is passed via --task (NOT -p) so the worker
     // starts interactively and uses the task as per-instance role context.
@@ -426,6 +427,7 @@ export default function (pi: ExtensionAPI) {
         callerSandbox,
         callerName,
         callerCwd: ctx.cwd,
+        provider: ctx.model?.provider,
         spawnWorker: productionSpawnWorker,
       });
 

--- a/packages/engine/agent/lib/child-spawn.d.mts
+++ b/packages/engine/agent/lib/child-spawn.d.mts
@@ -26,6 +26,7 @@ export function buildRecipeChildArgv(opts: {
   busRoot: string;
   instanceName?: string;
   agentName?: string;
+  provider?: string;
   topologyOverlay?: string;
   task?: string;
   inheritPty?: boolean;

--- a/packages/engine/agent/lib/child-spawn.mjs
+++ b/packages/engine/agent/lib/child-spawn.mjs
@@ -12,6 +12,7 @@
  *   --sandbox <sandbox>
  *   --peer-bus <busRoot>
  *   --peer-name <instanceName>      (always)
+ *   [--provider <value>]            (when provider is set and non-empty)
  *   [--topology-overlay <json>]     (when topologyOverlay is set)
  *   [--task <text>]                 (when task is set and non-empty)
  *   [--inherit-pty]                 (when inheritPty is true)
@@ -53,6 +54,7 @@ export function resolveRepoRoot() {
  * @param {string} opts.sandbox       - Absolute path to the sandbox/cwd for the child.
  * @param {string} opts.busRoot       - Absolute path to the peer bus root directory.
  * @param {string} opts.instanceName  - The child's instance name (passed as --peer-name).
+ * @param {string|undefined} [opts.provider]         - Provider name for --provider (e.g. "openrouter").
  * @param {string|undefined} [opts.topologyOverlay] - JSON string for --topology-overlay.
  * @param {string|undefined} [opts.task]            - Task text for --task (appended to system prompt).
  * @param {boolean|undefined} [opts.inheritPty]     - Pass --inherit-pty bare flag.
@@ -69,6 +71,7 @@ export function buildRecipeChildArgv(opts) {
     instanceName,
     // back-compat: accept agentName as alias for instanceName
     agentName,
+    provider,
     topologyOverlay,
     task,
     inheritPty,
@@ -85,6 +88,10 @@ export function buildRecipeChildArgv(opts) {
     "--peer-bus", busRoot,
     "--peer-name", resolvedInstanceName,
   ];
+
+  if (provider && provider.trim()) {
+    argv.push("--provider", provider);
+  }
 
   if (topologyOverlay) {
     argv.push("--topology-overlay", topologyOverlay);

--- a/packages/engine/agent/lib/child-spawn.test.ts
+++ b/packages/engine/agent/lib/child-spawn.test.ts
@@ -75,6 +75,17 @@ describe("buildRecipeChildArgv — required flags", () => {
 });
 
 describe("buildRecipeChildArgv — optional flags omitted when unset", () => {
+  it("omits --provider when not provided", () => {
+    const argv = buildRecipeChildArgv({
+      piBin: FAKE_PI_BIN,
+      recipe: "r",
+      sandbox: "/tmp/s",
+      busRoot: "/tmp/b",
+      instanceName: "a",
+    });
+    expect(argv).not.toContain("--provider");
+  });
+
   it("omits --topology-overlay when not provided", () => {
     const argv = buildRecipeChildArgv({
       piBin: FAKE_PI_BIN,
@@ -196,6 +207,20 @@ describe("buildRecipeChildArgv — optional flags present when set", () => {
     expect(next === undefined || next.startsWith("-")).toBe(true);
   });
 
+  it("includes --provider with its value", () => {
+    const argv = buildRecipeChildArgv({
+      piBin: FAKE_PI_BIN,
+      recipe: "r",
+      sandbox: "/tmp/s",
+      busRoot: "/tmp/b",
+      instanceName: "a",
+      provider: "openrouter",
+    });
+    const idx = argv.indexOf("--provider");
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(argv[idx + 1]).toBe("openrouter");
+  });
+
   it("includes -p with its prompt value", () => {
     const argv = buildRecipeChildArgv({
       piBin: FAKE_PI_BIN,
@@ -212,13 +237,14 @@ describe("buildRecipeChildArgv — optional flags present when set", () => {
 });
 
 describe("buildRecipeChildArgv — stable ordering", () => {
-  it("maintains stable ordering: piBin, --recipe, --sandbox, --peer-bus, --peer-name, optionals", () => {
+  it("maintains stable ordering: piBin, --recipe, --sandbox, --peer-bus, --peer-name, [--provider], [--topology-overlay], optionals", () => {
     const argv = buildRecipeChildArgv({
       piBin: FAKE_PI_BIN,
       recipe: "deferred-writer",
       sandbox: "/tmp/s",
       busRoot: "/tmp/b",
       instanceName: "cottontail-writer",
+      provider: "openrouter",
       topologyOverlay: '{"supervisor":"boss"}',
       task: "do something",
       inheritPty: true,
@@ -231,6 +257,7 @@ describe("buildRecipeChildArgv — stable ordering", () => {
     const sandboxIdx = argv.indexOf("--sandbox");
     const busIdx = argv.indexOf("--peer-bus");
     const peerNameIdx = argv.indexOf("--peer-name");
+    const providerIdx = argv.indexOf("--provider");
     const overlayIdx = argv.indexOf("--topology-overlay");
     const taskIdx = argv.indexOf("--task");
     const inheritPtyIdx = argv.indexOf("--inherit-pty");
@@ -241,7 +268,8 @@ describe("buildRecipeChildArgv — stable ordering", () => {
     expect(recipeIdx).toBeLessThan(sandboxIdx);
     expect(sandboxIdx).toBeLessThan(busIdx);
     expect(busIdx).toBeLessThan(peerNameIdx);
-    expect(peerNameIdx).toBeLessThan(overlayIdx);
+    expect(peerNameIdx).toBeLessThan(providerIdx);
+    expect(providerIdx).toBeLessThan(overlayIdx);
     expect(overlayIdx).toBeLessThan(taskIdx);
     expect(taskIdx).toBeLessThan(inheritPtyIdx);
     expect(inheritPtyIdx).toBeLessThan(debugIdx);

--- a/packages/engine/agent/lib/peer-spawn.test.ts
+++ b/packages/engine/agent/lib/peer-spawn.test.ts
@@ -514,6 +514,63 @@ describe("resolveInitialMeshScalarRef", () => {
   });
 });
 
+// ── runMeshSpawn — provider forwarding (issue #189) ──────────────────────────
+
+describe("runMeshSpawn — provider forwarding (issue #189)", () => {
+  it("forwards provider to spawnWorker when set", async () => {
+    const callerSandbox = makeTmpDir();
+    let capturedArgs: SpawnArgs | null = null;
+    const handle = makePendingHandle();
+    const spawnWorker = vi.fn((args: SpawnArgs) => {
+      capturedArgs = args;
+      return handle as WorkerHandle;
+    });
+
+    const ctx: MeshSpawnContext = {
+      recipe: "mesh-node",
+      workerName: "provider-test-node",
+      busRoot: "/tmp/bus",
+      callerSandbox,
+      callerName: "orchestrator",
+      callerCwd: "/tmp/caller-cwd",
+      provider: "openrouter",
+      spawnWorker,
+    };
+
+    const result = await runMeshSpawn(ctx);
+    expect(result.ok).toBe(true);
+    expect(capturedArgs).not.toBeNull();
+    expect(capturedArgs!.provider).toBe("openrouter");
+    fs.rmSync(result.scratchRoot, { recursive: true, force: true });
+  });
+
+  it("forwards undefined provider when not set", async () => {
+    const callerSandbox = makeTmpDir();
+    let capturedArgs: SpawnArgs | null = null;
+    const handle = makePendingHandle();
+    const spawnWorker = vi.fn((args: SpawnArgs) => {
+      capturedArgs = args;
+      return handle as WorkerHandle;
+    });
+
+    const ctx: MeshSpawnContext = {
+      recipe: "mesh-node",
+      workerName: "no-provider-node",
+      busRoot: "/tmp/bus",
+      callerSandbox,
+      callerName: "orchestrator",
+      callerCwd: "/tmp/caller-cwd",
+      spawnWorker,
+    };
+
+    const result = await runMeshSpawn(ctx);
+    expect(result.ok).toBe(true);
+    expect(capturedArgs).not.toBeNull();
+    expect(capturedArgs!.provider).toBeUndefined();
+    fs.rmSync(result.scratchRoot, { recursive: true, force: true });
+  });
+});
+
 // ── runMeshSpawn — callerCwd forwarding (issue #172) ─────────────────────────
 
 describe("runMeshSpawn — callerCwd forwarding (issue #172)", () => {

--- a/packages/engine/agent/lib/peer-spawn.ts
+++ b/packages/engine/agent/lib/peer-spawn.ts
@@ -191,6 +191,8 @@ export interface SpawnArgs {
   task: string;
   /** The cwd of the caller — workers are spawned with this as their working directory. */
   callerCwd: string;
+  /** Provider name forwarded from the spawning session (e.g. "openrouter"). */
+  provider?: string;
   /** Group memberships for the spawned worker (seeded into its Habitat). */
   groups?: string[];
   habitatOverlay: {
@@ -228,6 +230,8 @@ export interface MeshSpawnContext {
   callerName: string;
   /** The cwd of the calling session — workers inherit this as their working directory. */
   callerCwd: string;
+  /** Provider name forwarded from the spawning session (e.g. "openrouter"). */
+  provider?: string;
   spawnWorker: (args: SpawnArgs) => WorkerHandle;
 }
 
@@ -430,6 +434,7 @@ export async function runMeshSpawn(ctx: MeshSpawnContext): Promise<MeshSpawnResu
     busRoot: ctx.busRoot,
     task: ctx.task ?? "",
     callerCwd: ctx.callerCwd,
+    provider: ctx.provider,
     groups: ctx.groups,
     habitatOverlay,
   };


### PR DESCRIPTION
## What this fixes

#187 made `findModelByString` resolve a recipe's model under the session's **active provider** (`ctx.model?.provider`). That works for `npm run pi` (which passes `--provider openrouter`), but mesh launches didn't carry the provider, so spawned children defaulted to `google` and OpenRouter-slug models (`deepseek/deepseek-v3.2`, etc.) mis-resolved — fatally, post-#185 (`failHard` → `process.exit(1)`).

This forwards the spawning process's active provider to every mesh child, and sets the provider on the mesh wrapper:

- **`buildRecipeChildArgv`** (`agent/lib/child-spawn.mjs` + `.d.mts`) gains an optional `provider`, emitted as `--provider <value>` (between `--peer-name` and `--topology-overlay`) only when set — omitted otherwise, so non-provider launches are unchanged.
- **`mesh-spawn.ts`** (direct-fallback path) forwards `ctx.model?.provider` through `runMeshSpawn` → `SpawnArgs` → `productionSpawnWorker` (types threaded in `peer-spawn.ts`).
- **`mesh-mux.ts`** (host PtyPool path) captures `ctx.model?.provider` at `session_start` as `MeshMuxState.hostProvider` and passes it through the single `spawnPeerViaPtyPool` chokepoint — covering `initial_mesh`, the host hook, and launcher-bridge spawn-requests at once.
- **`package.json`** `mesh` script adds `--provider openrouter`, mirroring `pi`.

The engine stays provider-agnostic — it forwards whatever `ctx.model?.provider` is; only `package.json` names a concrete provider. `--is-host` is never forwarded to children (no `isHost` option was added to the builder).

## QA steps for the human

- `npm run mesh -- <a host recipe with initial_mesh or spawns>` — spawned children launch on the OpenRouter provider instead of aborting with "not found in registry".
- Solo / non-provider launches are unaffected (the flag is omitted when there's no active provider).

Exercised in the integration smoke: a mesh host spawned `analyst` + `scribe` peers with no model-resolution errors; `buildRecipeChildArgv` was confirmed live to emit `--provider openrouter` when set and omit it when unset; `npm run pi` path unaffected.

## Automated coverage

`npm run typecheck` (clean) and `npm test` (**1020/1020 pass**) — including argv-emission tests in `child-spawn.test.ts` (present/absent/ordering), provider-threading assertions in `mesh-spawn.test.ts` / `mesh-mux.test.ts` / `peer-spawn.test.ts`.

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)