### PR TITLE
feat(engine): bundle a basic read-only scout recipe with the package

### DIFF
--- a/packages/engine/agent/lib/bundled-recipes.test.ts
+++ b/packages/engine/agent/lib/bundled-recipes.test.ts
@@ -1,0 +1,38 @@
+// bundled-recipes.test.ts — static guard: the engine ships a usable `scout`
+// recipe in its bundled recipes dir (BUNDLED_RECIPES_DIR = <pkg>/agent/recipes),
+// so `pi --recipe scout` resolves on any install via the search-order fallback.
+//
+// Hermetic: reads the file and parses YAML; no pi runtime, no resolveRecipe.
+
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+// Mirror recipe-loader.ts: PACKAGE_DIR = <lib>/../.. , recipes = <pkg>/agent/recipes
+const PACKAGE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const RECIPES_DIR = join(PACKAGE_DIR, "agent", "recipes");
+const SCOUT_RECIPE = join(RECIPES_DIR, "scout.yaml");
+
+describe("bundled scout recipe", () => {
+  it("ships in the engine's bundled recipes dir", () => {
+    expect(RECIPES_DIR.endsWith(join("agent", "recipes"))).toBe(true);
+    expect(existsSync(SCOUT_RECIPE)).toBe(true);
+  });
+
+  it("parses as YAML with the fields the recipe-loader needs", () => {
+    const recipe = parseYaml(readFileSync(SCOUT_RECIPE, "utf8"));
+    expect(recipe).toBeTruthy();
+    expect(typeof recipe.model).toBe("string");
+    expect(recipe.model.length).toBeGreaterThan(0);
+    expect(Array.isArray(recipe.tools)).toBe(true);
+    expect(recipe.tools.length).toBeGreaterThan(0);
+  });
+
+  it("is read-only (no write/edit/move/delete tools)", () => {
+    const recipe = parseYaml(readFileSync(SCOUT_RECIPE, "utf8"));
+    const mutating = ["write", "edit", "deferred_write", "deferred_edit", "deferred_move", "deferred_delete"];
+    expect(recipe.tools.some((t: string) => mutating.includes(t))).toBe(false);
+  });
+});

--- a/packages/engine/agent/recipes/scout.yaml
+++ b/packages/engine/agent/recipes/scout.yaml
@@ -1,0 +1,38 @@
+# Basic read-only scout — bundled with the engine package.
+#
+# Ships via the engine's `files: ["agent/"]` and resolves from the recipe
+# search order's bundled fallback (BUNDLED_RECIPES_DIR), so `pi --recipe scout`
+# works on any install without a project- or user-local copy.
+#
+# Model: provider-qualified OpenRouter id. The `openrouter/` prefix makes the
+# recipe-loader resolve the OpenRouter copy regardless of the active provider
+# (a bare `google/gemini-2.5-flash-lite` also resolves under an openrouter
+# default provider, post-#188, but the explicit prefix is bulletproof).
+extends: peer
+model: openrouter/google/gemini-2.5-flash-lite
+shortName: scout
+description: Read-only scout that explores a directory and reports a structured map.
+
+prompt: |
+  You are a scout. Explore the directory, subsystem, or question the user
+  points you at, then report back concisely. You never modify anything.
+
+  Use `ls` and `find` to learn the layout, `grep` to locate the symbols or
+  patterns asked about, and `read` to confirm how the key files fit together.
+  Read enough to be confident — don't read everything — and say what you skipped.
+
+  End your reply with a markdown section titled "## Scout report":
+  - **Summary** — 2-3 sentences on what this area is and how it's organized.
+  - **Key files** — bullet list of `path` — one-line purpose (anchor to
+    `path:line` when a specific definition matters).
+  - **Findings** — entry points, conventions, surprises, gaps; flag uncertainty.
+  - **Not covered** — what you didn't look at.
+
+  Read-only: you use only `read`, `ls`, `grep`, and `find`. If you can't find
+  what was asked, say where you looked rather than guessing.
+
+tools:
+  - read
+  - ls
+  - grep
+  - find


### PR DESCRIPTION
## What this adds

Bundles a basic **scout** recipe with the engine package at `packages/engine/agent/recipes/scout.yaml`, shipped via the existing `files: ["agent/"]`. The recipe-loader's search order ends at `BUNDLED_RECIPES_DIR` (`<engine>/agent/recipes/`), so `pi --recipe scout` now resolves on any install without a project- or user-local copy.

The scout is **read-only** (`read`/`ls`/`grep`/`find`), explores a directory/subsystem, and ends its reply with a structured `## Scout report` (Summary / Key files / Findings / Not covered). Model: `openrouter/google/gemini-2.5-flash-lite` — provider-qualified so it resolves regardless of the active provider (cheap, fast, 1M context — well suited to read-and-summarize recon).

A hermetic guard test (`bundled-recipes.test.ts`) asserts the recipe bundles, parses with the fields the loader needs, and stays read-only (no write/edit tools) — so it can't silently break or drift mutating.

## QA steps for the human

None beyond automated coverage — smoke-verified live: with the user-local `~/.pi/agent/recipes/scout.yaml` copy moved aside, `pi --recipe scout` from a neutral cwd resolved the **bundled** recipe and produced a full `## Scout report`.

## Automated coverage

`npm run typecheck` (clean) and `npm test` (**1028/1028 pass**), including the new `bundled-recipes.test.ts`.

## Note

This is the first recipe bundled with the package (`BUNDLED_RECIPES_DIR` was previously empty). Pairs with #194/#195 (bundled `peer` template) — both are needed for `extends: peer` to resolve on a truly clean install. Bundling the broader recipe set remains a separate, deliberate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)