### PR TITLE
packaging: declare engine's real runtime deps (pi-tui, node-pty, @xterm/headless); pin loose * versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5362,7 +5362,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "peerDependencies": {
-        "@agentfactory/pi-engine": "*",
+        "@agentfactory/pi-engine": "^0.1.0",
         "@earendil-works/pi-coding-agent": "^0.75.4"
       }
     },
@@ -5371,10 +5371,10 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "typebox": "*"
+        "typebox": "^1.1.38"
       },
       "peerDependencies": {
-        "@agentfactory/pi-engine": "*",
+        "@agentfactory/pi-engine": "^0.1.0",
         "@earendil-works/pi-coding-agent": "^0.75.4"
       }
     },
@@ -5383,11 +5383,15 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "typebox": "*",
+        "@xterm/headless": "^6.0.0",
+        "node-pty": "^1.1.0",
+        "typebox": "^1.1.38",
         "yaml": "^2.8.3"
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.75.4"
+        "@earendil-works/pi-ai": "^0.75.4",
+        "@earendil-works/pi-coding-agent": "^0.75.4",
+        "@earendil-works/pi-tui": "^0.75.4"
       }
     },
     "packages/ui-rails": {
@@ -5395,7 +5399,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "peerDependencies": {
-        "@agentfactory/pi-engine": "*",
+        "@agentfactory/pi-engine": "^0.1.0",
         "@earendil-works/pi-coding-agent": "^0.75.4",
         "@earendil-works/pi-tui": "^0.75.4"
       }

--- a/packages/containment-rails/package.json
+++ b/packages/containment-rails/package.json
@@ -13,7 +13,7 @@
     ]
   },
   "peerDependencies": {
-    "@agentfactory/pi-engine": "*",
+    "@agentfactory/pi-engine": "^0.1.0",
     "@earendil-works/pi-coding-agent": "^0.75.4"
   }
 }

--- a/packages/deferred-rails/package.json
+++ b/packages/deferred-rails/package.json
@@ -16,10 +16,10 @@
     ]
   },
   "peerDependencies": {
-    "@agentfactory/pi-engine": "*",
+    "@agentfactory/pi-engine": "^0.1.0",
     "@earendil-works/pi-coding-agent": "^0.75.4"
   },
   "dependencies": {
-    "typebox": "*"
+    "typebox": "^1.1.38"
   }
 }

