### PR TITLE
packaging: bundle the 'peer' template in the engine package

### DIFF
--- a/docs/adr/0006-templates-compose-baseline-rails.md
+++ b/docs/adr/0006-templates-compose-baseline-rails.md
@@ -105,3 +105,16 @@ The set of **Rails** every **Recipe** loads is no longer hardcoded in `scripts/r
 - `docs/agents.md`: rewrite the "Recipe shape" and "Composing agents" sections to describe `extends:` and the template chain. Drop the `noEditAdd`/`noEditSkip` paragraph.
 - `CONTEXT.md`: already updated to introduce **Template** as a first-class term and refine **Recipe** to mention `extends:`.
 - The migration is grabbable as a sequence of vertical slices (one per concern: template file, runner, habitat, extensions, launcher, recipes, tests, docs); each slice is independently testable.
+
+## Addendum (2026-06, #194)
+
+The canonical home of `peer.yaml` is now `packages/engine/agent/templates/`
+(shipped via the engine package's `files: ["agent/"]` — see
+`packages/engine/package.json`). The repo-local copy at
+`pi-sandbox/templates/peer.yaml` has been removed; `getTemplateDirs` falls
+through to the bundled engine copy as the final tier in the search order.
+`pi-sandbox/templates/` is retained as an optional repo-local override
+directory — place a `peer.yaml` there to shadow the bundled copy for
+repo-local experimentation. This makes the engine package the single source
+of truth for the baseline peer template and ensures `peer.yaml` is always
+present in any downstream install of `@agentfactory/pi-engine`.

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -51,8 +51,12 @@ Pi's working directory is `pi-sandbox/`; the `npm run pi` script handles the
   `anon-grouped-mesh.yaml`, `authority-mesh.yaml`, `grouped-mesh.yaml`)
   launched via `npm run mesh -- <recipe-name>`
   (see `docs/agents/host-recipes.md`).
-- `pi-sandbox/templates/` — Template YAML files used by `extends:` chains
-  in recipes (e.g. `peer.yaml`).
+- `pi-sandbox/templates/` — Optional repo-local override directory for
+  `extends:` templates. The canonical `peer.yaml` now ships in the engine
+  package at `packages/engine/agent/templates/peer.yaml` (included via
+  `files: ["agent/"]`); place a `peer.yaml` here to shadow the bundled
+  copy for repo-local experimentation. `getTemplateDirs` searches
+  project-local dirs first, falling back to the bundled engine copy.
 - `pi-sandbox/.pi/extensions/` — Project-local pi extensions. Used during
   development; production extensions live in `packages/*/agent/extensions/`.
 - `pi-sandbox/.pi/scratch/` — Throwaway prompt files, raw pi output,

--- a/packages/engine/agent/lib/bundled-templates.test.ts
+++ b/packages/engine/agent/lib/bundled-templates.test.ts
@@ -1,0 +1,39 @@
+// bundled-templates.test.ts — static guard: the canonical peer template ships
+// in the engine package at agent/templates/peer.yaml (see #194).
+//
+// This test is hermetic and static — it reads the file and parses it with the
+// `yaml` library; it does NOT invoke the pi runtime or resolveRecipe.
+
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+const PACKAGE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const PEER_TEMPLATE = join(PACKAGE_DIR, "agent", "templates", "peer.yaml");
+
+describe("bundled peer template", () => {
+  it("exists at agent/templates/peer.yaml inside the engine package", () => {
+    expect(existsSync(PEER_TEMPLATE)).toBe(true);
+  });
+
+  it("parses as valid YAML to a non-null object", () => {
+    const raw = readFileSync(PEER_TEMPLATE, "utf8");
+    const parsed = parseYaml(raw);
+    expect(parsed).not.toBeNull();
+    expect(typeof parsed).toBe("object");
+  });
+
+  it("contains a non-empty extensions array", () => {
+    const raw = readFileSync(PEER_TEMPLATE, "utf8");
+    const parsed = parseYaml(raw) as Record<string, unknown>;
+    expect(Array.isArray(parsed["extensions"])).toBe(true);
+    expect((parsed["extensions"] as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it("lives under a path ending with agent/templates", () => {
+    const templateDir = dirname(PEER_TEMPLATE);
+    expect(templateDir.endsWith("agent/templates")).toBe(true);
+  });
+});

--- a/packages/engine/agent/templates/peer.yaml
+++ b/packages/engine/agent/templates/peer.yaml
@@ -1,8 +1,12 @@
 # Universal-rail bundle for mesh peers.
 #
-# This template is the canonical and authoritative source for the rails every
-# peer agent inherits. All recipes declare `extends: peer` to pick up these
-# rails; the engine resolves the extension list via the recipe-loader (ADR-0010).
+# This is the bundled canonical home for the peer template (ships via the
+# engine package's `files: ["agent/"]` — see packages/engine/package.json).
+# The repo-local copy at pi-sandbox/templates/ has been removed; resolution
+# falls through getTemplateDirs() to this file. pi-sandbox/templates/ is
+# retained as an optional override directory — place a peer.yaml there to
+# shadow this bundled copy for repo-local experimentation.
+#
 # Editing this file changes runtime behaviour for every recipe that extends it.
 #
 # Note: `habitat` is no longer listed — the engine's recipe-loader builds and


### PR DESCRIPTION
## What this fixes

`recipe-loader`'s `BUNDLED_TEMPLATES_DIR` points at `<engine>/agent/templates/`, but that directory didn't exist — the `peer` template lived only in the repo at `pi-sandbox/templates/peer.yaml`. Since the engine ships `files: ["agent/"]`, a published/standalone engine carried no templates, so `extends: peer` (used by all 15 recipes) resolved only when the cwd was the repo root or the user hand-copied `peer.yaml` into `~/.pi/agent/templates/`. From any other directory it died with `template 'peer' not found`.

This moves `peer.yaml` to `packages/engine/agent/templates/peer.yaml` as the single bundled source of truth (shipped by the existing `files: ["agent/"]` — no manifest change), and deletes the repo-only copy. `getTemplateDirs` still lists `<cwd>/pi-sandbox/templates/` as an optional override ahead of the bundle, so repo-root resolution simply falls through to the bundled file. The extensions list is unchanged (14 rails). Git tracks it as a rename.

Docs: `docs/repo-layout.md` updated; `docs/adr/0006` gets a dated addendum (historical body left intact).

## QA steps for the human

None beyond the automated coverage — the smoke proved it end-to-end:
- From a neutral cwd (`/tmp`), with the `~/.pi/agent/templates/peer.yaml` copy moved aside, a `peer`-extending recipe resolved **purely via the engine bundle** → `BUNDLED OK`.
- Repo-root resolution still works after the repo copy was deleted → `REPO OK`.

## Automated coverage

`npm run typecheck` (clean) and `npm test` (**1029/1029 pass**), including:
- New hermetic `bundled-templates.test.ts` (bundled `peer.yaml` exists, parses, non-empty `extensions:`).
- Existing `recipe-loader-search-paths.test.ts` — resolves a `peer`-extending recipe via real resolution, so its green confirms the bundled fallback works after the repo copy was removed.

## Related

Same packaging-completeness class as #191 (manifests) and the #193 pi-version alignment. Bundling the example *recipes* (`BUNDLED_RECIPES_DIR` is likewise empty) remains a separate, deliberate out-of-scope item.

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)