--- a/packages/engine/agent/lib/manifest-deps.test.ts
+++ b/packages/engine/agent/lib/manifest-deps.test.ts
@@ -1,0 +1,249 @@
+// manifest-deps.test.ts — static guard: every runtime value-import in
+// agent/**/*.{ts,mjs} must be declared in dependencies|peerDependencies|optionalDependencies.
+//
+// NOTE: monorepo hoisting masks under-declaration at install time — npm
+// satisfies an import from a root-level dep even when the sub-package never
+// lists it. This static scan is the real protection against packaging bugs
+// where a standalone install would fail.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, dirname, extname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isBuiltin } from "node:module";
+
+// ── Package roots (relative to this file) ────────────────────────────────────
+
+const ENGINE_ROOT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+
+const PACKAGES = [
+  { label: "engine",           root: ENGINE_ROOT },
+  { label: "deferred-rails",   root: join(ENGINE_ROOT, "..", "deferred-rails") },
+  { label: "containment-rails",root: join(ENGINE_ROOT, "..", "containment-rails") },
+  { label: "ui-rails",         root: join(ENGINE_ROOT, "..", "ui-rails") },
+] as const;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Normalize an import specifier to its package name. */
+function toPackageName(specifier: string): string {
+  if (specifier.startsWith("@")) {
+    // @scope/pkg  or  @scope/pkg/subpath
+    const parts = specifier.split("/");
+    return `${parts[0]}/${parts[1]}`;
+  }
+  // pkg  or  pkg/subpath
+  return specifier.split("/")[0]!;
+}
+
+/** True if the specifier refers to a Node.js built-in. */
+function isNodeBuiltin(specifier: string): boolean {
+  if (specifier.startsWith("node:")) return true;
+  return isBuiltin(specifier);
+}
+
+/** Collect all *.ts and *.mjs files under `dir`, excluding *.test.* files. */
+function walkAgentFiles(dir: string): string[] {
+  const results: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      results.push(...walkAgentFiles(full));
+    } else {
+      const ext = extname(entry);
+      const isSource = ext === ".ts" || ext === ".mjs";
+      const isTest = entry.includes(".test.");
+      if (isSource && !isTest) {
+        results.push(full);
+      }
+    }
+  }
+  return results;
+}
+
+/**
+ * Extract all non-type, non-relative, non-builtin import specifiers from
+ * source text.
+ *
+ * Rules (matching the planner spec):
+ *  - Skip `import type …` / `export type …` whole-statement type imports.
+ *  - KEEP mixed `import { x, type Y } from "…"` — has a value binding.
+ *  - Skip relative specifiers (starting with "./" or "../").
+ *  - Skip Node.js builtins.
+ *  - Also collect `_require("pkg")` / `require("pkg")` dynamic requires.
+ *
+ * Implementation notes:
+ *  - We strip line comments and identify import/export statements by finding
+ *    lines that START with `import` or `export` (at column 0 or after only
+ *    whitespace). We then join the statement lines until the first occurrence
+ *    of `from "…"` or `from '…'`, or until we see that it's a bare import.
+ *  - Template literals in function bodies cannot start at column 0 with the
+ *    keyword `import` or `export`, so this avoids false positives from log
+ *    strings.
+ */
+function extractSpecifiers(source: string): string[] {
+  const specifiers = new Set<string>();
+
+  // Strip single-line comments to avoid matching `// import "foo"` patterns.
+  // We do NOT strip block comments or template literals — we rely on the
+  // structural invariant that real import/export statements start at column 0.
+  const strippedLines = source.split("\n").map((l) => {
+    // Remove `//` comments (naively — good enough for our purpose)
+    const commentIdx = l.indexOf("//");
+    return commentIdx >= 0 ? l.slice(0, commentIdx) : l;
+  });
+
+  // Identify import/export statement "blocks": a sequence of lines starting
+  // from a line that begins (optionally with whitespace) with `import` or
+  // `export`, continuing until the `from "…"` or `from '…'` terminator (or
+  // a semicolon, whichever comes first if there's no `from`).
+  let i = 0;
+  while (i < strippedLines.length) {
+    const line = strippedLines[i]!;
+    const trimmed = line.trimStart();
+
+    if (/^(import|export)\s/.test(trimmed)) {
+      // Collect lines until we find `from "…"` or `from '…'` or end of stmt
+      const stmtLines: string[] = [line];
+      let found = false;
+
+      // Check if `from "…"` is on this line already
+      const fromHere = /\bfrom\s+["']([^"']+)["']/.exec(line);
+      if (fromHere) {
+        found = true;
+      } else {
+        // Multi-line import: accumulate until `from "…"` appears
+        let j = i + 1;
+        while (j < strippedLines.length) {
+          const next = strippedLines[j]!;
+          stmtLines.push(next);
+          if (/\bfrom\s+["']([^"']+)["']/.test(next)) {
+            found = true;
+            break;
+          }
+          // If we hit a line that isn't a continuation (empty, or starts with
+          // a non-import keyword) bail out — avoid runaway matching.
+          const nt = next.trim();
+          if (nt === "" || /^(const|let|var|function|class|if|for|while|switch|return|throw|try|case|default|\/\/)/.test(nt)) {
+            break;
+          }
+          j++;
+        }
+        if (found) i = j; // advance outer loop past the multi-line block
+      }
+
+      const stmtText = stmtLines.join(" ");
+
+      // Is it a type-only import/export?
+      const isTypeOnly = /^(import|export)\s+type\s/.test(trimmed);
+
+      if (!isTypeOnly && found) {
+        const m2 = /\bfrom\s+["']([^"']+)["']/.exec(stmtText);
+        if (m2) {
+          specifiers.add(m2[1]!);
+        }
+      }
+
+      // Bare side-effect import: `import "specifier"` (no `from`)
+      if (!found) {
+        const bareMatch = /^import\s+["']([^"']+)["']/.exec(trimmed);
+        if (bareMatch) {
+          specifiers.add(bareMatch[1]!);
+        }
+      }
+    }
+
+    i++;
+  }
+
+  // Dynamic _require("pkg") / require("pkg")
+  const requireRe = /\b_?require\s*\(\s*["']([^"']+)["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = requireRe.exec(source)) !== null) {
+    specifiers.add(m[1]!);
+  }
+
+  // Filter out relative, builtins, and normalize
+  const result: string[] = [];
+  for (const spec of specifiers) {
+    if (spec.startsWith("./") || spec.startsWith("../")) continue;
+    if (isNodeBuiltin(spec)) continue;
+    result.push(spec);
+  }
+  return result;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("manifest-deps guard", () => {
+  it.each(PACKAGES)(
+    "$label: every runtime import specifier is declared in the manifest",
+    ({ label, root }) => {
+      // 1. Read package.json and build allowedSet
+      const pkgJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+      const allowedSet = new Set<string>([
+        pkgJson.name as string,
+        ...Object.keys(pkgJson.dependencies ?? {}),
+        ...Object.keys(pkgJson.peerDependencies ?? {}),
+        ...Object.keys(pkgJson.optionalDependencies ?? {}),
+      ]);
+
+      // 2. Walk agent/**/*.{ts,mjs} excluding *.test.*
+      const agentDir = join(root, "agent");
+      const files = walkAgentFiles(agentDir);
+
+      // 3+4+5. Collect and normalize specifiers, check each against allowedSet
+      const missing: Array<{ pkg: string; specifier: string; file: string }> = [];
+
+      for (const file of files) {
+        const source = readFileSync(file, "utf8");
+        const specifiers = extractSpecifiers(source);
+        for (const spec of specifiers) {
+          const pkgName = toPackageName(spec);
+          if (!allowedSet.has(pkgName)) {
+            missing.push({ pkg: label, specifier: spec, file: file.replace(root, `<${label}>`) });
+          }
+        }
+      }
+
+      // 6. Assert no missing declarations
+      expect(
+        missing,
+        `Package "${label}" has runtime imports not declared in package.json:\n` +
+          missing.map((m) => `  ${m.specifier} (${m.file})`).join("\n"),
+      ).toEqual([]);
+    },
+  );
+
+  it('no manifest entry uses the wildcard "*" version across all four packages', () => {
+    const wildcards: Array<{ pkg: string; dep: string; version: string }> = [];
+
+    for (const { label, root } of PACKAGES) {
+      const pkgJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+      for (const section of ["dependencies", "peerDependencies", "optionalDependencies"] as const) {
+        for (const [dep, version] of Object.entries(pkgJson[section] ?? {})) {
+          if (version === "*") {
+            wildcards.push({ pkg: label, dep, version: version as string });
+          }
+        }
+      }
+    }
+
+    expect(
+      wildcards,
+      'Found wildcard "*" versions in package manifests:\n' +
+        wildcards.map((w) => `  ${w.pkg}: ${w.dep}@${w.version}`).join("\n"),
+    ).toEqual([]);
+  });
+});

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -28,10 +28,14 @@
     "agent/"
   ],
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.75.4"
+    "@earendil-works/pi-coding-agent": "^0.75.4",
+    "@earendil-works/pi-tui": "^0.75.4",
+    "@earendil-works/pi-ai": "^0.75.4"
   },
   "dependencies": {
     "yaml": "^2.8.3",
-    "typebox": "*"
+    "typebox": "^1.1.38",
+    "node-pty": "^1.1.0",
+    "@xterm/headless": "^6.0.0"
   }
 }

--- a/packages/ui-rails/package.json
+++ b/packages/ui-rails/package.json
@@ -15,7 +15,7 @@
     ]
   },
   "peerDependencies": {
-    "@agentfactory/pi-engine": "*",
+    "@agentfactory/pi-engine": "^0.1.0",
     "@earendil-works/pi-coding-agent": "^0.75.4",
     "@earendil-works/pi-tui": "^0.75.4"
   }


### PR DESCRIPTION
## What this fixes

The `@agentfactory/*` manifests under-declared their runtime deps — it only worked in-repo because the monorepo root declares them and npm hoists into one shared `node_modules`. A standalone publish/`pi install` of any package would fail to resolve them.

- **`pi-engine`** now declares what it actually uses at runtime: `node-pty` (`lib/pty-pool.mjs`, mesh PTY) and `@xterm/headless` (`lib/virtual-buffer.mjs`, mesh ANSI) as **`dependencies`** (the pi host doesn't ship them — verified `pi-coding-agent` lists neither and has no peerDeps, and the engine `_require()`s them directly); `@earendil-works/pi-tui` (value import `truncateToWidth` in `lib/mesh-rail.ts`) and `@earendil-works/pi-ai` (type-only `Api`/`Model`) as **`peerDependencies`** (host-provided pi runtime).
- **All loose `"*"` pins removed:** `typebox` → `^1.1.38` (engine + deferred-rails); the clusters' `@agentfactory/pi-engine` peer → `^0.1.0`.
- **`ui-rails` deliberately does NOT add `pi-ai`** — its only pi-ai import is type-only (`agent-footer.ts`), so it's erased at runtime.

### Regression guard
New `packages/engine/agent/lib/manifest-deps.test.ts` — parametrized over all four packages. It statically scans `agent/**/*.{ts,mjs}` for value imports (and dynamic `_require(...)` in `.mjs`), drops whole-statement `import type`/relative/`node:` builtins, normalizes scoped/subpath specifiers to the package name, and asserts every one is declared in deps/peerDeps. Plus an assertion that no manifest value is `"*"`. This is the real protection — monorepo hoisting otherwise masks under-declaration.

## QA steps for the human

None beyond the automated coverage — the smoke proved the guard fails on a removed dep and passes when restored, the packaged manifest carries the deps, and `npm run pi --recipe deferred-writer` still launches cleanly. (A full standalone `pi install` of the published tarball is the ultimate proof but requires publishing first — see #190/install discussion.)

## Automated coverage

`npm run typecheck` (clean) and `npm test` (**1025/1025 pass**), including the new parametrized manifest guard. Live smoke: guard test red-green verified (removing `node-pty` → fails naming it; restored → passes); runtime regression `DW OK`.

## Note

This makes the manifests self-contained enough to publish — the prerequisite for a real `pi install npm:@agentfactory/...`. Publishing/registry setup itself is still a separate follow-up.

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)